### PR TITLE
fix additional CDF issues

### DIFF
--- a/src/main/java/com/rcv/ResultsWriter.java
+++ b/src/main/java/com/rcv/ResultsWriter.java
@@ -27,8 +27,6 @@ import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
@@ -93,11 +91,6 @@ class ResultsWriter {
     ObjectMapper mapper = new ObjectMapper();
     // set mapper to order keys alphabetically for more legible output
     mapper.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
-    // create a module to contain a serializer for BigDecimal serialization
-    SimpleModule module = new SimpleModule();
-    module.addSerializer(BigDecimal.class, new ToStringSerializer());
-    // attach serializer to mapper
-    mapper.registerModule(module);
 
     // jsonWriter writes those object to disk
     ObjectWriter jsonWriter = mapper.writer(new DefaultPrettyPrinter());

--- a/src/main/java/com/rcv/StreamingCVRReader.java
+++ b/src/main/java/com/rcv/StreamingCVRReader.java
@@ -141,6 +141,10 @@ class StreamingCVRReader {
     return result - 1;
   }
 
+  private static String sanitizeStringForId(String s) {
+    return s.replaceAll("[^a-zA-Z0-9_\\-\\.]", "_");
+  }
+
   // function: handleEmptyCells
   // purpose: Handle empty cells encountered while parsing a CVR.  Unlike empty rows, empty cells
   // do not trigger parsing callbacks so their existence must be inferred and handled when they
@@ -178,7 +182,8 @@ class StreamingCVRReader {
     // handle any empty cells which may appear at the end of this row
     handleEmptyCells(config.getMaxRankingsAllowed() + 1);
     // determine what the new cvr ID will be
-    String computedCastVoteRecordID = String.format("%s(%d)", excelFileName, cvrIndex);
+    String computedCastVoteRecordID =
+        String.format("%s-%d", sanitizeStringForId(excelFileName), cvrIndex);
     // create new cast vote record
     CastVoteRecord newRecord =
         new CastVoteRecord(


### PR DESCRIPTION
Two more things that John Dziurlaj found in our JSON output:
1. BigDecimals should be numbers, not strings. I realized that this actually works properly with the default behavior. @moldover: do you remember why you added the custom logic for BigDecimals in the first place?
2. IDs can only use certain characters.