### PR TITLE
fix bugs uncovered by Armin's tests

### DIFF
--- a/src/main/java/com/rcv/Tabulator.java
+++ b/src/main/java/com/rcv/Tabulator.java
@@ -842,6 +842,9 @@ class Tabulator {
           recordSelectionForCastVoteRecord(cvr, currentRound, null, "overvote");
           break;
         } else if (overvoteDecision == OvervoteDecision.SKIP_TO_NEXT_RANK) {
+          if (rank == cvr.rankToCandidateIDs.lastKey()) {
+            recordSelectionForCastVoteRecord(cvr, currentRound, null, "no continuing candidates");
+          }
           continue;
         }
 

--- a/src/main/java/com/rcv/TallyTransfers.java
+++ b/src/main/java/com/rcv/TallyTransfers.java
@@ -49,30 +49,26 @@ class TallyTransfers {
   // param: sourceCandidate from which the transfers originate
   // param: targetCandidate to which the transfers go
   // param: value total value of all transfers
-  void addTransfer(int round,
-      String sourceCandidate,
-      String targetCandidate,
-      BigDecimal value) {
+  void addTransfer(int round, String sourceCandidate, String targetCandidate, BigDecimal value) {
     // null source means we are transferring the initial count
-    if(sourceCandidate == null) {
+    if (sourceCandidate == null) {
       sourceCandidate = "uncounted";
     }
     // null target means exhausted
-    if(targetCandidate == null) {
+    if (targetCandidate == null) {
       targetCandidate = "exhausted";
     }
 
     // lookup or create transfer entries for specified round
-    Map<String, Map<String, BigDecimal>> roundEntries = tallyTransfers
-        .computeIfAbsent(round, k -> new HashMap<>());
+    Map<String, Map<String, BigDecimal>> roundEntries =
+        tallyTransfers.computeIfAbsent(round, k -> new HashMap<>());
     // lookup or create map for the source candidate
-    Map<String, BigDecimal> candidateEntries = roundEntries
-        .computeIfAbsent(sourceCandidate, k -> new HashMap<>());
+    Map<String, BigDecimal> candidateEntries =
+        roundEntries.computeIfAbsent(sourceCandidate, k -> new HashMap<>());
     // lookup or create entry for the destination candidate
     BigDecimal currentValue = candidateEntries.getOrDefault(targetCandidate, BigDecimal.ZERO);
     // add transfer value and store the result
     BigDecimal newTally = currentValue.add(value);
     candidateEntries.put(targetCandidate, newTally);
   }
-
 }

--- a/test_data/2015_portland_mayor_expected.json
+++ b/test_data/2015_portland_mayor_expected.json
@@ -23,11 +23,12 @@
       "Miller, Markos S." : "3",
       "Rathband, Jed" : "2",
       "Strimling, Ethan K." : "1",
-      "UWI" : "0",
+      "Undeclared": "0",
       "Vail, Christopher L." : "6"
     },
     "tallyResults" : [ {
-      "eliminated" : "Undeclared"
+      "eliminated": "Undeclared",
+      "transfers": {}
     }, {
       "eliminated" : "Strimling, Ethan K.",
       "transfers" : {
@@ -276,7 +277,8 @@
       "Mavodones, Nicholas M. Jr." : "54"
     },
     "tallyResults" : [ {
-      "elected" : "Mavodones, Nicholas M. Jr."
+      "elected": "Mavodones, Nicholas M. Jr.",
+      "transfers": {}
     } ]
   } ]
 }

--- a/test_data/test_continue_tabulation_expected.json
+++ b/test_data/test_continue_tabulation_expected.json
@@ -14,7 +14,8 @@
       "Vail, Christopher L." : "10"
     },
     "tallyResults" : [ {
-      "elected" : "Vail, Christopher L."
+      "elected": "Vail, Christopher L.",
+      "transfers": {}
     } ]
   }, {
     "round" : 2,


### PR DESCRIPTION
Fixes #205.

This PR resolves three issues:
- When we exhausted a ballot due to overvote when that overvote was in the last ranking slot, we weren't properly recording the transfer.
- When we had an elimination or win with no transfers, we weren't adding a transfers map to the JSON. Not technically a bug, but arguably this makes the code easier on the visualization side.
- We weren't translating back to the full candidate names when we printed tallies in the JSON.