### PR TITLE
Log updates

### DIFF
--- a/src/main/java/com/rcv/CVRReader.java
+++ b/src/main/java/com/rcv/CVRReader.java
@@ -79,7 +79,7 @@ class CVRReader {
       inputStream.close();
       workbook.close();
     } catch (IOException exception) {
-      Logger.Log(
+      Logger.log(
           Level.SEVERE, "Failed to open CVR file: %s\n%s", excelFilePath, exception.toString());
     }
     return firstSheet;
@@ -102,7 +102,7 @@ class CVRReader {
       Row headerRow = iterator.next();
       // require at least one non-header row
       if (headerRow == null || contestSheet.getLastRowNum() < 2) {
-        Logger.Log(
+        Logger.log(
             Level.SEVERE,
             "Invalid CVR source file %s: not enough rows (%d)",
             this.excelFilePath,
@@ -184,14 +184,14 @@ class CVRReader {
         // empty cells are sometimes treated as undeclared write-ins (Portland / ES&S)
         if (config.isTreatBlankAsUndeclaredWriteInEnabled()) {
           candidate = config.getUndeclaredWriteInLabel();
-          Logger.Log(Level.WARNING, "Empty cell -- treating as UWI");
+          Logger.log(Level.WARNING, "Empty cell -- treating as UWI");
         } else {
           // just ignore this cell
           continue;
         }
       } else {
         if (cvrDataCell.getCellTypeEnum() != CellType.STRING) {
-          Logger.Log(
+          Logger.log(
               Level.WARNING,
               "unexpected cell type at ranking %d ballot %s",
               rank,

--- a/src/main/java/com/rcv/CVRReader.java
+++ b/src/main/java/com/rcv/CVRReader.java
@@ -79,7 +79,7 @@ class CVRReader {
       inputStream.close();
       workbook.close();
     } catch (IOException exception) {
-      Logger.executionLog(
+      Logger.Log(
           Level.SEVERE, "Failed to open CVR file: %s\n%s", excelFilePath, exception.toString());
     }
     return firstSheet;
@@ -102,7 +102,7 @@ class CVRReader {
       Row headerRow = iterator.next();
       // require at least one non-header row
       if (headerRow == null || contestSheet.getLastRowNum() < 2) {
-        Logger.executionLog(
+        Logger.Log(
             Level.SEVERE,
             "Invalid CVR source file %s: not enough rows (%d)",
             this.excelFilePath,
@@ -184,14 +184,14 @@ class CVRReader {
         // empty cells are sometimes treated as undeclared write-ins (Portland / ES&S)
         if (config.isTreatBlankAsUndeclaredWriteInEnabled()) {
           candidate = config.getUndeclaredWriteInLabel();
-          Logger.executionLog(Level.WARNING, "Empty cell -- treating as UWI");
+          Logger.Log(Level.WARNING, "Empty cell -- treating as UWI");
         } else {
           // just ignore this cell
           continue;
         }
       } else {
         if (cvrDataCell.getCellTypeEnum() != CellType.STRING) {
-          Logger.executionLog(
+          Logger.Log(
               Level.WARNING,
               "unexpected cell type at ranking %d ballot %s",
               rank,

--- a/src/main/java/com/rcv/CVRReader.java
+++ b/src/main/java/com/rcv/CVRReader.java
@@ -87,13 +87,11 @@ class CVRReader {
 
   // function: parseCVRFile
   // purpose: parse the given file path into a List of CastVoteRecords suitable for tabulation
+  // param: castVoteRecords existing list to append new CastVoteRecords to
   // returns: list of parsed CVRs
-  List<CastVoteRecord> parseCVRFile() throws SourceWithUnrecognizedCandidatesException {
+  List<CastVoteRecord> parseCVRFile(List<CastVoteRecord> castVoteRecords) throws SourceWithUnrecognizedCandidatesException {
     // contestSheet contains all the CVR data we will be parsing
     Sheet contestSheet = getFirstSheet(excelFilePath);
-    // container for all CastVoteRecords parsed from the input file
-    List<CastVoteRecord> castVoteRecords = new LinkedList<>();
-
     if (contestSheet != null) {
       // validate header
       // Row iterator is used to iterate through a row of data from the sheet object
@@ -122,6 +120,10 @@ class CVRReader {
         CastVoteRecord cvr =
             parseRow(iterator.next(), cvrFileName, cvrIndex++, unrecognizedCandidateCounts);
         castVoteRecords.add(cvr);
+        // log update every 10,000 records
+        if(castVoteRecords.size() % 10000 == 0) {
+          Logger.log(Level.INFO, "Parsed %d cast vote records", castVoteRecords.size());
+        }
       }
 
       if (unrecognizedCandidateCounts.size() > 0) {

--- a/src/main/java/com/rcv/CVRReader.java
+++ b/src/main/java/com/rcv/CVRReader.java
@@ -79,7 +79,7 @@ class CVRReader {
       inputStream.close();
       workbook.close();
     } catch (IOException exception) {
-      Logger.tabulationLog(
+      Logger.executionLog(
           Level.SEVERE, "Failed to open CVR file: %s\n%s", excelFilePath, exception.toString());
     }
     return firstSheet;
@@ -102,7 +102,7 @@ class CVRReader {
       Row headerRow = iterator.next();
       // require at least one non-header row
       if (headerRow == null || contestSheet.getLastRowNum() < 2) {
-        Logger.tabulationLog(
+        Logger.executionLog(
             Level.SEVERE,
             "Invalid CVR source file %s: not enough rows (%d)",
             this.excelFilePath,
@@ -184,14 +184,14 @@ class CVRReader {
         // empty cells are sometimes treated as undeclared write-ins (Portland / ES&S)
         if (config.isTreatBlankAsUndeclaredWriteInEnabled()) {
           candidate = config.getUndeclaredWriteInLabel();
-          Logger.tabulationLog(Level.WARNING, "Empty cell -- treating as UWI");
+          Logger.executionLog(Level.WARNING, "Empty cell -- treating as UWI");
         } else {
           // just ignore this cell
           continue;
         }
       } else {
         if (cvrDataCell.getCellTypeEnum() != CellType.STRING) {
-          Logger.tabulationLog(
+          Logger.executionLog(
               Level.WARNING,
               "unexpected cell type at ranking %d ballot %s",
               rank,

--- a/src/main/java/com/rcv/ContestConfig.java
+++ b/src/main/java/com/rcv/ContestConfig.java
@@ -60,7 +60,7 @@ class ContestConfig {
   // purpose: validate the correctness of the config data
   // returns any detected problems
   boolean validate() {
-    Logger.executionLog(Level.INFO, "Validating config...");
+    Logger.Log(Level.INFO, "Validating config...");
     isValid = true;
 
     validateContestSettings();
@@ -69,9 +69,9 @@ class ContestConfig {
     validateRules();
 
     if (isValid) {
-      Logger.executionLog(Level.INFO, "Config validation successful.");
+      Logger.Log(Level.INFO, "Config validation successful.");
     } else {
-      Logger.executionLog(
+      Logger.Log(
           Level.SEVERE, "Config validation failed! Please modify the config file and try again.");
     }
 
@@ -81,28 +81,28 @@ class ContestConfig {
   private void validateContestSettings() {
     if (getContestName() == null || getContestName().isEmpty()) {
       isValid = false;
-      Logger.executionLog(Level.SEVERE, "Contest name is required.");
+      Logger.Log(Level.SEVERE, "Contest name is required.");
     }
 
     if (getOutputDirectory() == null || getOutputDirectory().isEmpty()) {
       isValid = false;
-      Logger.executionLog(Level.SEVERE, "Output directory is required.");
+      Logger.Log(Level.SEVERE, "Output directory is required.");
     }
   }
 
   private void validateCvrFileSources() {
     if (rawConfig.cvrFileSources == null || rawConfig.cvrFileSources.isEmpty()) {
       isValid = false;
-      Logger.executionLog(Level.SEVERE, "Config doesn't contain any CVR files.");
+      Logger.Log(Level.SEVERE, "Config doesn't contain any CVR files.");
     } else {
       HashSet<String> cvrFilePathSet = new HashSet<>();
       for (CVRSource source : rawConfig.cvrFileSources) {
         if (source.getFilePath() == null || source.getFilePath().isEmpty()) {
           isValid = false;
-          Logger.executionLog(Level.SEVERE, "filePath is required for each CVR file.");
+          Logger.Log(Level.SEVERE, "filePath is required for each CVR file.");
         } else if (cvrFilePathSet.contains(source.getFilePath())) {
           isValid = false;
-          Logger.executionLog(
+          Logger.Log(
               Level.SEVERE, "Duplicate CVR filePaths are not allowed: %s", source.getFilePath());
         } else {
           cvrFilePathSet.add(source.getFilePath());
@@ -110,12 +110,12 @@ class ContestConfig {
 
         if (source.getFirstVoteColumnIndex() == null) {
           isValid = false;
-          Logger.executionLog(
+          Logger.Log(
               Level.SEVERE, "firstVoteColumnIndex is required: %s", source.getFilePath());
         } else if (source.getFirstVoteColumnIndex() < 0
             || source.getFirstVoteColumnIndex() > 1000) {
           isValid = false;
-          Logger.executionLog(
+          Logger.Log(
               Level.SEVERE,
               "firstVoteColumnIndex must be from 0 to 1000: %s",
               source.getFilePath());
@@ -124,21 +124,21 @@ class ContestConfig {
         if (source.getIdColumnIndex() != null
             && (source.getIdColumnIndex() < 0 || source.getIdColumnIndex() > 1000)) {
           isValid = false;
-          Logger.executionLog(
+          Logger.Log(
               Level.SEVERE, "idColumnIndex must be from 0 to 1000: %s", source.getFilePath());
         }
 
         if (isTabulateByPrecinctEnabled()) {
           if (source.getPrecinctColumnIndex() == null) {
             isValid = false;
-            Logger.executionLog(
+            Logger.Log(
                 Level.SEVERE,
                 "precinctColumnIndex is required when tabulateByPrecinct is enabled: %s",
                 source.getFilePath());
           } else if (source.getPrecinctColumnIndex() < 0
               || source.getPrecinctColumnIndex() > 1000) {
             isValid = false;
-            Logger.executionLog(
+            Logger.Log(
                 Level.SEVERE,
                 "precinctColumnIndex must be from 0 to 1000: %s",
                 source.getFilePath());
@@ -154,10 +154,10 @@ class ContestConfig {
     for (Candidate candidate : rawConfig.candidates) {
       if (candidate.getName() == null || candidate.getName().isEmpty()) {
         isValid = false;
-        Logger.executionLog(Level.SEVERE, "Name is required for each candidate.");
+        Logger.Log(Level.SEVERE, "Name is required for each candidate.");
       } else if (candidateNameSet.contains(candidate.getName())) {
         isValid = false;
-        Logger.executionLog(
+        Logger.Log(
             Level.SEVERE, "Duplicate candidate names are not allowed: %s", candidate.getName());
       } else {
         candidateNameSet.add(candidate.getName());
@@ -166,7 +166,7 @@ class ContestConfig {
       if (candidate.getCode() != null && !candidate.getCode().isEmpty()) {
         if (candidateCodeSet.contains(candidate.getCode())) {
           isValid = false;
-          Logger.executionLog(
+          Logger.Log(
               Level.SEVERE, "Duplicate candidate codes are not allowed: %s", candidate.getCode());
         } else {
           candidateCodeSet.add(candidate.getCode());
@@ -176,31 +176,31 @@ class ContestConfig {
 
     if (candidateCodeSet.size() > 0 && candidateCodeSet.size() != candidateNameSet.size()) {
       isValid = false;
-      Logger.executionLog(
+      Logger.Log(
           Level.SEVERE,
           "If candidate codes are used, a unique code is required for each candidate.");
     }
 
     if (getNumDeclaredCandidates() < 1) {
       isValid = false;
-      Logger.executionLog(Level.SEVERE, "Config must contain at least one declared candidate.");
+      Logger.Log(Level.SEVERE, "Config must contain at least one declared candidate.");
     }
   }
 
   private void validateRules() {
     if (getTiebreakMode() == Tabulator.TieBreakMode.MODE_UNKNOWN) {
       isValid = false;
-      Logger.executionLog(Level.SEVERE, "Invalid tie-break mode.");
+      Logger.Log(Level.SEVERE, "Invalid tie-break mode.");
     }
 
     if (getOvervoteRule() == Tabulator.OvervoteRule.RULE_UNKNOWN) {
       isValid = false;
-      Logger.executionLog(Level.SEVERE, "Invalid overvote rule.");
+      Logger.Log(Level.SEVERE, "Invalid overvote rule.");
     } else if ((getOvervoteLabel() != null && !getOvervoteLabel().isEmpty())
         && getOvervoteRule() != Tabulator.OvervoteRule.EXHAUST_IMMEDIATELY
         && getOvervoteRule() != Tabulator.OvervoteRule.ALWAYS_SKIP_TO_NEXT_RANK) {
       isValid = false;
-      Logger.executionLog(
+      Logger.Log(
           Level.SEVERE,
           "When overvoteLabel is supplied, overvoteRule must be either exhaustImmediately "
               + "or alwaysSkipToNextRank.");
@@ -208,48 +208,48 @@ class ContestConfig {
 
     if (getMaxRankingsAllowed() == null) {
       isValid = false;
-      Logger.executionLog(Level.SEVERE, "maxRankingsAllowed is required.");
+      Logger.Log(Level.SEVERE, "maxRankingsAllowed is required.");
     } else if (getMaxRankingsAllowed() < 1 || getMaxRankingsAllowed() > 100) {
       isValid = false;
-      Logger.executionLog(Level.SEVERE, "maxRankingsAllowed must be from 1 to 100.");
+      Logger.Log(Level.SEVERE, "maxRankingsAllowed must be from 1 to 100.");
     }
 
     if (getMaxSkippedRanksAllowed() == null) {
       isValid = false;
-      Logger.executionLog(Level.SEVERE, "maxSkippedRanksAllowed is required.");
+      Logger.Log(Level.SEVERE, "maxSkippedRanksAllowed is required.");
     } else if (getMaxSkippedRanksAllowed() < 0 || getMaxSkippedRanksAllowed() > 100) {
       isValid = false;
-      Logger.executionLog(Level.SEVERE, "maxSkippedRanksAllowed must be from 0 to 100.");
+      Logger.Log(Level.SEVERE, "maxSkippedRanksAllowed must be from 0 to 100.");
     }
 
     if (getNumberOfWinners() < 1 || getNumberOfWinners() > 100) {
       isValid = false;
-      Logger.executionLog(Level.SEVERE, "numberOfWinners must be from 1 to 100.");
+      Logger.Log(Level.SEVERE, "numberOfWinners must be from 1 to 100.");
     }
 
     if (getMinimumVoteThreshold().intValue() < 0 || getMinimumVoteThreshold().intValue() > 10000) {
       isValid = false;
-      Logger.executionLog(Level.SEVERE, "minimumVoteThreshold must be from 0 to 10000.");
+      Logger.Log(Level.SEVERE, "minimumVoteThreshold must be from 0 to 10000.");
     }
 
     // If this is a multi-seat contest, we validate a number of extra parameters.
     if (getNumberOfWinners() > 1) {
       if (willContinueUntilTwoCandidatesRemain()) {
         isValid = false;
-        Logger.executionLog(
+        Logger.Log(
             Level.SEVERE,
             "continueUntilTwoCandidatesRemain can't be true in a multi-winner contest.");
       }
 
       if (isBatchEliminationEnabled()) {
         isValid = false;
-        Logger.executionLog(
+        Logger.Log(
             Level.SEVERE, "batchElimination can't be true in a multi-winner contest.");
       }
 
       if (getDecimalPlacesForVoteArithmetic() < 0 || getDecimalPlacesForVoteArithmetic() > 20) {
         isValid = false;
-        Logger.executionLog(Level.SEVERE, "decimalPlacesForVoteArithmetic must be from 0 to 20.");
+        Logger.Log(Level.SEVERE, "decimalPlacesForVoteArithmetic must be from 0 to 20.");
       }
     }
   }

--- a/src/main/java/com/rcv/ContestConfig.java
+++ b/src/main/java/com/rcv/ContestConfig.java
@@ -60,7 +60,7 @@ class ContestConfig {
   // purpose: validate the correctness of the config data
   // returns any detected problems
   boolean validate() {
-    Logger.Log(Level.INFO, "Validating config...");
+    Logger.log(Level.INFO, "Validating config...");
     isValid = true;
 
     validateContestSettings();
@@ -69,9 +69,9 @@ class ContestConfig {
     validateRules();
 
     if (isValid) {
-      Logger.Log(Level.INFO, "Config validation successful.");
+      Logger.log(Level.INFO, "Config validation successful.");
     } else {
-      Logger.Log(
+      Logger.log(
           Level.SEVERE, "Config validation failed! Please modify the config file and try again.");
     }
 
@@ -81,28 +81,28 @@ class ContestConfig {
   private void validateContestSettings() {
     if (getContestName() == null || getContestName().isEmpty()) {
       isValid = false;
-      Logger.Log(Level.SEVERE, "Contest name is required.");
+      Logger.log(Level.SEVERE, "Contest name is required.");
     }
 
     if (getOutputDirectory() == null || getOutputDirectory().isEmpty()) {
       isValid = false;
-      Logger.Log(Level.SEVERE, "Output directory is required.");
+      Logger.log(Level.SEVERE, "Output directory is required.");
     }
   }
 
   private void validateCvrFileSources() {
     if (rawConfig.cvrFileSources == null || rawConfig.cvrFileSources.isEmpty()) {
       isValid = false;
-      Logger.Log(Level.SEVERE, "Config doesn't contain any CVR files.");
+      Logger.log(Level.SEVERE, "Config doesn't contain any CVR files.");
     } else {
       HashSet<String> cvrFilePathSet = new HashSet<>();
       for (CVRSource source : rawConfig.cvrFileSources) {
         if (source.getFilePath() == null || source.getFilePath().isEmpty()) {
           isValid = false;
-          Logger.Log(Level.SEVERE, "filePath is required for each CVR file.");
+          Logger.log(Level.SEVERE, "filePath is required for each CVR file.");
         } else if (cvrFilePathSet.contains(source.getFilePath())) {
           isValid = false;
-          Logger.Log(
+          Logger.log(
               Level.SEVERE, "Duplicate CVR filePaths are not allowed: %s", source.getFilePath());
         } else {
           cvrFilePathSet.add(source.getFilePath());
@@ -110,12 +110,12 @@ class ContestConfig {
 
         if (source.getFirstVoteColumnIndex() == null) {
           isValid = false;
-          Logger.Log(
+          Logger.log(
               Level.SEVERE, "firstVoteColumnIndex is required: %s", source.getFilePath());
         } else if (source.getFirstVoteColumnIndex() < 0
             || source.getFirstVoteColumnIndex() > 1000) {
           isValid = false;
-          Logger.Log(
+          Logger.log(
               Level.SEVERE,
               "firstVoteColumnIndex must be from 0 to 1000: %s",
               source.getFilePath());
@@ -124,21 +124,21 @@ class ContestConfig {
         if (source.getIdColumnIndex() != null
             && (source.getIdColumnIndex() < 0 || source.getIdColumnIndex() > 1000)) {
           isValid = false;
-          Logger.Log(
+          Logger.log(
               Level.SEVERE, "idColumnIndex must be from 0 to 1000: %s", source.getFilePath());
         }
 
         if (isTabulateByPrecinctEnabled()) {
           if (source.getPrecinctColumnIndex() == null) {
             isValid = false;
-            Logger.Log(
+            Logger.log(
                 Level.SEVERE,
                 "precinctColumnIndex is required when tabulateByPrecinct is enabled: %s",
                 source.getFilePath());
           } else if (source.getPrecinctColumnIndex() < 0
               || source.getPrecinctColumnIndex() > 1000) {
             isValid = false;
-            Logger.Log(
+            Logger.log(
                 Level.SEVERE,
                 "precinctColumnIndex must be from 0 to 1000: %s",
                 source.getFilePath());
@@ -154,10 +154,10 @@ class ContestConfig {
     for (Candidate candidate : rawConfig.candidates) {
       if (candidate.getName() == null || candidate.getName().isEmpty()) {
         isValid = false;
-        Logger.Log(Level.SEVERE, "Name is required for each candidate.");
+        Logger.log(Level.SEVERE, "Name is required for each candidate.");
       } else if (candidateNameSet.contains(candidate.getName())) {
         isValid = false;
-        Logger.Log(
+        Logger.log(
             Level.SEVERE, "Duplicate candidate names are not allowed: %s", candidate.getName());
       } else {
         candidateNameSet.add(candidate.getName());
@@ -166,7 +166,7 @@ class ContestConfig {
       if (candidate.getCode() != null && !candidate.getCode().isEmpty()) {
         if (candidateCodeSet.contains(candidate.getCode())) {
           isValid = false;
-          Logger.Log(
+          Logger.log(
               Level.SEVERE, "Duplicate candidate codes are not allowed: %s", candidate.getCode());
         } else {
           candidateCodeSet.add(candidate.getCode());
@@ -176,31 +176,31 @@ class ContestConfig {
 
     if (candidateCodeSet.size() > 0 && candidateCodeSet.size() != candidateNameSet.size()) {
       isValid = false;
-      Logger.Log(
+      Logger.log(
           Level.SEVERE,
           "If candidate codes are used, a unique code is required for each candidate.");
     }
 
     if (getNumDeclaredCandidates() < 1) {
       isValid = false;
-      Logger.Log(Level.SEVERE, "Config must contain at least one declared candidate.");
+      Logger.log(Level.SEVERE, "Config must contain at least one declared candidate.");
     }
   }
 
   private void validateRules() {
     if (getTiebreakMode() == Tabulator.TieBreakMode.MODE_UNKNOWN) {
       isValid = false;
-      Logger.Log(Level.SEVERE, "Invalid tie-break mode.");
+      Logger.log(Level.SEVERE, "Invalid tie-break mode.");
     }
 
     if (getOvervoteRule() == Tabulator.OvervoteRule.RULE_UNKNOWN) {
       isValid = false;
-      Logger.Log(Level.SEVERE, "Invalid overvote rule.");
+      Logger.log(Level.SEVERE, "Invalid overvote rule.");
     } else if ((getOvervoteLabel() != null && !getOvervoteLabel().isEmpty())
         && getOvervoteRule() != Tabulator.OvervoteRule.EXHAUST_IMMEDIATELY
         && getOvervoteRule() != Tabulator.OvervoteRule.ALWAYS_SKIP_TO_NEXT_RANK) {
       isValid = false;
-      Logger.Log(
+      Logger.log(
           Level.SEVERE,
           "When overvoteLabel is supplied, overvoteRule must be either exhaustImmediately "
               + "or alwaysSkipToNextRank.");
@@ -208,48 +208,48 @@ class ContestConfig {
 
     if (getMaxRankingsAllowed() == null) {
       isValid = false;
-      Logger.Log(Level.SEVERE, "maxRankingsAllowed is required.");
+      Logger.log(Level.SEVERE, "maxRankingsAllowed is required.");
     } else if (getMaxRankingsAllowed() < 1 || getMaxRankingsAllowed() > 100) {
       isValid = false;
-      Logger.Log(Level.SEVERE, "maxRankingsAllowed must be from 1 to 100.");
+      Logger.log(Level.SEVERE, "maxRankingsAllowed must be from 1 to 100.");
     }
 
     if (getMaxSkippedRanksAllowed() == null) {
       isValid = false;
-      Logger.Log(Level.SEVERE, "maxSkippedRanksAllowed is required.");
+      Logger.log(Level.SEVERE, "maxSkippedRanksAllowed is required.");
     } else if (getMaxSkippedRanksAllowed() < 0 || getMaxSkippedRanksAllowed() > 100) {
       isValid = false;
-      Logger.Log(Level.SEVERE, "maxSkippedRanksAllowed must be from 0 to 100.");
+      Logger.log(Level.SEVERE, "maxSkippedRanksAllowed must be from 0 to 100.");
     }
 
     if (getNumberOfWinners() < 1 || getNumberOfWinners() > 100) {
       isValid = false;
-      Logger.Log(Level.SEVERE, "numberOfWinners must be from 1 to 100.");
+      Logger.log(Level.SEVERE, "numberOfWinners must be from 1 to 100.");
     }
 
     if (getMinimumVoteThreshold().intValue() < 0 || getMinimumVoteThreshold().intValue() > 10000) {
       isValid = false;
-      Logger.Log(Level.SEVERE, "minimumVoteThreshold must be from 0 to 10000.");
+      Logger.log(Level.SEVERE, "minimumVoteThreshold must be from 0 to 10000.");
     }
 
     // If this is a multi-seat contest, we validate a number of extra parameters.
     if (getNumberOfWinners() > 1) {
       if (willContinueUntilTwoCandidatesRemain()) {
         isValid = false;
-        Logger.Log(
+        Logger.log(
             Level.SEVERE,
             "continueUntilTwoCandidatesRemain can't be true in a multi-winner contest.");
       }
 
       if (isBatchEliminationEnabled()) {
         isValid = false;
-        Logger.Log(
+        Logger.log(
             Level.SEVERE, "batchElimination can't be true in a multi-winner contest.");
       }
 
       if (getDecimalPlacesForVoteArithmetic() < 0 || getDecimalPlacesForVoteArithmetic() > 20) {
         isValid = false;
-        Logger.Log(Level.SEVERE, "decimalPlacesForVoteArithmetic must be from 0 to 20.");
+        Logger.log(Level.SEVERE, "decimalPlacesForVoteArithmetic must be from 0 to 20.");
       }
     }
   }

--- a/src/main/java/com/rcv/GuiConfigController.java
+++ b/src/main/java/com/rcv/GuiConfigController.java
@@ -210,9 +210,9 @@ public class GuiConfigController implements Initializable {
   public void buttonAddCvrFileClicked() {
     CVRSource cvrSource = new CVRSource();
     if (textFieldCvrFilePath.getText().isEmpty()) {
-      Logger.executionLog(Level.WARNING, "CVR file path is required!");
+      Logger.Log(Level.WARNING, "CVR file path is required!");
     } else if (textFieldCvrFirstVoteCol.getText().isEmpty()) {
-      Logger.executionLog(Level.WARNING, "CVR first vote column is required!");
+      Logger.Log(Level.WARNING, "CVR first vote column is required!");
     } else {
       cvrSource.setFilePath(textFieldCvrFilePath.getText());
       cvrSource.setFirstVoteColumnIndex(getIntValueElse(textFieldCvrFirstVoteCol, null));
@@ -237,7 +237,7 @@ public class GuiConfigController implements Initializable {
   public void buttonAddCandidateClicked() {
     Candidate candidate = new Candidate();
     if (textFieldCandidateName.getText().isEmpty()) {
-      Logger.executionLog(Level.WARNING, "Candidate name field is required!");
+      Logger.Log(Level.WARNING, "Candidate name field is required!");
     } else {
       candidate.setName(textFieldCandidateName.getText());
       candidate.setCode(textFieldCandidateCode.getText());
@@ -255,7 +255,7 @@ public class GuiConfigController implements Initializable {
 
   @Override
   public void initialize(URL location, ResourceBundle resources) {
-    Logger.executionLog(Level.INFO, "Opening config creator GUI...");
+    Logger.Log(Level.INFO, "Opening config creator GUI...");
 
     String helpText;
     try {
@@ -265,7 +265,7 @@ public class GuiConfigController implements Initializable {
               .lines()
               .collect(Collectors.joining("\n"));
     } catch (Exception exception) {
-      Logger.executionLog(
+      Logger.Log(
           Level.SEVERE, "Error loading: %s\n%s", CONFIG_FILE_NAME, exception.toString());
       helpText = String.format("<Error loading %s>", CONFIG_FILE_NAME);
     }

--- a/src/main/java/com/rcv/GuiConfigController.java
+++ b/src/main/java/com/rcv/GuiConfigController.java
@@ -210,9 +210,9 @@ public class GuiConfigController implements Initializable {
   public void buttonAddCvrFileClicked() {
     CVRSource cvrSource = new CVRSource();
     if (textFieldCvrFilePath.getText().isEmpty()) {
-      Logger.Log(Level.WARNING, "CVR file path is required!");
+      Logger.log(Level.WARNING, "CVR file path is required!");
     } else if (textFieldCvrFirstVoteCol.getText().isEmpty()) {
-      Logger.Log(Level.WARNING, "CVR first vote column is required!");
+      Logger.log(Level.WARNING, "CVR first vote column is required!");
     } else {
       cvrSource.setFilePath(textFieldCvrFilePath.getText());
       cvrSource.setFirstVoteColumnIndex(getIntValueElse(textFieldCvrFirstVoteCol, null));
@@ -237,7 +237,7 @@ public class GuiConfigController implements Initializable {
   public void buttonAddCandidateClicked() {
     Candidate candidate = new Candidate();
     if (textFieldCandidateName.getText().isEmpty()) {
-      Logger.Log(Level.WARNING, "Candidate name field is required!");
+      Logger.log(Level.WARNING, "Candidate name field is required!");
     } else {
       candidate.setName(textFieldCandidateName.getText());
       candidate.setCode(textFieldCandidateCode.getText());
@@ -255,7 +255,7 @@ public class GuiConfigController implements Initializable {
 
   @Override
   public void initialize(URL location, ResourceBundle resources) {
-    Logger.Log(Level.INFO, "Opening config creator GUI...");
+    Logger.log(Level.INFO, "Opening config creator GUI...");
 
     String helpText;
     try {
@@ -265,7 +265,7 @@ public class GuiConfigController implements Initializable {
               .lines()
               .collect(Collectors.joining("\n"));
     } catch (Exception exception) {
-      Logger.Log(
+      Logger.log(
           Level.SEVERE, "Error loading: %s\n%s", CONFIG_FILE_NAME, exception.toString());
       helpText = String.format("<Error loading %s>", CONFIG_FILE_NAME);
     }

--- a/src/main/java/com/rcv/GuiConfigController.java
+++ b/src/main/java/com/rcv/GuiConfigController.java
@@ -210,9 +210,9 @@ public class GuiConfigController implements Initializable {
   public void buttonAddCvrFileClicked() {
     CVRSource cvrSource = new CVRSource();
     if (textFieldCvrFilePath.getText().isEmpty()) {
-      Logger.guiLog(Level.WARNING, "CVR file path is required!");
+      Logger.executionLog(Level.WARNING, "CVR file path is required!");
     } else if (textFieldCvrFirstVoteCol.getText().isEmpty()) {
-      Logger.guiLog(Level.WARNING, "CVR first vote column is required!");
+      Logger.executionLog(Level.WARNING, "CVR first vote column is required!");
     } else {
       cvrSource.setFilePath(textFieldCvrFilePath.getText());
       cvrSource.setFirstVoteColumnIndex(getIntValueElse(textFieldCvrFirstVoteCol, null));
@@ -237,7 +237,7 @@ public class GuiConfigController implements Initializable {
   public void buttonAddCandidateClicked() {
     Candidate candidate = new Candidate();
     if (textFieldCandidateName.getText().isEmpty()) {
-      Logger.guiLog(Level.WARNING, "Candidate name field is required!");
+      Logger.executionLog(Level.WARNING, "Candidate name field is required!");
     } else {
       candidate.setName(textFieldCandidateName.getText());
       candidate.setCode(textFieldCandidateCode.getText());
@@ -255,7 +255,7 @@ public class GuiConfigController implements Initializable {
 
   @Override
   public void initialize(URL location, ResourceBundle resources) {
-    Logger.executionLog(Level.FINE, "Opening config creator GUI...");
+    Logger.executionLog(Level.INFO, "Opening config creator GUI...");
 
     String helpText;
     try {

--- a/src/main/java/com/rcv/GuiContext.java
+++ b/src/main/java/com/rcv/GuiContext.java
@@ -69,7 +69,7 @@ class GuiContext {
     try {
       getContentVBox().getChildren().add(FXMLLoader.load(getClass().getResource(resourcePath)));
     } catch (IOException exception) {
-      Logger.Log(
+      Logger.log(
           Level.SEVERE, "Failed to open: %s:\n%s", resourcePath, exception.getCause().toString());
     }
   }

--- a/src/main/java/com/rcv/GuiContext.java
+++ b/src/main/java/com/rcv/GuiContext.java
@@ -69,7 +69,7 @@ class GuiContext {
     try {
       getContentVBox().getChildren().add(FXMLLoader.load(getClass().getResource(resourcePath)));
     } catch (IOException exception) {
-      Logger.executionLog(
+      Logger.Log(
           Level.SEVERE, "Failed to open: %s:\n%s", resourcePath, exception.getCause().toString());
     }
   }

--- a/src/main/java/com/rcv/GuiMainController.java
+++ b/src/main/java/com/rcv/GuiMainController.java
@@ -35,7 +35,7 @@ public class GuiMainController implements Initializable {
   @Override
   public void initialize(URL location, ResourceBundle resources) {
     Logger.addGuiLogging(this.textAreaStatus);
-    Logger.Log(Level.INFO, "Opening GUI...");
+    Logger.log(Level.INFO, "Opening GUI...");
     GuiContext.getInstance().setContentVBox(vBoxContent);
     GuiContext.getInstance().showContent("/GuiMenuLayout.fxml");
   }

--- a/src/main/java/com/rcv/GuiMainController.java
+++ b/src/main/java/com/rcv/GuiMainController.java
@@ -35,7 +35,7 @@ public class GuiMainController implements Initializable {
   @Override
   public void initialize(URL location, ResourceBundle resources) {
     Logger.addGuiLogging(this.textAreaStatus);
-    Logger.executionLog(Level.INFO, "Opening GUI...");
+    Logger.Log(Level.INFO, "Opening GUI...");
     GuiContext.getInstance().setContentVBox(vBoxContent);
     GuiContext.getInstance().showContent("/GuiMenuLayout.fxml");
   }

--- a/src/main/java/com/rcv/GuiMainController.java
+++ b/src/main/java/com/rcv/GuiMainController.java
@@ -35,7 +35,7 @@ public class GuiMainController implements Initializable {
   @Override
   public void initialize(URL location, ResourceBundle resources) {
     Logger.addGuiLogging(this.textAreaStatus);
-    Logger.executionLog(Level.FINE, "Opening GUI...");
+    Logger.executionLog(Level.INFO, "Opening GUI...");
     GuiContext.getInstance().setContentVBox(vBoxContent);
     GuiContext.getInstance().showContent("/GuiMenuLayout.fxml");
   }

--- a/src/main/java/com/rcv/GuiMenuController.java
+++ b/src/main/java/com/rcv/GuiMenuController.java
@@ -85,13 +85,13 @@ public class GuiMenuController implements Initializable {
       service.setOnFailed(event -> setButtonsDisable(false));
       service.start();
     } else {
-      Logger.Log(Level.WARNING, "Please load a config file before attempting to tabulate!");
+      Logger.log(Level.WARNING, "Please load a config file before attempting to tabulate!");
     }
   }
 
   @Override
   public void initialize(URL location, ResourceBundle resources) {
-    Logger.Log(Level.INFO, "Opening main menu GUI...");
+    Logger.log(Level.INFO, "Opening main menu GUI...");
   }
 
   private static class TabulatorService extends Service<Void> {

--- a/src/main/java/com/rcv/GuiMenuController.java
+++ b/src/main/java/com/rcv/GuiMenuController.java
@@ -85,13 +85,13 @@ public class GuiMenuController implements Initializable {
       service.setOnFailed(event -> setButtonsDisable(false));
       service.start();
     } else {
-      Logger.guiLog(Level.WARNING, "Please load a config file before attempting to tabulate!");
+      Logger.executionLog(Level.WARNING, "Please load a config file before attempting to tabulate!");
     }
   }
 
   @Override
   public void initialize(URL location, ResourceBundle resources) {
-    Logger.executionLog(Level.FINE, "Opening main menu GUI...");
+    Logger.executionLog(Level.INFO, "Opening main menu GUI...");
   }
 
   private static class TabulatorService extends Service<Void> {

--- a/src/main/java/com/rcv/GuiMenuController.java
+++ b/src/main/java/com/rcv/GuiMenuController.java
@@ -85,13 +85,13 @@ public class GuiMenuController implements Initializable {
       service.setOnFailed(event -> setButtonsDisable(false));
       service.start();
     } else {
-      Logger.executionLog(Level.WARNING, "Please load a config file before attempting to tabulate!");
+      Logger.Log(Level.WARNING, "Please load a config file before attempting to tabulate!");
     }
   }
 
   @Override
   public void initialize(URL location, ResourceBundle resources) {
-    Logger.executionLog(Level.INFO, "Opening main menu GUI...");
+    Logger.Log(Level.INFO, "Opening main menu GUI...");
   }
 
   private static class TabulatorService extends Service<Void> {

--- a/src/main/java/com/rcv/JsonParser.java
+++ b/src/main/java/com/rcv/JsonParser.java
@@ -40,15 +40,15 @@ class JsonParser {
       rawConfig =
           new ObjectMapper().readValue(new FileReader(jsonFilePath), RawContestConfig.class);
     } catch (JsonParseException | JsonMappingException exception) {
-      Logger.Log(
+      Logger.log(
           Level.SEVERE, "Error parsing JSON file: %s\n%s", jsonFilePath, exception.toString());
-      Logger.Log(
+      Logger.log(
           Level.SEVERE, "Check your file formatting and values to make sure they are correct.");
       rawConfig = null;
     } catch (IOException exception) {
-      Logger.Log(
+      Logger.log(
           Level.SEVERE, "Error opening file: %s\n%s", jsonFilePath, exception.toString());
-      Logger.Log(
+      Logger.log(
           Level.SEVERE, "Check your file path and permissions and make sure they are correct.");
       rawConfig = null;
     }
@@ -58,10 +58,10 @@ class JsonParser {
   static void createFileFromRawContestConfig(File jsonFile, RawContestConfig config) {
     try {
       new ObjectMapper().writer().withDefaultPrettyPrinter().writeValue(jsonFile, config);
-      Logger.Log(
+      Logger.log(
           Level.INFO, "Saved config via the GUI to: %s", jsonFile.getAbsolutePath());
     } catch (IOException exception) {
-      Logger.Log(
+      Logger.log(
           Level.SEVERE,
           "Error saving file: %s\n%s",
           jsonFile.getAbsolutePath(),

--- a/src/main/java/com/rcv/JsonParser.java
+++ b/src/main/java/com/rcv/JsonParser.java
@@ -40,15 +40,15 @@ class JsonParser {
       rawConfig =
           new ObjectMapper().readValue(new FileReader(jsonFilePath), RawContestConfig.class);
     } catch (JsonParseException | JsonMappingException exception) {
-      Logger.executionLog(
+      Logger.Log(
           Level.SEVERE, "Error parsing JSON file: %s\n%s", jsonFilePath, exception.toString());
-      Logger.executionLog(
+      Logger.Log(
           Level.SEVERE, "Check your file formatting and values to make sure they are correct.");
       rawConfig = null;
     } catch (IOException exception) {
-      Logger.executionLog(
+      Logger.Log(
           Level.SEVERE, "Error opening file: %s\n%s", jsonFilePath, exception.toString());
-      Logger.executionLog(
+      Logger.Log(
           Level.SEVERE, "Check your file path and permissions and make sure they are correct.");
       rawConfig = null;
     }
@@ -58,10 +58,10 @@ class JsonParser {
   static void createFileFromRawContestConfig(File jsonFile, RawContestConfig config) {
     try {
       new ObjectMapper().writer().withDefaultPrettyPrinter().writeValue(jsonFile, config);
-      Logger.executionLog(
+      Logger.Log(
           Level.INFO, "Saved config via the GUI to: %s", jsonFile.getAbsolutePath());
     } catch (IOException exception) {
-      Logger.executionLog(
+      Logger.Log(
           Level.SEVERE,
           "Error saving file: %s\n%s",
           jsonFile.getAbsolutePath(),

--- a/src/main/java/com/rcv/Logger.java
+++ b/src/main/java/com/rcv/Logger.java
@@ -41,7 +41,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Date;
-import java.util.logging.ErrorManager;
 import java.util.logging.FileHandler;
 import java.util.logging.Formatter;
 import java.util.logging.Handler;
@@ -98,7 +97,7 @@ class Logger {
     fileHandler.setLevel(Level.INFO);
     executionLogger.addHandler(fileHandler);
     // log results
-    executionLog(Level.INFO,"RCV Tabulator Logging execution to %s", logPath.toString());
+    Log(Level.INFO,"RCV Tabulator Logging execution to %s", logPath.toString());
   }
 
   // function: addTabulationFileLogging
@@ -122,7 +121,7 @@ class Logger {
   }
 
   // logs to execution log and GUI if there is one
-  static void executionLog(Level level, String format, Object... obj) {
+  static void Log(Level level, String format, Object... obj) {
     executionLogger.log(level, String.format(format, obj));
   }
 

--- a/src/main/java/com/rcv/Logger.java
+++ b/src/main/java/com/rcv/Logger.java
@@ -97,7 +97,7 @@ class Logger {
     fileHandler.setLevel(Level.INFO);
     executionLogger.addHandler(fileHandler);
     // log results
-    Log(Level.INFO,"RCV Tabulator Logging execution to %s", logPath.toString());
+    log(Level.INFO,"RCV Tabulator Logging execution to %s", logPath.toString());
   }
 
   // function: addTabulationFileLogging
@@ -121,7 +121,7 @@ class Logger {
   }
 
   // logs to execution log and GUI if there is one
-  static void Log(Level level, String format, Object... obj) {
+  static void log(Level level, String format, Object... obj) {
     executionLogger.log(level, String.format(format, obj));
   }
 

--- a/src/main/java/com/rcv/Logger.java
+++ b/src/main/java/com/rcv/Logger.java
@@ -65,7 +65,7 @@ class Logger {
   // cache for gui handler
   private static java.util.logging.Handler guiHandler;
   // cache for custom formatter
-  private static java.util.logging.Formatter formatter;
+  private static final java.util.logging.Formatter formatter = new LogFormatter();
 
   // function: setup
   // purpose: initialize logging module
@@ -75,7 +75,7 @@ class Logger {
     logger = java.util.logging.Logger.getLogger("");
     logger.setLevel(Level.FINE);
 
-    // logPath is where default file logging is written
+    // logPath is where execution file logging is written
     // "user.dir" property is the current working directory, i.e. folder from whence the rcv jar
     // was launched
     Path logPath = Paths.get(System.getProperty("user.dir"),
@@ -91,7 +91,6 @@ class Logger {
     logger.addHandler(executionHandler);
 
     // use our custom formatter for all installed handlers
-    formatter = new LogFormatter();
     for(Handler handler : logger.getHandlers()) {
       handler.setFormatter(formatter);
     }

--- a/src/main/java/com/rcv/Logger.java
+++ b/src/main/java/com/rcv/Logger.java
@@ -97,7 +97,7 @@ class Logger {
     }
 
     // log results
-    log(Level.INFO,"RCV Tabulator Logging execution to %s", logPath.toString());
+    log(Level.INFO,"RCV Tabulator logging execution to %s", logPath.toString());
   }
 
   // function: addTabulationFileLogging

--- a/src/main/java/com/rcv/Main.java
+++ b/src/main/java/com/rcv/Main.java
@@ -102,16 +102,16 @@ public class Main extends GuiApplication {
     boolean isConfigValid = config.validate();
 
     if (isConfigValid) {
-      boolean isexecutionLogSetUp = false;
+      boolean isTabulationLogSetUp = false;
       // current date-time formatted as a string used for creating unique output files names
       final String timestampString = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss").format(new Date());
-      String executionLogPath =
+      String tabulationLogPath =
           Paths.get(config.getOutputDirectory(), String.format("%s_audit.log",
               timestampString)).toAbsolutePath().toString();
       try {
         FileUtils.createOutputDirectory(config.getOutputDirectory());
-        Logger.addTabulationFileLogging(executionLogPath);
-        isexecutionLogSetUp = true;
+        Logger.addTabulationFileLogging(tabulationLogPath);
+        isTabulationLogSetUp = true;
       } catch (UnableToCreateDirectoryException exception) {
         Logger.log(
             Level.SEVERE,
@@ -123,8 +123,8 @@ public class Main extends GuiApplication {
             Level.SEVERE, "Failed to configure tabulation logger!\n%s", exception.toString());
       }
 
-      if (isexecutionLogSetUp) {
-        Logger.log(Level.INFO, "Logging tabulation to: %s", executionLogPath);
+      if (isTabulationLogSetUp) {
+        Logger.log(Level.INFO, "Logging tabulation to: %s", tabulationLogPath);
         // Read cast vote records from CVR files
         // castVoteRecords will contain all cast vote records parsed by the reader
         List<CastVoteRecord> castVoteRecords;
@@ -147,7 +147,7 @@ public class Main extends GuiApplication {
         } else {
           Logger.log(Level.SEVERE, "Skipping tabulation due to source file errors.");
         }
-        Logger.log(Level.INFO, "Done logging tabulation to: %s", executionLogPath);
+        Logger.log(Level.INFO, "Done logging tabulation to: %s", tabulationLogPath);
         Logger.removeTabulationFileLogging();
       }
     }

--- a/src/main/java/com/rcv/Main.java
+++ b/src/main/java/com/rcv/Main.java
@@ -184,14 +184,12 @@ public class Main extends GuiApplication {
 
       // the CVRs parsed from this source
       try {
-        List<CastVoteRecord> cvrs = new CVRReader(config, source).parseCVRFile();
+        List<CastVoteRecord> cvrs = new CVRReader(config, source).parseCVRFile(castVoteRecords);
         if (cvrs.isEmpty()) {
           Logger.log(
               Level.SEVERE, "Source file contains no CVRs: %s", source.getFilePath());
           encounteredSourceProblem = true;
         }
-        // add records to the master list
-        castVoteRecords.addAll(cvrs);
       } catch (SourceWithUnrecognizedCandidatesException exception) {
         Logger.log(
             Level.SEVERE,

--- a/src/main/java/com/rcv/Main.java
+++ b/src/main/java/com/rcv/Main.java
@@ -53,14 +53,14 @@ public class Main extends GuiApplication {
       launch(args);
     } else {
       // assume user wants to use CLI
-      Logger.executionLog(Level.INFO, "Tabulator is being used via the CLI.");
+      Logger.Log(Level.INFO, "Tabulator is being used via the CLI.");
       String configPath = args[0];
       // config file for running the tabulator
       ContestConfig config = loadContestConfig(configPath);
       if (config != null) {
         executeTabulation(config);
       } else {
-        Logger.executionLog(Level.SEVERE, "Aborting because config is invalid.");
+        Logger.Log(Level.SEVERE, "Aborting because config is invalid.");
       }
     }
 
@@ -81,11 +81,11 @@ public class Main extends GuiApplication {
 
     // if raw config failed alert user
     if (rawConfig == null) {
-      Logger.executionLog(Level.SEVERE, "Failed to load config file: %s", configPath);
+      Logger.Log(Level.SEVERE, "Failed to load config file: %s", configPath);
     } else {
       // proceed to create the ContestConfig wrapper
       config = new ContestConfig(rawConfig);
-      Logger.executionLog(Level.INFO, "Successfully loaded config file: %s", configPath);
+      Logger.Log(Level.INFO, "Successfully loaded config file: %s", configPath);
     }
 
     return config;
@@ -96,7 +96,7 @@ public class Main extends GuiApplication {
   // param: config object containing CVR file paths to parse
   // returns: String indicating whether or not execution was successful
   static void executeTabulation(ContestConfig config) {
-    Logger.executionLog(Level.INFO, "Starting tabulation process...");
+    Logger.Log(Level.INFO, "Starting tabulation process...");
 
     boolean isTabulationCompleted = false;
     boolean isConfigValid = config.validate();
@@ -113,18 +113,18 @@ public class Main extends GuiApplication {
         Logger.addTabulationFileLogging(executionLogPath);
         isexecutionLogSetUp = true;
       } catch (UnableToCreateDirectoryException exception) {
-        Logger.executionLog(
+        Logger.Log(
             Level.SEVERE,
             "Failed to create output directory: %s\n%s",
             config.getOutputDirectory(),
             exception.toString());
       } catch (IOException exception) {
-        Logger.executionLog(
+        Logger.Log(
             Level.SEVERE, "Failed to configure tabulation logger!\n%s", exception.toString());
       }
 
       if (isexecutionLogSetUp) {
-        Logger.executionLog(Level.INFO, "Logging tabulation to: %s", executionLogPath);
+        Logger.Log(Level.INFO, "Logging tabulation to: %s", executionLogPath);
         // Read cast vote records from CVR files
         // castVoteRecords will contain all cast vote records parsed by the reader
         List<CastVoteRecord> castVoteRecords;
@@ -142,20 +142,20 @@ public class Main extends GuiApplication {
             tabulator.doAudit(castVoteRecords);
             isTabulationCompleted = true;
           } else {
-            Logger.executionLog(Level.SEVERE, "No cast vote records found.");
+            Logger.Log(Level.SEVERE, "No cast vote records found.");
           }
         } else {
-          Logger.executionLog(Level.SEVERE, "Skipping tabulation due to source file errors.");
+          Logger.Log(Level.SEVERE, "Skipping tabulation due to source file errors.");
         }
-        Logger.executionLog(Level.INFO, "Done logging tabulation to: %s", executionLogPath);
+        Logger.Log(Level.INFO, "Done logging tabulation to: %s", executionLogPath);
         Logger.removeTabulationFileLogging();
       }
     }
 
     if (isTabulationCompleted) {
-      Logger.executionLog(Level.INFO, "Tabulation process completed.");
+      Logger.Log(Level.INFO, "Tabulation process completed.");
     } else {
-      Logger.executionLog(Level.SEVERE, "Unable to complete tabulation process!");
+      Logger.Log(Level.SEVERE, "Unable to complete tabulation process!");
     }
   }
 
@@ -164,7 +164,7 @@ public class Main extends GuiApplication {
   // param: config object containing CVR file paths to parse
   // returns: list of all CastVoteRecord objects parsed from CVR files (or null if there's an error)
   private static List<CastVoteRecord> parseCastVoteRecords(ContestConfig config) {
-    Logger.executionLog(Level.INFO, "Parsing cast vote records...");
+    Logger.Log(Level.INFO, "Parsing cast vote records...");
 
     // castVoteRecords will contain all cast vote records parsed by the reader
     List<CastVoteRecord> castVoteRecords = new ArrayList<>();
@@ -179,28 +179,28 @@ public class Main extends GuiApplication {
       if (source.getProvider() != null && !source.getProvider().isEmpty()) {
         logMessage.append(" (provider: ").append(source.getProvider()).append(")");
       }
-      Logger.executionLog(Level.INFO, logMessage.toString());
+      Logger.Log(Level.INFO, logMessage.toString());
       logMessage.setLength(0);
 
       // the CVRs parsed from this source
       try {
         List<CastVoteRecord> cvrs = new CVRReader(config, source).parseCVRFile();
         if (cvrs.isEmpty()) {
-          Logger.executionLog(
+          Logger.Log(
               Level.SEVERE, "Source file contains no CVRs: %s", source.getFilePath());
           encounteredSourceProblem = true;
         }
         // add records to the master list
         castVoteRecords.addAll(cvrs);
       } catch (SourceWithUnrecognizedCandidatesException exception) {
-        Logger.executionLog(
+        Logger.Log(
             Level.SEVERE,
             "Source file contains unrecognized candidate(s): %s",
             source.getFilePath());
         // map from name to number of times encountered
         Map<String, Integer> candidateCounts = exception.getCandidateCounts();
         for (String candidate : candidateCounts.keySet()) {
-          Logger.executionLog(
+          Logger.Log(
               Level.SEVERE,
               "Unrecognized candidate \"%s\" appears %d time(s).",
               candidate,
@@ -211,10 +211,10 @@ public class Main extends GuiApplication {
     }
 
     if (!encounteredSourceProblem) {
-      Logger.executionLog(
+      Logger.Log(
           Level.INFO, "Parsed %d cast vote records successfully.", castVoteRecords.size());
     } else {
-      Logger.executionLog(Level.SEVERE, "Parsing cast vote records failed!");
+      Logger.Log(Level.SEVERE, "Parsing cast vote records failed!");
       castVoteRecords = null;
     }
 

--- a/src/main/java/com/rcv/Main.java
+++ b/src/main/java/com/rcv/Main.java
@@ -27,6 +27,7 @@ package com.rcv;
 import com.rcv.CVRReader.SourceWithUnrecognizedCandidatesException;
 import com.rcv.FileUtils.UnableToCreateDirectoryException;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -164,7 +165,7 @@ public class Main extends GuiApplication {
   // param: config object containing CVR file paths to parse
   // returns: list of all CastVoteRecord objects parsed from CVR files (or null if there's an error)
   private static List<CastVoteRecord> parseCastVoteRecords(ContestConfig config) {
-    Logger.log(Level.INFO, "Parsing cast vote records...");
+    Logger.log(Level.INFO, "Parsing cast vote records");
 
     // castVoteRecords will contain all cast vote records parsed by the reader
     List<CastVoteRecord> castVoteRecords = new ArrayList<>();
@@ -173,15 +174,9 @@ public class Main extends GuiApplication {
 
     // At each iteration of the following loop, we add records from another source file.
     // source: index over config sources
-    StringBuilder logMessage = new StringBuilder();
     for (RawContestConfig.CVRSource source : config.rawConfig.cvrFileSources) {
-      logMessage.append("Reading CVR file: ").append(source.getFilePath());
-      if (source.getProvider() != null && !source.getProvider().isEmpty()) {
-        logMessage.append(" (provider: ").append(source.getProvider()).append(")");
-      }
-      Logger.log(Level.INFO, logMessage.toString());
-      logMessage.setLength(0);
-
+      Path cvrPath = Paths.get(source.getFilePath()).toAbsolutePath();
+      Logger.log(Level.INFO, "Reading cast vote record file: %s...", cvrPath);
       // the CVRs parsed from this source
       try {
         List<CastVoteRecord> cvrs = new CVRReader(config, source).parseCVRFile(castVoteRecords);

--- a/src/main/java/com/rcv/Main.java
+++ b/src/main/java/com/rcv/Main.java
@@ -53,14 +53,14 @@ public class Main extends GuiApplication {
       launch(args);
     } else {
       // assume user wants to use CLI
-      Logger.Log(Level.INFO, "Tabulator is being used via the CLI.");
+      Logger.log(Level.INFO, "Tabulator is being used via the CLI.");
       String configPath = args[0];
       // config file for running the tabulator
       ContestConfig config = loadContestConfig(configPath);
       if (config != null) {
         executeTabulation(config);
       } else {
-        Logger.Log(Level.SEVERE, "Aborting because config is invalid.");
+        Logger.log(Level.SEVERE, "Aborting because config is invalid.");
       }
     }
 
@@ -81,11 +81,11 @@ public class Main extends GuiApplication {
 
     // if raw config failed alert user
     if (rawConfig == null) {
-      Logger.Log(Level.SEVERE, "Failed to load config file: %s", configPath);
+      Logger.log(Level.SEVERE, "Failed to load config file: %s", configPath);
     } else {
       // proceed to create the ContestConfig wrapper
       config = new ContestConfig(rawConfig);
-      Logger.Log(Level.INFO, "Successfully loaded config file: %s", configPath);
+      Logger.log(Level.INFO, "Successfully loaded config file: %s", configPath);
     }
 
     return config;
@@ -96,7 +96,7 @@ public class Main extends GuiApplication {
   // param: config object containing CVR file paths to parse
   // returns: String indicating whether or not execution was successful
   static void executeTabulation(ContestConfig config) {
-    Logger.Log(Level.INFO, "Starting tabulation process...");
+    Logger.log(Level.INFO, "Starting tabulation process...");
 
     boolean isTabulationCompleted = false;
     boolean isConfigValid = config.validate();
@@ -113,18 +113,18 @@ public class Main extends GuiApplication {
         Logger.addTabulationFileLogging(executionLogPath);
         isexecutionLogSetUp = true;
       } catch (UnableToCreateDirectoryException exception) {
-        Logger.Log(
+        Logger.log(
             Level.SEVERE,
             "Failed to create output directory: %s\n%s",
             config.getOutputDirectory(),
             exception.toString());
       } catch (IOException exception) {
-        Logger.Log(
+        Logger.log(
             Level.SEVERE, "Failed to configure tabulation logger!\n%s", exception.toString());
       }
 
       if (isexecutionLogSetUp) {
-        Logger.Log(Level.INFO, "Logging tabulation to: %s", executionLogPath);
+        Logger.log(Level.INFO, "Logging tabulation to: %s", executionLogPath);
         // Read cast vote records from CVR files
         // castVoteRecords will contain all cast vote records parsed by the reader
         List<CastVoteRecord> castVoteRecords;
@@ -142,20 +142,20 @@ public class Main extends GuiApplication {
             tabulator.doAudit(castVoteRecords);
             isTabulationCompleted = true;
           } else {
-            Logger.Log(Level.SEVERE, "No cast vote records found.");
+            Logger.log(Level.SEVERE, "No cast vote records found.");
           }
         } else {
-          Logger.Log(Level.SEVERE, "Skipping tabulation due to source file errors.");
+          Logger.log(Level.SEVERE, "Skipping tabulation due to source file errors.");
         }
-        Logger.Log(Level.INFO, "Done logging tabulation to: %s", executionLogPath);
+        Logger.log(Level.INFO, "Done logging tabulation to: %s", executionLogPath);
         Logger.removeTabulationFileLogging();
       }
     }
 
     if (isTabulationCompleted) {
-      Logger.Log(Level.INFO, "Tabulation process completed.");
+      Logger.log(Level.INFO, "Tabulation process completed.");
     } else {
-      Logger.Log(Level.SEVERE, "Unable to complete tabulation process!");
+      Logger.log(Level.SEVERE, "Unable to complete tabulation process!");
     }
   }
 
@@ -164,7 +164,7 @@ public class Main extends GuiApplication {
   // param: config object containing CVR file paths to parse
   // returns: list of all CastVoteRecord objects parsed from CVR files (or null if there's an error)
   private static List<CastVoteRecord> parseCastVoteRecords(ContestConfig config) {
-    Logger.Log(Level.INFO, "Parsing cast vote records...");
+    Logger.log(Level.INFO, "Parsing cast vote records...");
 
     // castVoteRecords will contain all cast vote records parsed by the reader
     List<CastVoteRecord> castVoteRecords = new ArrayList<>();
@@ -179,28 +179,28 @@ public class Main extends GuiApplication {
       if (source.getProvider() != null && !source.getProvider().isEmpty()) {
         logMessage.append(" (provider: ").append(source.getProvider()).append(")");
       }
-      Logger.Log(Level.INFO, logMessage.toString());
+      Logger.log(Level.INFO, logMessage.toString());
       logMessage.setLength(0);
 
       // the CVRs parsed from this source
       try {
         List<CastVoteRecord> cvrs = new CVRReader(config, source).parseCVRFile();
         if (cvrs.isEmpty()) {
-          Logger.Log(
+          Logger.log(
               Level.SEVERE, "Source file contains no CVRs: %s", source.getFilePath());
           encounteredSourceProblem = true;
         }
         // add records to the master list
         castVoteRecords.addAll(cvrs);
       } catch (SourceWithUnrecognizedCandidatesException exception) {
-        Logger.Log(
+        Logger.log(
             Level.SEVERE,
             "Source file contains unrecognized candidate(s): %s",
             source.getFilePath());
         // map from name to number of times encountered
         Map<String, Integer> candidateCounts = exception.getCandidateCounts();
         for (String candidate : candidateCounts.keySet()) {
-          Logger.Log(
+          Logger.log(
               Level.SEVERE,
               "Unrecognized candidate \"%s\" appears %d time(s).",
               candidate,
@@ -211,10 +211,10 @@ public class Main extends GuiApplication {
     }
 
     if (!encounteredSourceProblem) {
-      Logger.Log(
+      Logger.log(
           Level.INFO, "Parsed %d cast vote records successfully.", castVoteRecords.size());
     } else {
-      Logger.Log(Level.SEVERE, "Parsing cast vote records failed!");
+      Logger.log(Level.SEVERE, "Parsing cast vote records failed!");
       castVoteRecords = null;
     }
 

--- a/src/main/java/com/rcv/Main.java
+++ b/src/main/java/com/rcv/Main.java
@@ -106,9 +106,8 @@ public class Main extends GuiApplication {
       // current date-time formatted as a string used for creating unique output files names
       final String timestampString = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss").format(new Date());
       String tabulationLogPath =
-          Paths.get(config.getOutputDirectory(), String.format("%s_audit.log", timestampString))
-              .toString();
-
+          Paths.get(config.getOutputDirectory(), String.format("%s_audit.log",
+              timestampString)).toAbsolutePath().toString();
       try {
         FileUtils.createOutputDirectory(config.getOutputDirectory());
         Logger.addTabulationFileLogging(tabulationLogPath);

--- a/src/main/java/com/rcv/Main.java
+++ b/src/main/java/com/rcv/Main.java
@@ -102,16 +102,16 @@ public class Main extends GuiApplication {
     boolean isConfigValid = config.validate();
 
     if (isConfigValid) {
-      boolean isTabulationLogSetUp = false;
+      boolean isexecutionLogSetUp = false;
       // current date-time formatted as a string used for creating unique output files names
       final String timestampString = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss").format(new Date());
-      String tabulationLogPath =
+      String executionLogPath =
           Paths.get(config.getOutputDirectory(), String.format("%s_audit.log",
               timestampString)).toAbsolutePath().toString();
       try {
         FileUtils.createOutputDirectory(config.getOutputDirectory());
-        Logger.addTabulationFileLogging(tabulationLogPath);
-        isTabulationLogSetUp = true;
+        Logger.addTabulationFileLogging(executionLogPath);
+        isexecutionLogSetUp = true;
       } catch (UnableToCreateDirectoryException exception) {
         Logger.executionLog(
             Level.SEVERE,
@@ -123,8 +123,8 @@ public class Main extends GuiApplication {
             Level.SEVERE, "Failed to configure tabulation logger!\n%s", exception.toString());
       }
 
-      if (isTabulationLogSetUp) {
-        Logger.allLogs(Level.INFO, "Logging tabulation to: %s", tabulationLogPath);
+      if (isexecutionLogSetUp) {
+        Logger.executionLog(Level.INFO, "Logging tabulation to: %s", executionLogPath);
         // Read cast vote records from CVR files
         // castVoteRecords will contain all cast vote records parsed by the reader
         List<CastVoteRecord> castVoteRecords;
@@ -142,12 +142,12 @@ public class Main extends GuiApplication {
             tabulator.doAudit(castVoteRecords);
             isTabulationCompleted = true;
           } else {
-            Logger.tabulationLog(Level.SEVERE, "No cast vote records found.");
+            Logger.executionLog(Level.SEVERE, "No cast vote records found.");
           }
         } else {
-          Logger.tabulationLog(Level.SEVERE, "Skipping tabulation due to source file errors.");
+          Logger.executionLog(Level.SEVERE, "Skipping tabulation due to source file errors.");
         }
-        Logger.allLogs(Level.INFO, "Done logging tabulation to: %s", tabulationLogPath);
+        Logger.executionLog(Level.INFO, "Done logging tabulation to: %s", executionLogPath);
         Logger.removeTabulationFileLogging();
       }
     }
@@ -164,7 +164,7 @@ public class Main extends GuiApplication {
   // param: config object containing CVR file paths to parse
   // returns: list of all CastVoteRecord objects parsed from CVR files (or null if there's an error)
   private static List<CastVoteRecord> parseCastVoteRecords(ContestConfig config) {
-    Logger.tabulationLog(Level.INFO, "Parsing cast vote records...");
+    Logger.executionLog(Level.INFO, "Parsing cast vote records...");
 
     // castVoteRecords will contain all cast vote records parsed by the reader
     List<CastVoteRecord> castVoteRecords = new ArrayList<>();
@@ -179,28 +179,28 @@ public class Main extends GuiApplication {
       if (source.getProvider() != null && !source.getProvider().isEmpty()) {
         logMessage.append(" (provider: ").append(source.getProvider()).append(")");
       }
-      Logger.tabulationLog(Level.INFO, logMessage.toString());
+      Logger.executionLog(Level.INFO, logMessage.toString());
       logMessage.setLength(0);
 
       // the CVRs parsed from this source
       try {
         List<CastVoteRecord> cvrs = new CVRReader(config, source).parseCVRFile();
         if (cvrs.isEmpty()) {
-          Logger.tabulationLog(
+          Logger.executionLog(
               Level.SEVERE, "Source file contains no CVRs: %s", source.getFilePath());
           encounteredSourceProblem = true;
         }
         // add records to the master list
         castVoteRecords.addAll(cvrs);
       } catch (SourceWithUnrecognizedCandidatesException exception) {
-        Logger.tabulationLog(
+        Logger.executionLog(
             Level.SEVERE,
             "Source file contains unrecognized candidate(s): %s",
             source.getFilePath());
         // map from name to number of times encountered
         Map<String, Integer> candidateCounts = exception.getCandidateCounts();
         for (String candidate : candidateCounts.keySet()) {
-          Logger.tabulationLog(
+          Logger.executionLog(
               Level.SEVERE,
               "Unrecognized candidate \"%s\" appears %d time(s).",
               candidate,
@@ -211,10 +211,10 @@ public class Main extends GuiApplication {
     }
 
     if (!encounteredSourceProblem) {
-      Logger.tabulationLog(
+      Logger.executionLog(
           Level.INFO, "Parsed %d cast vote records successfully.", castVoteRecords.size());
     } else {
-      Logger.tabulationLog(Level.SEVERE, "Parsing cast vote records failed!");
+      Logger.executionLog(Level.SEVERE, "Parsing cast vote records failed!");
       castVoteRecords = null;
     }
 

--- a/src/main/java/com/rcv/ResultsWriter.java
+++ b/src/main/java/com/rcv/ResultsWriter.java
@@ -154,7 +154,7 @@ class ResultsWriter {
   // file access: write / create
   private void generateSummarySpreadsheet(
       Map<Integer, Map<String, BigDecimal>> roundTallies, String precinct, String outputPath) {
-    Logger.executionLog(Level.INFO, "Generating summary spreadsheet: %s", outputPath);
+    Logger.Log(Level.INFO, "Generating summary spreadsheet: %s", outputPath);
 
     // Get all candidates sorted by their first round tally. This determines the display order.
     // container for firstRoundTally
@@ -440,7 +440,7 @@ class ResultsWriter {
       workbook.write(outputStream);
       outputStream.close();
     } catch (IOException exception) {
-      Logger.executionLog(
+      Logger.Log(
           Level.SEVERE, "Error saving file: %s\n%s", outputPath, exception.toString());
     }
   }

--- a/src/main/java/com/rcv/ResultsWriter.java
+++ b/src/main/java/com/rcv/ResultsWriter.java
@@ -154,7 +154,7 @@ class ResultsWriter {
   // file access: write / create
   private void generateSummarySpreadsheet(
       Map<Integer, Map<String, BigDecimal>> roundTallies, String precinct, String outputPath) {
-    Logger.Log(Level.INFO, "Generating summary spreadsheet: %s", outputPath);
+    Logger.log(Level.INFO, "Generating summary spreadsheet: %s", outputPath);
 
     // Get all candidates sorted by their first round tally. This determines the display order.
     // container for firstRoundTally
@@ -440,7 +440,7 @@ class ResultsWriter {
       workbook.write(outputStream);
       outputStream.close();
     } catch (IOException exception) {
-      Logger.Log(
+      Logger.log(
           Level.SEVERE, "Error saving file: %s\n%s", outputPath, exception.toString());
     }
   }

--- a/src/main/java/com/rcv/ResultsWriter.java
+++ b/src/main/java/com/rcv/ResultsWriter.java
@@ -154,7 +154,7 @@ class ResultsWriter {
   // file access: write / create
   private void generateSummarySpreadsheet(
       Map<Integer, Map<String, BigDecimal>> roundTallies, String precinct, String outputPath) {
-    Logger.tabulationLog(Level.INFO, "Generating summary spreadsheet: %s", outputPath);
+    Logger.executionLog(Level.INFO, "Generating summary spreadsheet: %s", outputPath);
 
     // Get all candidates sorted by their first round tally. This determines the display order.
     // container for firstRoundTally
@@ -440,7 +440,7 @@ class ResultsWriter {
       workbook.write(outputStream);
       outputStream.close();
     } catch (IOException exception) {
-      Logger.tabulationLog(
+      Logger.executionLog(
           Level.SEVERE, "Error saving file: %s\n%s", outputPath, exception.toString());
     }
   }

--- a/src/main/java/com/rcv/Tabulator.java
+++ b/src/main/java/com/rcv/Tabulator.java
@@ -95,7 +95,7 @@ class Tabulator {
       // vote count for this candidate
       BigDecimal votes = roundTally.get(candidate);
       if (shouldLog) {
-        Logger.tabulationLog(Level.INFO, "Candidate %s got %s votes.", candidate, votes.toString());
+        Logger.executionLog(Level.INFO, "Candidate %s got %s votes.", candidate, votes.toString());
       }
       // all candidates in the existing output structure (if any) who received the same vote tally
       LinkedList<String> candidates =
@@ -111,7 +111,7 @@ class Tabulator {
   //  this is the high-level control of the tabulation algorithm
   void tabulate() {
     logSummaryInfo();
-    Logger.tabulationLog(Level.INFO, "Starting tabulation...");
+    Logger.executionLog(Level.INFO, "Starting tabulation...");
 
     // Loop until we've found our winner(s) unless using continueUntilTwoCandidatesRemain, in which
     // case we loop until only two candidates remain.
@@ -121,7 +121,7 @@ class Tabulator {
     // remaining candidates.
     while (shouldContinueTabulating()) {
       currentRound++;
-      Logger.tabulationLog(Level.INFO, "Round: %d", currentRound);
+      Logger.executionLog(Level.INFO, "Round: %d", currentRound);
 
       // currentRoundCandidateToTally is a map from candidateID to vote tally for the current round.
       // At each iteration of this loop that involves eliminating candidates, the eliminatedRound
@@ -198,27 +198,27 @@ class Tabulator {
       updatePastWinnerTallies();
     }
 
-    Logger.tabulationLog(Level.INFO, "Tabulation completed.");
+    Logger.executionLog(Level.INFO, "Tabulation completed.");
   }
 
   // function: logSummaryInfo
   // purpose: log some basic info about the contest before starting tabulation
   private void logSummaryInfo() {
-    Logger.tabulationLog(
+    Logger.executionLog(
         Level.INFO,
         "There are %d declared candidates for this contest:",
         config.getNumDeclaredCandidates());
     // candidateID indexes over all candidate IDs to log them
     for (String candidateID : candidateIDs) {
-      Logger.tabulationLog(Level.INFO, "%s", candidateID);
+      Logger.executionLog(Level.INFO, "%s", candidateID);
     }
 
     if (config.getTiebreakMode() == TieBreakMode.GENERATE_PERMUTATION) {
-      Logger.tabulationLog(
+      Logger.executionLog(
           Level.INFO, "Randomly generated candidate permutation for tie-breaking:");
       // candidateID indexes over all candidates in ordered list
       for (String candidateID : config.getCandidatePermutation()) {
-        Logger.tabulationLog(Level.INFO, "%s", candidateID);
+        Logger.executionLog(Level.INFO, "%s", candidateID);
       }
     }
   }
@@ -370,7 +370,7 @@ class Tabulator {
         List<String> winningCandidates = currentRoundTallyToCandidates.get(tally);
         for (String winningCandidate : winningCandidates) {
           selectedWinners.add(winningCandidate);
-          Logger.tabulationLog(
+          Logger.executionLog(
               Level.INFO,
               "%s won in round %d with %s votes.",
               winningCandidate,
@@ -397,7 +397,7 @@ class Tabulator {
         && candidateIDs.contains(label)
         && currentRoundCandidateToTally.get(label).signum() == 1) {
       eliminated.add(label);
-      Logger.tabulationLog(
+      Logger.executionLog(
           Level.INFO,
           "Eliminated %s in round %d because it represents undeclared write-ins. It had "
               + "%s votes.",
@@ -425,7 +425,7 @@ class Tabulator {
           // candidate indexes over all candidates who received this tally
           for (String candidate : currentRoundTallyToCandidates.get(tally)) {
             eliminated.add(candidate);
-            Logger.tabulationLog(
+            Logger.executionLog(
                 Level.INFO,
                 "Eliminated %s in round %d because they only had %s vote(s), below the "
                     + "minimum threshold of %s.",
@@ -456,7 +456,7 @@ class Tabulator {
         // elimination iterates over all BatchElimination objects describing the eliminations
         for (BatchElimination elimination : batchEliminations) {
           eliminated.add(elimination.candidateID);
-          Logger.tabulationLog(
+          Logger.executionLog(
               Level.INFO,
               "Batch-eliminated %s in round %d. The running total was %s vote(s) and the "
                   + "next-highest count was %s vote(s).",
@@ -498,7 +498,7 @@ class Tabulator {
       // results of tiebreak stored here
       eliminatedCandidate = tieBreak.selectLoser();
       // TODO: If returned eliminatedCandidate is null, infinite loop!
-      Logger.tabulationLog(
+      Logger.executionLog(
           Level.INFO,
           "%s lost a tie-breaker in round %d against %s. Each candidate had %s vote(s). %s",
           eliminatedCandidate,
@@ -509,7 +509,7 @@ class Tabulator {
     } else {
       // last place candidate will be eliminated
       eliminatedCandidate = lastPlaceCandidates.getFirst();
-      Logger.tabulationLog(
+      Logger.executionLog(
           Level.INFO,
           "%s was eliminated in round %d with %s vote(s).",
           eliminatedCandidate,
@@ -859,12 +859,12 @@ class Tabulator {
   // purpose: log the audit info to console and audit file
   // param: castVoteRecords list of all CVRs which have been tabulated
   void doAudit(List<CastVoteRecord> castVoteRecords) {
-    Logger.tabulationLog(Level.INFO, "Writing audit info to logs...");
+    Logger.executionLog(Level.INFO, "Writing audit info to logs...");
     for (CastVoteRecord cvr : castVoteRecords) {
       // use level FINE to keep audit logging out of the console
-      Logger.tabulationLog(Level.FINE, cvr.getAuditString());
+      Logger.executionLog(Level.FINE, cvr.getAuditString());
     }
-    Logger.tabulationLog(Level.INFO, "Audit info written.");
+    Logger.executionLog(Level.INFO, "Audit info written.");
   }
 
   // OvervoteRule determines how overvotes are handled

--- a/src/main/java/com/rcv/Tabulator.java
+++ b/src/main/java/com/rcv/Tabulator.java
@@ -861,7 +861,8 @@ class Tabulator {
   void doAudit(List<CastVoteRecord> castVoteRecords) {
     Logger.tabulationLog(Level.INFO, "Writing audit info to logs...");
     for (CastVoteRecord cvr : castVoteRecords) {
-      Logger.auditLog(Level.FINER, cvr.getAuditString());
+      // use level FINE to keep audit logging out of the console
+      Logger.tabulationLog(Level.FINE, cvr.getAuditString());
     }
     Logger.tabulationLog(Level.INFO, "Audit info written.");
   }

--- a/src/main/java/com/rcv/Tabulator.java
+++ b/src/main/java/com/rcv/Tabulator.java
@@ -95,7 +95,7 @@ class Tabulator {
       // vote count for this candidate
       BigDecimal votes = roundTally.get(candidate);
       if (shouldLog) {
-        Logger.executionLog(Level.INFO, "Candidate %s got %s votes.", candidate, votes.toString());
+        Logger.Log(Level.INFO, "Candidate %s got %s votes.", candidate, votes.toString());
       }
       // all candidates in the existing output structure (if any) who received the same vote tally
       LinkedList<String> candidates =
@@ -111,7 +111,7 @@ class Tabulator {
   //  this is the high-level control of the tabulation algorithm
   void tabulate() {
     logSummaryInfo();
-    Logger.executionLog(Level.INFO, "Starting tabulation...");
+    Logger.Log(Level.INFO, "Starting tabulation...");
 
     // Loop until we've found our winner(s) unless using continueUntilTwoCandidatesRemain, in which
     // case we loop until only two candidates remain.
@@ -121,7 +121,7 @@ class Tabulator {
     // remaining candidates.
     while (shouldContinueTabulating()) {
       currentRound++;
-      Logger.executionLog(Level.INFO, "Round: %d", currentRound);
+      Logger.Log(Level.INFO, "Round: %d", currentRound);
 
       // currentRoundCandidateToTally is a map from candidateID to vote tally for the current round.
       // At each iteration of this loop that involves eliminating candidates, the eliminatedRound
@@ -198,27 +198,27 @@ class Tabulator {
       updatePastWinnerTallies();
     }
 
-    Logger.executionLog(Level.INFO, "Tabulation completed.");
+    Logger.Log(Level.INFO, "Tabulation completed.");
   }
 
   // function: logSummaryInfo
   // purpose: log some basic info about the contest before starting tabulation
   private void logSummaryInfo() {
-    Logger.executionLog(
+    Logger.Log(
         Level.INFO,
         "There are %d declared candidates for this contest:",
         config.getNumDeclaredCandidates());
     // candidateID indexes over all candidate IDs to log them
     for (String candidateID : candidateIDs) {
-      Logger.executionLog(Level.INFO, "%s", candidateID);
+      Logger.Log(Level.INFO, "%s", candidateID);
     }
 
     if (config.getTiebreakMode() == TieBreakMode.GENERATE_PERMUTATION) {
-      Logger.executionLog(
+      Logger.Log(
           Level.INFO, "Randomly generated candidate permutation for tie-breaking:");
       // candidateID indexes over all candidates in ordered list
       for (String candidateID : config.getCandidatePermutation()) {
-        Logger.executionLog(Level.INFO, "%s", candidateID);
+        Logger.Log(Level.INFO, "%s", candidateID);
       }
     }
   }
@@ -370,7 +370,7 @@ class Tabulator {
         List<String> winningCandidates = currentRoundTallyToCandidates.get(tally);
         for (String winningCandidate : winningCandidates) {
           selectedWinners.add(winningCandidate);
-          Logger.executionLog(
+          Logger.Log(
               Level.INFO,
               "%s won in round %d with %s votes.",
               winningCandidate,
@@ -397,7 +397,7 @@ class Tabulator {
         && candidateIDs.contains(label)
         && currentRoundCandidateToTally.get(label).signum() == 1) {
       eliminated.add(label);
-      Logger.executionLog(
+      Logger.Log(
           Level.INFO,
           "Eliminated %s in round %d because it represents undeclared write-ins. It had "
               + "%s votes.",
@@ -425,7 +425,7 @@ class Tabulator {
           // candidate indexes over all candidates who received this tally
           for (String candidate : currentRoundTallyToCandidates.get(tally)) {
             eliminated.add(candidate);
-            Logger.executionLog(
+            Logger.Log(
                 Level.INFO,
                 "Eliminated %s in round %d because they only had %s vote(s), below the "
                     + "minimum threshold of %s.",
@@ -456,7 +456,7 @@ class Tabulator {
         // elimination iterates over all BatchElimination objects describing the eliminations
         for (BatchElimination elimination : batchEliminations) {
           eliminated.add(elimination.candidateID);
-          Logger.executionLog(
+          Logger.Log(
               Level.INFO,
               "Batch-eliminated %s in round %d. The running total was %s vote(s) and the "
                   + "next-highest count was %s vote(s).",
@@ -498,7 +498,7 @@ class Tabulator {
       // results of tiebreak stored here
       eliminatedCandidate = tieBreak.selectLoser();
       // TODO: If returned eliminatedCandidate is null, infinite loop!
-      Logger.executionLog(
+      Logger.Log(
           Level.INFO,
           "%s lost a tie-breaker in round %d against %s. Each candidate had %s vote(s). %s",
           eliminatedCandidate,
@@ -509,7 +509,7 @@ class Tabulator {
     } else {
       // last place candidate will be eliminated
       eliminatedCandidate = lastPlaceCandidates.getFirst();
-      Logger.executionLog(
+      Logger.Log(
           Level.INFO,
           "%s was eliminated in round %d with %s vote(s).",
           eliminatedCandidate,
@@ -859,12 +859,12 @@ class Tabulator {
   // purpose: log the audit info to console and audit file
   // param: castVoteRecords list of all CVRs which have been tabulated
   void doAudit(List<CastVoteRecord> castVoteRecords) {
-    Logger.executionLog(Level.INFO, "Writing audit info to logs...");
+    Logger.Log(Level.INFO, "Writing audit info to logs...");
     for (CastVoteRecord cvr : castVoteRecords) {
       // use level FINE to keep audit logging out of the console
-      Logger.executionLog(Level.FINE, cvr.getAuditString());
+      Logger.Log(Level.FINE, cvr.getAuditString());
     }
-    Logger.executionLog(Level.INFO, "Audit info written.");
+    Logger.Log(Level.INFO, "Audit info written.");
   }
 
   // OvervoteRule determines how overvotes are handled

--- a/src/main/java/com/rcv/Tabulator.java
+++ b/src/main/java/com/rcv/Tabulator.java
@@ -95,7 +95,7 @@ class Tabulator {
       // vote count for this candidate
       BigDecimal votes = roundTally.get(candidate);
       if (shouldLog) {
-        Logger.Log(Level.INFO, "Candidate %s got %s votes.", candidate, votes.toString());
+        Logger.log(Level.INFO, "Candidate %s got %s votes.", candidate, votes.toString());
       }
       // all candidates in the existing output structure (if any) who received the same vote tally
       LinkedList<String> candidates =
@@ -111,7 +111,7 @@ class Tabulator {
   //  this is the high-level control of the tabulation algorithm
   void tabulate() {
     logSummaryInfo();
-    Logger.Log(Level.INFO, "Starting tabulation...");
+    Logger.log(Level.INFO, "Starting tabulation...");
 
     // Loop until we've found our winner(s) unless using continueUntilTwoCandidatesRemain, in which
     // case we loop until only two candidates remain.
@@ -121,7 +121,7 @@ class Tabulator {
     // remaining candidates.
     while (shouldContinueTabulating()) {
       currentRound++;
-      Logger.Log(Level.INFO, "Round: %d", currentRound);
+      Logger.log(Level.INFO, "Round: %d", currentRound);
 
       // currentRoundCandidateToTally is a map from candidateID to vote tally for the current round.
       // At each iteration of this loop that involves eliminating candidates, the eliminatedRound
@@ -198,27 +198,27 @@ class Tabulator {
       updatePastWinnerTallies();
     }
 
-    Logger.Log(Level.INFO, "Tabulation completed.");
+    Logger.log(Level.INFO, "Tabulation completed.");
   }
 
   // function: logSummaryInfo
   // purpose: log some basic info about the contest before starting tabulation
   private void logSummaryInfo() {
-    Logger.Log(
+    Logger.log(
         Level.INFO,
         "There are %d declared candidates for this contest:",
         config.getNumDeclaredCandidates());
     // candidateID indexes over all candidate IDs to log them
     for (String candidateID : candidateIDs) {
-      Logger.Log(Level.INFO, "%s", candidateID);
+      Logger.log(Level.INFO, "%s", candidateID);
     }
 
     if (config.getTiebreakMode() == TieBreakMode.GENERATE_PERMUTATION) {
-      Logger.Log(
+      Logger.log(
           Level.INFO, "Randomly generated candidate permutation for tie-breaking:");
       // candidateID indexes over all candidates in ordered list
       for (String candidateID : config.getCandidatePermutation()) {
-        Logger.Log(Level.INFO, "%s", candidateID);
+        Logger.log(Level.INFO, "%s", candidateID);
       }
     }
   }
@@ -370,7 +370,7 @@ class Tabulator {
         List<String> winningCandidates = currentRoundTallyToCandidates.get(tally);
         for (String winningCandidate : winningCandidates) {
           selectedWinners.add(winningCandidate);
-          Logger.Log(
+          Logger.log(
               Level.INFO,
               "%s won in round %d with %s votes.",
               winningCandidate,
@@ -397,7 +397,7 @@ class Tabulator {
         && candidateIDs.contains(label)
         && currentRoundCandidateToTally.get(label).signum() == 1) {
       eliminated.add(label);
-      Logger.Log(
+      Logger.log(
           Level.INFO,
           "Eliminated %s in round %d because it represents undeclared write-ins. It had "
               + "%s votes.",
@@ -425,7 +425,7 @@ class Tabulator {
           // candidate indexes over all candidates who received this tally
           for (String candidate : currentRoundTallyToCandidates.get(tally)) {
             eliminated.add(candidate);
-            Logger.Log(
+            Logger.log(
                 Level.INFO,
                 "Eliminated %s in round %d because they only had %s vote(s), below the "
                     + "minimum threshold of %s.",
@@ -456,7 +456,7 @@ class Tabulator {
         // elimination iterates over all BatchElimination objects describing the eliminations
         for (BatchElimination elimination : batchEliminations) {
           eliminated.add(elimination.candidateID);
-          Logger.Log(
+          Logger.log(
               Level.INFO,
               "Batch-eliminated %s in round %d. The running total was %s vote(s) and the "
                   + "next-highest count was %s vote(s).",
@@ -498,7 +498,7 @@ class Tabulator {
       // results of tiebreak stored here
       eliminatedCandidate = tieBreak.selectLoser();
       // TODO: If returned eliminatedCandidate is null, infinite loop!
-      Logger.Log(
+      Logger.log(
           Level.INFO,
           "%s lost a tie-breaker in round %d against %s. Each candidate had %s vote(s). %s",
           eliminatedCandidate,
@@ -509,7 +509,7 @@ class Tabulator {
     } else {
       // last place candidate will be eliminated
       eliminatedCandidate = lastPlaceCandidates.getFirst();
-      Logger.Log(
+      Logger.log(
           Level.INFO,
           "%s was eliminated in round %d with %s vote(s).",
           eliminatedCandidate,
@@ -859,12 +859,12 @@ class Tabulator {
   // purpose: log the audit info to console and audit file
   // param: castVoteRecords list of all CVRs which have been tabulated
   void doAudit(List<CastVoteRecord> castVoteRecords) {
-    Logger.Log(Level.INFO, "Writing audit info to logs...");
+    Logger.log(Level.INFO, "Writing audit info to logs...");
     for (CastVoteRecord cvr : castVoteRecords) {
       // use level FINE to keep audit logging out of the console
-      Logger.Log(Level.FINE, cvr.getAuditString());
+      Logger.log(Level.FINE, cvr.getAuditString());
     }
-    Logger.Log(Level.INFO, "Audit info written.");
+    Logger.log(Level.INFO, "Audit info written.");
   }
 
   // OvervoteRule determines how overvotes are handled

--- a/src/main/java/com/rcv/TieBreak.java
+++ b/src/main/java/com/rcv/TieBreak.java
@@ -214,13 +214,13 @@ class TieBreak {
   // purpose: interactively select the loser of this tiebreak via the graphical user interface
   // return: candidateID of the selected loser
   private String doInteractiveGui() {
-    Logger.Log(
+    Logger.log(
         Level.INFO,
         "Tie in round %d for the following candidates, each of whom has %d votes: %s",
         round,
         numVotes.intValue(),
         String.join(", ", tiedCandidates));
-    Logger.Log(
+    Logger.log(
         Level.INFO,
         "Please use the pop-up window to select the candidate who should lose this tiebreaker.");
 
@@ -232,10 +232,10 @@ class TieBreak {
         Platform.runLater(futureTask);
         selectedCandidate = futureTask.get();
       } catch (InterruptedException | ExecutionException exception) {
-        Logger.Log(Level.SEVERE, "Failed to get tiebreaker!\n%s", exception.toString());
+        Logger.log(Level.SEVERE, "Failed to get tiebreaker!\n%s", exception.toString());
       }
       if (selectedCandidate == null || selectedCandidate.isEmpty()) {
-        Logger.Log(Level.WARNING, "Invalid selection. Please try again.");
+        Logger.log(Level.WARNING, "Invalid selection. Please try again.");
       }
     }
 
@@ -313,7 +313,7 @@ class TieBreak {
         window.showAndWait();
         candidateToEliminate = controller.getCandidateToEliminate();
       } catch (IOException exception) {
-        Logger.Log(
+        Logger.log(
             Level.SEVERE, "Failed to open: %s:\n%s", resourcePath, exception.getCause().toString());
       }
 

--- a/src/main/java/com/rcv/TieBreak.java
+++ b/src/main/java/com/rcv/TieBreak.java
@@ -232,7 +232,7 @@ class TieBreak {
         Platform.runLater(futureTask);
         selectedCandidate = futureTask.get();
       } catch (InterruptedException | ExecutionException exception) {
-        Logger.tabulationLog(Level.SEVERE, "Failed to get tiebreaker!\n%s", exception.toString());
+        Logger.executionLog(Level.SEVERE, "Failed to get tiebreaker!\n%s", exception.toString());
       }
       if (selectedCandidate == null || selectedCandidate.isEmpty()) {
         Logger.executionLog(Level.WARNING, "Invalid selection. Please try again.");
@@ -313,7 +313,7 @@ class TieBreak {
         window.showAndWait();
         candidateToEliminate = controller.getCandidateToEliminate();
       } catch (IOException exception) {
-        Logger.tabulationLog(
+        Logger.executionLog(
             Level.SEVERE, "Failed to open: %s:\n%s", resourcePath, exception.getCause().toString());
       }
 

--- a/src/main/java/com/rcv/TieBreak.java
+++ b/src/main/java/com/rcv/TieBreak.java
@@ -214,13 +214,13 @@ class TieBreak {
   // purpose: interactively select the loser of this tiebreak via the graphical user interface
   // return: candidateID of the selected loser
   private String doInteractiveGui() {
-    Logger.executionLog(
+    Logger.Log(
         Level.INFO,
         "Tie in round %d for the following candidates, each of whom has %d votes: %s",
         round,
         numVotes.intValue(),
         String.join(", ", tiedCandidates));
-    Logger.executionLog(
+    Logger.Log(
         Level.INFO,
         "Please use the pop-up window to select the candidate who should lose this tiebreaker.");
 
@@ -232,10 +232,10 @@ class TieBreak {
         Platform.runLater(futureTask);
         selectedCandidate = futureTask.get();
       } catch (InterruptedException | ExecutionException exception) {
-        Logger.executionLog(Level.SEVERE, "Failed to get tiebreaker!\n%s", exception.toString());
+        Logger.Log(Level.SEVERE, "Failed to get tiebreaker!\n%s", exception.toString());
       }
       if (selectedCandidate == null || selectedCandidate.isEmpty()) {
-        Logger.executionLog(Level.WARNING, "Invalid selection. Please try again.");
+        Logger.Log(Level.WARNING, "Invalid selection. Please try again.");
       }
     }
 
@@ -313,7 +313,7 @@ class TieBreak {
         window.showAndWait();
         candidateToEliminate = controller.getCandidateToEliminate();
       } catch (IOException exception) {
-        Logger.executionLog(
+        Logger.Log(
             Level.SEVERE, "Failed to open: %s:\n%s", resourcePath, exception.getCause().toString());
       }
 

--- a/src/main/java/com/rcv/TieBreak.java
+++ b/src/main/java/com/rcv/TieBreak.java
@@ -214,13 +214,13 @@ class TieBreak {
   // purpose: interactively select the loser of this tiebreak via the graphical user interface
   // return: candidateID of the selected loser
   private String doInteractiveGui() {
-    Logger.guiLog(
+    Logger.executionLog(
         Level.INFO,
         "Tie in round %d for the following candidates, each of whom has %d votes: %s",
         round,
         numVotes.intValue(),
         String.join(", ", tiedCandidates));
-    Logger.guiLog(
+    Logger.executionLog(
         Level.INFO,
         "Please use the pop-up window to select the candidate who should lose this tiebreaker.");
 
@@ -235,7 +235,7 @@ class TieBreak {
         Logger.tabulationLog(Level.SEVERE, "Failed to get tiebreaker!\n%s", exception.toString());
       }
       if (selectedCandidate == null || selectedCandidate.isEmpty()) {
-        Logger.guiLog(Level.WARNING, "Invalid selection. Please try again.");
+        Logger.executionLog(Level.WARNING, "Invalid selection. Please try again.");
       }
     }
 


### PR DESCRIPTION
Some much needed refactoring of Logging to fix "double console logging" but more importantly, greatly simplify logging to use multiple LogHandlers instead of multiple Loggers.  I tested this with a few tabulations from the CLI and GUI and it seems ok, but if you guys wouldn't mind running a couple tabulations and verifying the logging outputs look ok that would be greatly appreciated.  

Users of the Logger no longer need to know about different flavors of logger.  They DO need to be aware of the LEVEL they use, notably: Level.FINE will go into the execution log only (for audit logging).  Level.INFO (and above) will go into execution log file, tabulation file (if tabulating) and GUI (if GUI mode).  So for most use cases, you just call Logger.Log(Level.X, ...) and get on with your day :)

Note: this does not attempt to address the issue of potentially huge audit log files.  @CalebKleppner: it would be fairly easy to split up a huge audit output (using the Logger framework) say every 100MB (or 50, etc.) gets written to a different file.  Is that something that would be useful?