### PR TITLE
fix tabulation bugs for continueUntilTwoCandidatesRemain mode

### DIFF
--- a/src/main/java/com/rcv/Tabulator.java
+++ b/src/main/java/com/rcv/Tabulator.java
@@ -367,14 +367,11 @@ class Tabulator {
       return numEliminatedCandidates + numWinnersDeclared + 1 < config.getNumCandidates()
           || candidateToRoundEliminated.values().contains(currentRound);
     } else {
-      // This line just finds the most recent round in which we've declared a winner (or -1 if we
-      // haven't declared any winners yet).
-      int lastWinnerRound = winnerToRound.values().stream().mapToInt(v -> v).max().orElse(-1);
       // If there are more seats to fill, we should keep going, of course.
       // But also: if we've selected all the winners in a multi-seat contest, we should tabulate one
       // extra round in order to show the effect of redistributing the final surpluses.
       return numWinnersDeclared < config.getNumberOfWinners()
-          || (config.getNumberOfWinners() > 1 && lastWinnerRound == currentRound);
+          || (config.getNumberOfWinners() > 1 && winnerToRound.values().contains(currentRound));
     }
   }
 

--- a/src/main/java/com/rcv/Tabulator.java
+++ b/src/main/java/com/rcv/Tabulator.java
@@ -180,9 +180,12 @@ class Tabulator {
             }
           }
         }
-      } else if (winnerToRound.size() < config.getNumberOfWinners()) {
-        // since there are no winners in this round and we still need to fill more seats, let's
-        // determine which candidate(s) will be eliminated
+      } else if (winnerToRound.size() < config.getNumberOfWinners()
+          || (config.willContinueUntilTwoCandidatesRemain()
+          && candidateToRoundEliminated.size() < config.getNumCandidates() - 2)) {
+        // We need to make more eliminations if
+        // a) we haven't found all the winners yet, or
+        // b) we've found our winner, but we're continuing until we have only two candidates
 
         // container for eliminated candidate(s)
         List<String> eliminated;
@@ -359,7 +362,10 @@ class Tabulator {
     int numWinnersDeclared = winnerToRound.size();
     // apply config setting if specified
     if (config.willContinueUntilTwoCandidatesRemain()) {
-      return numEliminatedCandidates + numWinnersDeclared + 1 < config.getNumCandidates();
+      // Keep going if there are more than two candidates alive. Also make sure we tabulate one last
+      // round after we've made our final elimination.
+      return numEliminatedCandidates + numWinnersDeclared + 1 < config.getNumCandidates()
+          || candidateToRoundEliminated.values().contains(currentRound);
     } else {
       // This line just finds the most recent round in which we've declared a winner (or -1 if we
       // haven't declared any winners yet).

--- a/test_data/config_test_continue_tabulation.json
+++ b/test_data/config_test_continue_tabulation.json
@@ -1,7 +1,7 @@
 {
   "outputSettings": {
     "contestName": "Portland 2015 Mayoral Race",
-    "outputDirectory": "test",
+    "outputDirectory": "test_output/continue_tabulation",
     "contestDate": "2015-11-03",
     "contestJurisdiction": "Portland, ME",
     "contestOffice": "Mayor",

--- a/test_data/test_continue_tabulation_expected.json
+++ b/test_data/test_continue_tabulation_expected.json
@@ -1,0 +1,40 @@
+{
+  "config" : {
+    "contest" : "Portland 2015 Mayoral Race",
+    "date" : "2015-11-03",
+    "jurisdiction" : "Portland, ME",
+    "office" : "Mayor",
+    "threshold" : "10"
+  },
+  "results" : [ {
+    "round" : 1,
+    "tally" : {
+      "Carmona, Ralph C." : "5",
+      "Haadoow, Hamza A." : "3",
+      "Vail, Christopher L." : "10"
+    },
+    "tallyResults" : [ {
+      "elected" : "Vail, Christopher L."
+    } ]
+  }, {
+    "round" : 2,
+    "tally" : {
+      "Carmona, Ralph C." : "5",
+      "Haadoow, Hamza A." : "3",
+      "Vail, Christopher L." : "10"
+    },
+    "tallyResults" : [ {
+      "eliminated" : "Haadoow, Hamza A.",
+      "transfers" : {
+        "Vail, Christopher L." : "3"
+      }
+    } ]
+  }, {
+    "round" : 3,
+    "tally" : {
+      "Carmona, Ralph C." : "5",
+      "Vail, Christopher L." : "13"
+    },
+    "tallyResults" : [ ]
+  } ]
+}

--- a/tests/com/rcv/TabulatorTests.java
+++ b/tests/com/rcv/TabulatorTests.java
@@ -57,7 +57,7 @@ class TabulatorTests {
       BufferedReader reader2 = new BufferedReader(new FileReader(path2));
 
       // loop until EOF is encountered
-      while(true) {
+      while (true) {
         // line1 and line2 store current line read from readers or null if EOF
         String line1 = reader1.readLine();
         String line2 = reader2.readLine();
@@ -67,14 +67,14 @@ class TabulatorTests {
           break;
         } else if (line1 == null || line2 == null) {
           // one file ended but the other did not
-          Logger.log(Level.SEVERE,"files are unequal lengths");
+          Logger.log(Level.SEVERE, "files are unequal lengths");
           result = false;
           break;
         }
         // both files have content so compare it
         if (!line1.equals(line2)) {
           // report inequality and keep processing in case there are more inequalities
-          Logger.log(Level.SEVERE,"files are not equal:\n%s\n%s", line1, line2);
+          Logger.log(Level.SEVERE, "files are not equal:\n%s\n%s", line1, line2);
           result = false;
         }
       }
@@ -94,13 +94,15 @@ class TabulatorTests {
   // param: expectedFile name of expected summary results json file
   static void runTabulationTest(String configFile, String expectedFile) {
     // full path to config file
-    String configPath = Paths.get(System.getProperty("user.dir"), TEST_ASSET_FOLDER, configFile)
+    String configPath =
+        Paths.get(System.getProperty("user.dir"), TEST_ASSET_FOLDER, configFile)
             .toAbsolutePath()
             .toString();
     // full path to expected results file
-    String expectedPath = Paths.get(System.getProperty("user.dir"), TEST_ASSET_FOLDER, expectedFile)
-        .toAbsolutePath()
-        .toString();
+    String expectedPath =
+        Paths.get(System.getProperty("user.dir"), TEST_ASSET_FOLDER, expectedFile)
+            .toAbsolutePath()
+            .toString();
     // load the contest config
     ContestConfig config = Main.loadContestConfig(configPath);
     Assertions.assertNotNull(config);
@@ -129,5 +131,12 @@ class TabulatorTests {
   @DisplayName("Portland Mayor 2015")
   void testPortlandMayor() {
     runTabulationTest("config_2015_portland_mayor.json", "2015_portland_mayor_expected.json");
+  }
+
+  @Test
+  @DisplayName("Continue Until Two Candidates Remain")
+  void testContinueUntilTwoCandidatesRemain() {
+    runTabulationTest(
+        "config_test_continue_tabulation.json", "test_continue_tabulation_expected.json");
   }
 }


### PR DESCRIPTION
Fixes #200.

This addresses two bugs associated with the continueUntilTwoCandidatesRemain mode. It was working previously, but we broke it at some point. (This was probably my fault.)
1. We had an infinite loop because we were failing to eliminate candidates after declaring a winner.
2. We weren't running a final round of tabulation to show the result of the last elimination.

I also added a test case for this. Hooray for tests!

Note to @HEdingfield: you have to mark the tests directory as the "Test Sources Root" before you can run TabulatorTests.