### PR TITLE
add final redistribution round for multi-seat

### DIFF
--- a/src/main/java/com/rcv/Tabulator.java
+++ b/src/main/java/com/rcv/Tabulator.java
@@ -361,6 +361,8 @@ class Tabulator {
     if (config.willContinueUntilTwoCandidatesRemain()) {
       return numEliminatedCandidates + numWinnersDeclared + 1 < config.getNumCandidates();
     } else {
+      // This line just finds the most recent round in which we've declared a winner (or -1 if we
+      // haven't declared any winners yet).
       int lastWinnerRound = winnerToRound.values().stream().mapToInt(v -> v).max().orElse(-1);
       // If there are more seats to fill, we should keep going, of course.
       // But also: if we've selected all the winners in a multi-seat contest, we should tabulate one


### PR DESCRIPTION
This is a little hairy, but I think it works OK. George and Caleb requested that we redistribute the surplus for all winners in a multi-seat contest, even if there are no more seats to fill. Since the way our code works is to declare a winner in round r and then show the consequences of redistributing that winner's surplus in round r+1, we need to add a single extra round of tabulation for multi-seat contests -- but unlike all other rounds, there are no actions (winner declarations or eliminations) in this round. 