### PR TITLE
read IDs from CVR files

### DIFF
--- a/docs/config_file_documentation.txt
+++ b/docs/config_file_documentation.txt
@@ -73,12 +73,17 @@ Config file must be valid JSON format. Examples can be found under the test fold
         value: string of length [1..1000]
 
       "firstVoteColumnIndex" required
-        index of the column that contains ballot top-ranked candidate
+        index of the column that contains the top-ranked candidate for each CVR
         example: 3
         value: [0..1000]
 
+      "idColumnIndex" optional
+        index of the column that contains the unique ID for each CVR
+        example: 0
+        value: [0..1000]
+
       "precinctColumnIndex" required if "tabulateByPrecinct" is in use
-        the index of the column that contains ballot precinct name
+        the index of the column that contains the precinct name for each CVR
         example: 2
         value: [0..1000]
 

--- a/src/com/rcv/CastVoteRecord.java
+++ b/src/com/rcv/CastVoteRecord.java
@@ -23,10 +23,10 @@ import javafx.util.Pair;
 
 class CastVoteRecord {
 
-  // name of the vendor, this becomes part of the audit output but is not used in tabulation
-  private final String sourceName;
-  // unique identifier for this cast vote record
-  private final String cvrID;
+  // computed unique ID for this CVR (source file + line number)
+  private final String computedID;
+  // supplied unique ID for this CVR
+  private final String suppliedID;
   // which precinct this ballot came from
   private final String precinct;
   // container for ALL CVR data parsed from the source CVR file
@@ -45,19 +45,19 @@ class CastVoteRecord {
 
   // function: CastVoteRecord
   // purpose: create a new CVR object
-  // param: source what vendor created the CVR file from which this CVR was parsed
-  // param: ballotID unique ID of this ballot
+  // param: computedID is our computed unique ID for this CVR
+  // param: suppliedID is the (ostensibly unique) ID from the input data
   // param: rankings list of rank->candidateID selections parsed for this CVR
   // param: fullCVRData list of strings containing ALL data parsed for this CVR
   CastVoteRecord(
-      String sourceName,
-      String cvrID,
+      String computedID,
+      String suppliedID,
       String precinct,
       List<String> fullCVRData,
       List<Pair<Integer, String>> rankings
   ) {
-    this.sourceName = sourceName;
-    this.cvrID = cvrID;
+    this.computedID = computedID;
+    this.suppliedID = suppliedID;
     this.precinct = precinct;
     this.fullCVRData = fullCVRData;
     sortRankings(rankings);
@@ -169,10 +169,10 @@ class CastVoteRecord {
   String getAuditString() {
     // use a string builder for more efficient string creation
     StringBuilder auditStringBuilder = new StringBuilder();
-    auditStringBuilder.append("[CVR Source] ");
-    auditStringBuilder.append(sourceName);
-    auditStringBuilder.append(" [Ballot ID] ");
-    auditStringBuilder.append(cvrID);
+    auditStringBuilder.append(" [Computed ID] ");
+    auditStringBuilder.append(computedID);
+    auditStringBuilder.append(" [Supplied ID] ");
+    auditStringBuilder.append(suppliedID);
     if (precinct != null) {
       auditStringBuilder.append(" [Precinct] ");
       auditStringBuilder.append(precinct);

--- a/src/com/rcv/Main.java
+++ b/src/com/rcv/Main.java
@@ -165,6 +165,7 @@ class Main {
       reader.parseCVRFile(
           source.filePath,
           source.firstVoteColumnIndex,
+          source.idColumnIndex,
           source.precinctColumnIndex,
           config
       );

--- a/src/com/rcv/RawElectionConfig.java
+++ b/src/com/rcv/RawElectionConfig.java
@@ -95,6 +95,8 @@ public class RawElectionConfig {
     public String filePath;
     // column where rankings data begins
     public Integer firstVoteColumnIndex;
+    // column containing CVR ID (if any)
+    public Integer idColumnIndex;
     // column containing precinct (if any)
     public Integer precinctColumnIndex;
   }

--- a/test/config_maine_gov_primary_dem_2018.json
+++ b/test/config_maine_gov_primary_dem_2018.json
@@ -29,6 +29,7 @@
       "provider": "ES&S",
       "filePath": "test/2018-maine-governor-primary-dem-cvr.xlsx",
       "firstVoteColumnIndex": 3,
+      "idColumnIndex": 0,
       "precinctColumnIndex": 1
     }
   ]


### PR DESCRIPTION
This addresses #79.

I also cleaned up a couple related minor things:
- We were showing the source file name twice in each audit line.
- We were interpreting numbers read from the input file as doubles. For now, I think it's safe to assume that they're integers. This might change in the future.