### PR TITLE
Add 2018 Maine gubernatorial Democratic primary

### DIFF
--- a/test/config_maine_gov_primary_dem_2018.json
+++ b/test/config_maine_gov_primary_dem_2018.json
@@ -1,0 +1,35 @@
+{
+  "outputDirectory":"test_output/maine_2018",
+  "contestName":"Maine 2018 Democratic Governor Primary race",
+  "jurisdiction":"Maine",
+  "office":"Governor",
+  "date":"2018-06-12",
+  "rules": {
+    "description":"Maine Rules",
+    "maxRankingsAllowed":8,
+    "batchElimination":true,
+    "overvoteRule":"exhaustImmediately",
+    "maxSkippedRanksAllowed":1,
+    "overvoteLabel":"overvote",
+    "undervoteLabel":"undervote",
+    "tiebreakMode":"interactive"
+  },
+  "candidates": [
+    {"name":"Mills, Janet T."},
+    {"name":"Cote, Adam Roland"},
+    {"name":"Sweet, Elizabeth A."},
+    {"name":"Eves, Mark W."},
+    {"name":"Dion, Mark N."},
+    {"name":"Russell, Diane Marie"},
+    {"name":"Dion, Donna J."},
+    {"name":"Write-in"}
+  ],
+  "cvrFileSources": [
+    {
+      "provider": "ES&S",
+      "filePath": "test/2018-maine-governor-primary-dem-cvr.xlsx",
+      "firstVoteColumnIndex": 3,
+      "precinctColumnIndex": 1
+    }
+  ]
+}


### PR DESCRIPTION
This works perfectly except for the mysterious 3-vote discrepancy in the transfer from Sweet to Mills.