### PR TITLE
generate CVR CDF JSON

### DIFF
--- a/src/main/java/com/rcv/CastVoteRecord.java
+++ b/src/main/java/com/rcv/CastVoteRecord.java
@@ -132,6 +132,8 @@ class CastVoteRecord {
     return cdfSnapshotData;
   }
 
+  // purpose: store info that we'll need in order to generate the CVR JSON snapshots in the Common
+  // Data Format at the end of the tabulation (if this option is enabled)
   void logCdfSnapshotData(int round) {
     List<Pair<String, BigDecimal>> data = new LinkedList<>();
     for (Entry<String, BigDecimal> entry : winnerToFractionalValue.entrySet()) {

--- a/src/main/java/com/rcv/CastVoteRecord.java
+++ b/src/main/java/com/rcv/CastVoteRecord.java
@@ -70,6 +70,10 @@ class CastVoteRecord {
     sortRankings(rankings);
   }
 
+  String getID() {
+    return suppliedID != null ? suppliedID : computedID;
+  }
+
   // function: logRoundOutcome
   // purpose: logs the outcome for this CVR for this round for auditing purposes
   // param: outcomeType indicates what happened

--- a/src/main/java/com/rcv/ContestConfig.java
+++ b/src/main/java/com/rcv/ContestConfig.java
@@ -41,6 +41,7 @@ class ContestConfig {
 
   // If any booleans are unspecified in config file, they should default to false no matter what
   static final boolean SUGGESTED_TABULATE_BY_PRECINCT = false;
+  static final boolean SUGGESTED_GENERATE_CDF_JSON = false;
   static final boolean SUGGESTED_CANDIDATE_EXCLUDED = false;
   static final boolean SUGGESTED_SEQUENTIAL_MULTI_SEAT = false;
   static final boolean SUGGESTED_NON_INTEGER_WINNING_THRESHOLD = false;
@@ -516,6 +517,10 @@ class ContestConfig {
   // returns: true if and only if we should tabulate by precinct
   boolean isTabulateByPrecinctEnabled() {
     return rawConfig.outputSettings.tabulateByPrecinct;
+  }
+
+  boolean isGenerateCdfJsonEnabled() {
+    return rawConfig.outputSettings.generateCdfJson;
   }
 
   // function: getMaxRankingsAllowed

--- a/src/main/java/com/rcv/GuiConfigController.java
+++ b/src/main/java/com/rcv/GuiConfigController.java
@@ -95,6 +95,8 @@ public class GuiConfigController implements Initializable {
   @FXML
   private CheckBox checkBoxTabulateByPrecinct;
   @FXML
+  private CheckBox checkBoxGenerateCdfJson;
+  @FXML
   private TableView<CVRSource> tableViewCvrFiles;
   @FXML
   private TableColumn<CVRSource, String> tableColumnCvrFilePath;
@@ -569,6 +571,7 @@ public class GuiConfigController implements Initializable {
     labelCurrentlyLoaded.setText("Currently loaded: <New Config>");
 
     checkBoxTabulateByPrecinct.setSelected(ContestConfig.SUGGESTED_TABULATE_BY_PRECINCT);
+    checkBoxGenerateCdfJson.setSelected(ContestConfig.SUGGESTED_GENERATE_CDF_JSON);
     checkBoxSequentialMultiSeat.setSelected(ContestConfig.SUGGESTED_SEQUENTIAL_MULTI_SEAT);
     checkBoxNonIntegerWinningThreshold.setSelected(
         ContestConfig.SUGGESTED_NON_INTEGER_WINNING_THRESHOLD);
@@ -597,6 +600,7 @@ public class GuiConfigController implements Initializable {
     textFieldContestJurisdiction.clear();
     textFieldContestOffice.clear();
     checkBoxTabulateByPrecinct.setSelected(false);
+    checkBoxGenerateCdfJson.setSelected(false);
 
     textFieldCvrFilePath.clear();
     textFieldCvrFirstVoteCol.clear();
@@ -731,6 +735,7 @@ public class GuiConfigController implements Initializable {
     textFieldContestJurisdiction.setText(outputSettings.contestJurisdiction);
     textFieldContestOffice.setText(outputSettings.contestOffice);
     checkBoxTabulateByPrecinct.setSelected(outputSettings.tabulateByPrecinct);
+    checkBoxGenerateCdfJson.setSelected(outputSettings.generateCdfJson);
 
     if (rawConfig.cvrFileSources != null) {
       tableViewCvrFiles.setItems(FXCollections.observableArrayList(rawConfig.cvrFileSources));
@@ -796,6 +801,7 @@ public class GuiConfigController implements Initializable {
     outputSettings.contestJurisdiction = textFieldContestJurisdiction.getText();
     outputSettings.contestOffice = textFieldContestOffice.getText();
     outputSettings.tabulateByPrecinct = checkBoxTabulateByPrecinct.isSelected();
+    outputSettings.generateCdfJson = checkBoxGenerateCdfJson.isSelected();
     config.outputSettings = outputSettings;
 
     config.cvrFileSources = new ArrayList<>(tableViewCvrFiles.getItems());

--- a/src/main/java/com/rcv/RawContestConfig.java
+++ b/src/main/java/com/rcv/RawContestConfig.java
@@ -85,6 +85,7 @@ public class RawContestConfig {
     public String contestOffice;
     // should we report round-by-round results by precinct also?
     public boolean tabulateByPrecinct;
+    public boolean generateCdfJson;
   }
 
   // CVRSource: encapsulates a source cast vote record file

--- a/src/main/java/com/rcv/ResultsWriter.java
+++ b/src/main/java/com/rcv/ResultsWriter.java
@@ -531,6 +531,7 @@ class ResultsWriter {
     generateJsonFile(outputPath, outputJson);
   }
 
+  // purpose: helper method for generateCdfJson to compile the data for all the CVR snapshots
   private List<Map<String, Object>> generateCdfMapForCvrs(List<CastVoteRecord> castVoteRecords) {
     List<Map<String, Object>> cvrMaps = new LinkedList<>();
 
@@ -562,6 +563,7 @@ class ResultsWriter {
     return cvrMaps;
   }
 
+  // purpose: helper for generateCdfMapForCvrs to handle a single CVR in a single round
   private Map<String, Object> generateCvrSnapshotMap(
       CastVoteRecord cvr, Integer round, List<Pair<String, BigDecimal>> currentRoundSnapshotData) {
     List<Map<String, Object>> selectionMapList = new LinkedList<>();

--- a/src/main/java/com/rcv/Tabulator.java
+++ b/src/main/java/com/rcv/Tabulator.java
@@ -766,6 +766,10 @@ class Tabulator {
     // log the vote outcome
     cvr.logRoundOutcome(
         currentRound, outcomeType, outcomeDescription, cvr.getFractionalTransferValue());
+
+    if (config.isGenerateCdfJsonEnabled()) {
+      cvr.logCdfSnapshotData(currentRound);
+    }
   }
 
   // function: computeTalliesForRound

--- a/src/main/java/com/rcv/Tabulator.java
+++ b/src/main/java/com/rcv/Tabulator.java
@@ -629,6 +629,10 @@ class Tabulator {
     if (config.isTabulateByPrecinctEnabled()) {
       writer.generatePrecinctSummarySpreadsheets(precinctRoundTallies);
     }
+
+    if (config.isGenerateCdfJsonEnabled()) {
+      writer.generateCdfJson(castVoteRecords);
+    }
   }
 
   // Function: runBatchElimination

--- a/src/main/resources/GuiConfigLayout.fxml
+++ b/src/main/resources/GuiConfigLayout.fxml
@@ -81,6 +81,12 @@
                 <Insets top="10.0"/>
               </VBox.margin>
             </CheckBox>
+            <CheckBox mnemonicParsing="false" text="Generate CDF JSON"
+              fx:id="checkBoxGenerateCdfJson">
+              <VBox.margin>
+                <Insets top="10.0"/>
+              </VBox.margin>
+            </CheckBox>
             <padding>
               <Insets bottom="12.0" left="12.0" right="12.0" top="12.0"/>
             </padding>

--- a/src/main/resources/config_file_documentation.txt
+++ b/src/main/resources/config_file_documentation.txt
@@ -44,6 +44,11 @@ Config file must be valid JSON format. Examples can be found under the test fold
         value: true | false
         if not supplied: false
 
+      "generateCdfJson" optional
+        tabulator will generate a JSON of cast vote records in the Common Data Format
+        value: true | false
+        if not supplied: false
+
   "cvrFileSources" required
     list of input CVR file paths and their associated parameters
     each "cvrFileSources" list item contains the following parameters:

--- a/src/test/java/com/rcv/TabulatorTests.java
+++ b/src/test/java/com/rcv/TabulatorTests.java
@@ -149,8 +149,8 @@ class TabulatorTests {
   private static void compareJson(
       ContestConfig config, String stem, String timestampString, Integer sequentialNumber) {
     String actualOutputPath =
-        ResultsWriter.getSummaryOutputPath(
-            config.getOutputDirectory(), timestampString, sequentialNumber)
+        ResultsWriter.getOutputFilePath(
+            config.getOutputDirectory(), "summary", timestampString, sequentialNumber)
             + ".json";
     String expectedPath =
         getTestFilePath(


### PR DESCRIPTION
First attempt on #243.

I tested it with a (very small) single-seat contest and a multi-seat contest and they both seemed to work fine. I'm sure we'll need to iterate on some of the details, though. And there are some fields (e.g. the election ID and contest ID) that I'm just using constants for now, but that we should actually be propagating from the input file if it's also using the CDF.

I made some effort to minimize the memory footprint, but there's room to make it more compact if necessary. Right now I imagine it will not scale well at all; even if we can keep the data in CastVoteRecord to a reasonable size, the size of the output JSON (represented as a Map) that we're preparing in memory grows extremely quickly. If we actually want to be able to generate this for an election with many thousands of ballots, I think we'll need to rewrite the JSON output logic to use a streaming solution. Something like this: https://static.javadoc.io/com.google.code.gson/gson/2.6.2/com/google/gson/stream/JsonWriter.html

Anyway, here's what my code generates for the multi-winner redistribution test that's already in our test data: https://jsoneditoronline.org/?id=d6a274e2ae9641b79cbe16d1cc19d81e

I recommend reviewing the three commits one at a time.

Super nit that I noticed: we're not consistent in our code about the casing of initialisms. I'm not even consistent within this single PR. E.g. should it be generateCvrSnapshotID, generateCvrSnapshotId, generateCVRSnapshotID, or g3n3rAt3cVrSnApSh0tId? We should just agree on this and then clean it up in a future PR.