### PR TITLE
improve memory footprint of audit text

### DIFF
--- a/src/com/rcv/Tabulator.java
+++ b/src/com/rcv/Tabulator.java
@@ -10,6 +10,7 @@
 
 package com.rcv;
 
+import com.rcv.CastVoteRecord.VoteOutcomeType;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.HashMap;
@@ -630,8 +631,7 @@ class Tabulator {
           break;
         } else if (overvoteDecision == OvervoteDecision.IGNORE) {
           // description of the overvote decision
-          String description = String.format("%d|ignored:%s|", currentRound, "overvote");
-          cvr.addRoundDescription(description, currentRound);
+          cvr.addRoundOutcome(VoteOutcomeType.IGNORED, "overvote");
           break;
         } else if (overvoteDecision == OvervoteDecision.SKIP_TO_NEXT_RANK) {
           continue;
@@ -655,9 +655,7 @@ class Tabulator {
             assert selectedCandidateID == null;
             // we found a continuing candidate, so increase their tally by 1
             selectedCandidateID = candidateID;
-            // text description of the vote
-            String description = String.format("%d|%s|", currentRound, selectedCandidateID);
-            cvr.addRoundDescription(description, currentRound);
+            cvr.addRoundOutcome(VoteOutcomeType.COUNTED, selectedCandidateID);
             // Increment the tally for this candidate by the fractional transfer value of the CVR.
             // (By default the FTV is exactly one vote, but it could be less than one in a multi-
             // winner election if this CVR already helped elect a winner.)


### PR DESCRIPTION
I tested the config_minneapolis_2013_scale.json file today and couldn't even get it to finish. It looks like it got into a state where it was spending more and more of its time garbage-collecting until it was barely making progress at all. This used to work fine, and I'm not sure what changed, but my best guess would be the upgrade to Java 9. In any case, I changed the CVR audit strings from a HashMap of Strings to a List of simple objects and eliminated all the calls to String.format, and it seems to have resolved the issue.