### PR TITLE
Fix bugs in exhaustion reason logic (fixes #121)

### DIFF
--- a/src/main/resources/config_file_documentation.txt
+++ b/src/main/resources/config_file_documentation.txt
@@ -112,6 +112,7 @@ Config file must be valid JSON format. Examples can be found under the test fold
 
       "numberOfWinners" optional
         the number of seats to be won in this contest
+        note: we use fractional vote transfer to redistribute votes in multi-seat contests
         value: [1..100]
         default: 1
 


### PR DESCRIPTION
In debugging #121, I realized that the tabulation logic had a couple minor bugs that didn't affect candidate vote totals, but did lead to our reporting the wrong reason for some ballot exhaustions. E.g. we were sometimes reporting an overvote when it was technically an undervote.