### PR TITLE
fix rounding and require decimal places >= 1

### DIFF
--- a/src/main/java/com/rcv/ContestConfig.java
+++ b/src/main/java/com/rcv/ContestConfig.java
@@ -268,10 +268,10 @@ class ContestConfig {
     }
 
     if (getDecimalPlacesForVoteArithmetic() == null
-        || getDecimalPlacesForVoteArithmetic() < 0
+        || getDecimalPlacesForVoteArithmetic() < 1
         || getDecimalPlacesForVoteArithmetic() > 20) {
       isValid = false;
-      Logger.log(Level.SEVERE, "decimalPlacesForVoteArithmetic must be from 0 to 20.");
+      Logger.log(Level.SEVERE, "decimalPlacesForVoteArithmetic must be from 1 to 20.");
     }
 
     if (getMinimumVoteThreshold() == null
@@ -321,13 +321,13 @@ class ContestConfig {
   // param: divisor is the denominator in the division operation
   // returns: the quotient
   BigDecimal divide(BigDecimal dividend, BigDecimal divisor) {
-    return dividend.divide(divisor, getDecimalPlacesForVoteArithmetic(), RoundingMode.HALF_EVEN);
+    return dividend.divide(divisor, getDecimalPlacesForVoteArithmetic(), RoundingMode.DOWN);
   }
 
   BigDecimal multiply(BigDecimal multiplier, BigDecimal multiplicand) {
     return multiplier
         .multiply(multiplicand)
-        .setScale(getDecimalPlacesForVoteArithmetic(), RoundingMode.HALF_EVEN);
+        .setScale(getDecimalPlacesForVoteArithmetic(), RoundingMode.DOWN);
   }
 
   // function: getOutputDirectoryRaw

--- a/src/main/resources/config_file_documentation.txt
+++ b/src/main/resources/config_file_documentation.txt
@@ -120,7 +120,7 @@ Config file must be valid JSON format. Examples can be found under the test fold
 
       "decimalPlacesForVoteArithmetic" required
         number of rounding decimal places when computing winning thresholds and fractional vote transfers
-        value: [0..20]
+        value: [1..20]
 
       "minimumVoteThreshold" required
         the minimum number of votes a candidate must receive in the first round to avoid automatic elimination


### PR DESCRIPTION
Addressing two minor things that came up this week:
1. All of our multiplication and division operations should round down. I audited them (there aren't many) and confirmed that rounding down is appropriate in each case.
2. decimalPlacesForVoteArithmetic should be at least 1, because setting it to zero makes surplus transfer impossible.