### PR TITLE
audit log improvements (#146)

### DIFF
--- a/src/main/java/com/rcv/CastVoteRecord.java
+++ b/src/main/java/com/rcv/CastVoteRecord.java
@@ -111,7 +111,7 @@ class CastVoteRecord {
     // add complete data for round 1 only
     if (round == 1) {
       logStringBuilder.append(" [Raw Data] ");
-      logStringBuilder.append(fullCVRData).append(" ");
+      logStringBuilder.append(fullCVRData);
     }
 
     // output with level FINE routes to audit log

--- a/src/main/java/com/rcv/CastVoteRecord.java
+++ b/src/main/java/com/rcv/CastVoteRecord.java
@@ -71,7 +71,7 @@ class CastVoteRecord {
   }
 
   // function: logRoundOutcome
-  // purpose: adds the outcome for this CVR for this round (for auditing purposes)
+  // purpose: logs the outcome for this CVR for this round for auditing purposes
   // param: outcomeType indicates what happened
   // param: detail reflects who (if anyone) received the vote or why it was exhausted/ignored
   // param: fractionalTransferValue if someone received the vote (not exhausted/ignored)
@@ -81,14 +81,14 @@ class CastVoteRecord {
       BigDecimal fractionalTransferValue) {
 
     StringBuilder logStringBuilder = new StringBuilder();
-    // add info on the outcome
+    // add round and ID
     logStringBuilder.append("[Round] ").append(round).append(" [CVR] ");
     if (suppliedID != null && !suppliedID.isEmpty()) {
       logStringBuilder.append(suppliedID);
     } else {
       logStringBuilder.append(computedID);
     }
-
+    // add outcome type
     if (outcomeType == VoteOutcomeType.IGNORED) {
       logStringBuilder.append(" [was ignored] ");
     } else if (outcomeType == VoteOutcomeType.EXHAUSTED) {
@@ -100,7 +100,7 @@ class CastVoteRecord {
         logStringBuilder.append(" [transferred to] ");
       }
     }
-    // detail string is candidate ID or more explanation for other outcomes
+    // add detail: either candidate ID or more explanation for other outcomes
     logStringBuilder.append(detail);
 
     // add fractional transfer value of the vote if it is fractional
@@ -121,7 +121,6 @@ class CastVoteRecord {
   // function: exhaust
   // purpose: transition the CVR into exhausted state with the given reason
   // param: round the exhaustion occurs
-  // param: reason: the reason for exhaustion
   void exhaust() {
     assert !isExhausted;
     isExhausted = true;

--- a/src/main/java/com/rcv/Logger.java
+++ b/src/main/java/com/rcv/Logger.java
@@ -116,6 +116,8 @@ class Logger {
   // function: removeTabulationFileLogging
   // purpose: remove file logging once a tabulation run is complete
   static void removeTabulationFileLogging() {
+    tabulationHandler.flush();
+    tabulationHandler.close();
     logger.removeHandler(tabulationHandler);
   }
 

--- a/src/main/java/com/rcv/Main.java
+++ b/src/main/java/com/rcv/Main.java
@@ -139,8 +139,6 @@ public class Main extends GuiApplication {
             tabulator.tabulate();
             // generate visualizer spreadsheet data
             tabulator.generateSummarySpreadsheet(timestampString);
-            // generate audit data
-            tabulator.doAudit(castVoteRecords);
             isTabulationCompleted = true;
           } else {
             Logger.log(Level.SEVERE, "No cast vote records found.");

--- a/src/main/java/com/rcv/Tabulator.java
+++ b/src/main/java/com/rcv/Tabulator.java
@@ -688,8 +688,7 @@ class Tabulator {
 
     // CVR indexes over the cast vote records to count votes for continuing candidateIDs
     for (CastVoteRecord cvr : castVoteRecords) {
-
-      // see if this cvr has a current recipient which is continuing
+      // see if this cvr recipient is a continuing candidate
       // in this case we can skip logic to determine who the cvr will count for
       if (!cvr.isExhausted() &&
           !(cvr.getCurrentRecipientOfVote() == null) &&
@@ -744,8 +743,10 @@ class Tabulator {
           }
           if (duplicateCandidate != null && !duplicateCandidate.isEmpty()) {
             cvr.exhaust();
-            cvr.logRoundOutcome(currentRound, VoteOutcomeType.EXHAUSTED,
-                "duplicate candidate: " + duplicateCandidate, null);
+            cvr.logRoundOutcome(currentRound,
+                VoteOutcomeType.EXHAUSTED,
+                "duplicate candidate: " + duplicateCandidate,
+                null);
             break;
           }
         }
@@ -793,7 +794,9 @@ class Tabulator {
               cvr.getPrecinct());
 
           // log the vote transfer to new recipient
-          cvr.logRoundOutcome(currentRound, VoteOutcomeType.COUNTED, selectedCandidate,
+          cvr.logRoundOutcome(currentRound,
+              VoteOutcomeType.COUNTED,
+              selectedCandidate,
               fractionalTransferValue);
         }
 
@@ -870,6 +873,11 @@ class Tabulator {
 
   // function: incrementTallies
   // purpose: transfer vote to round tally and (if valid) the precinct round tally
+  // param: tally is a round tally that we're in the process of computing
+  // param: cvr is a single cast vote record
+  // param: selectedCandidateID is the candidate this CVR's vote is going to in this round
+  // param: roundTallyByPrecinct map of precinct IDs to roundTallies
+  // param: precinct ID of precinct for current CVR
   private void incrementTallies(
       Map<String, BigDecimal> tally,
       BigDecimal fractionalTransferValue,


### PR DESCRIPTION
only log cvr data when it changes
log during tabulation (instead of after)
remove VoteOutcome cache from cvr
flush and close audit fileHandler

add check in Tabulate main loop to continue if the cvr counts to the
same continuing candidate as the previous round (issue #155)