### PR TITLE
handle duplicate candidates in CVRs properly in CDF output

### DIFF
--- a/src/main/java/com/rcv/CommonDataFormatReader.java
+++ b/src/main/java/com/rcv/CommonDataFormatReader.java
@@ -97,7 +97,7 @@ class CommonDataFormatReader {
     for (Object contestObject : CVRContests) {
       HashMap CVRContest = (HashMap) contestObject;
       // each contest contains contestSelections
-      ArrayList contestSelections = (ArrayList) CVRContest.get("ContestSelection");
+      ArrayList contestSelections = (ArrayList) CVRContest.get("CVRContestSelection");
       for (Object contestSelectionObject : contestSelections) {
         HashMap contestSelection = (HashMap) contestSelectionObject;
         // selectionID is the candidate/contest ID for this selection position
@@ -152,31 +152,6 @@ class CommonDataFormatReader {
 
           // we found the current CVR snapshot so get rankings and create a new cvr
           List<Pair<Integer, String>> rankings = parseRankingsFromSnapshot(snapshot);
-          // at the top level is a list of contests each of which contains selections
-          ArrayList CVRContests = (ArrayList) snapshot.get("CVRContest");
-          for (Object contestObject : CVRContests) {
-            // extract the CVRContest
-            HashMap CVRContest = (HashMap) contestObject;
-            // contest contains contestSelections
-            ArrayList contestSelections = (ArrayList) CVRContest.get("ContestSelection");
-            for (Object contestSelectionObject : contestSelections) {
-              // extract the contestSelection
-              HashMap contestSelection = (HashMap) contestSelectionObject;
-              // selectionID is the candidate/contest ID for this selection position
-              String selectionID = (String) contestSelection.get("ContestSelectionId");
-              // extract all the positions (ranks) which this selection has been assigned
-              ArrayList selectionPositions = (ArrayList) contestSelection.get("SelectionPosition");
-              for (Object selectionPositionObject : selectionPositions) {
-                // extract the position object
-                HashMap selectionPosition = (HashMap) selectionPositionObject;
-                // and finally the rank
-                Integer rank = (Integer) selectionPosition.get("Rank");
-                assert rank != null;
-                // create a new ranking object and save it
-                rankings.add(new Pair<>(rank, selectionID));
-              }
-            }
-          }
 
           // create new cast vote record
           CastVoteRecord newRecord =

--- a/src/main/java/com/rcv/GuiApplication.java
+++ b/src/main/java/com/rcv/GuiApplication.java
@@ -30,7 +30,7 @@ public class GuiApplication extends Application {
   @Override
   public void start(Stage window) throws Exception {
     Parent root = FXMLLoader.load(getClass().getResource("/GuiConfigLayout.fxml"));
-    window.setTitle("RCV Universal Tabulator");
+    window.setTitle("RCVRC Tabulator");
     window.setScene(new Scene(root));
     // cache main window so we can parent file choosers to it
     GuiContext context = GuiContext.getInstance();

--- a/src/main/java/com/rcv/ResultsWriter.java
+++ b/src/main/java/com/rcv/ResultsWriter.java
@@ -37,6 +37,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -141,6 +142,43 @@ class ResultsWriter {
       candidateCodeToCdfId.put(code, id);
     }
     return id;
+  }
+
+  // purpose: Instead of a map from rank to list of candidates, we need a sorted list of candidates
+  // with the ranks they were given. (Ordinarily a candidate will have only a single rank, but they
+  // could have multiple ranks if the ballot duplicates the candidate, i.e. assigns them multiple
+  // ranks.
+  // We sort by the lowest (best) rank, then alphabetically by name.
+  private static List<Map.Entry<String, List<Integer>>> getCandidatesWithRanksList(
+      Map<Integer, Set<String>> rankToCandidateIDs) {
+    Map<String, List<Integer>> candidateIdToRanks = new HashMap<>();
+    // first group the ranks by candidate
+    for (int rank : rankToCandidateIDs.keySet()) {
+      for (String candidateId : rankToCandidateIDs.get(rank)) {
+        candidateIdToRanks.computeIfAbsent(candidateId, k -> new LinkedList<>());
+        candidateIdToRanks.get(candidateId).add(rank);
+      }
+    }
+    // we want the ranks for a given candidate in ascending order
+    for (List<Integer> list : candidateIdToRanks.values()) {
+      Collections.sort(list);
+    }
+    List<Map.Entry<String, List<Integer>>> sortedCandidatesWithRanks =
+        new LinkedList<>(candidateIdToRanks.entrySet());
+    // and now we sort the list of candidates with ranks
+    sortedCandidatesWithRanks.sort(
+        (firstObject, secondObject) -> {
+          int ret;
+          Integer firstRank = firstObject.getValue().get(0);
+          Integer secondRank = secondObject.getValue().get(0);
+          if (!firstRank.equals(secondRank)) {
+            ret = firstRank.compareTo(secondRank);
+          } else {
+            ret = firstObject.getKey().compareTo(secondObject.getKey());
+          }
+          return ret;
+        });
+    return sortedCandidatesWithRanks;
   }
 
   ResultsWriter setRoundToResidualSurplus(Map<Integer, BigDecimal> roundToResidualSurplus) {
@@ -643,38 +681,53 @@ class ResultsWriter {
   private Map<String, Object> generateCvrSnapshotMap(
       CastVoteRecord cvr, Integer round, List<Pair<String, BigDecimal>> currentRoundSnapshotData) {
     List<Map<String, Object>> selectionMapList = new LinkedList<>();
-    for (int rank : cvr.rankToCandidateIDs.keySet()) {
-      for (String candidateCode : cvr.rankToCandidateIDs.get(rank)) {
-        String isAllocable = "unknown";
-        BigDecimal numberVotes = BigDecimal.ONE;
-        if (currentRoundSnapshotData != null) {
-          // scanning the list isn't actually expensive because it will almost always be very short
-          for (Pair<String, BigDecimal> allocation : currentRoundSnapshotData) {
-            if (allocation.getKey().equals(candidateCode)) {
-              isAllocable = "yes";
-              numberVotes = allocation.getValue();
-              break;
-            }
-          }
-          if (isAllocable.equals("unknown")) {
-            isAllocable = "no";
-            // not sure what numberVotes should be in this situation
+    List<Map.Entry<String, List<Integer>>> candidatesWithRanksList =
+        getCandidatesWithRanksList(cvr.rankToCandidateIDs);
+
+    for (Map.Entry<String, List<Integer>> candidateWithRanks : candidatesWithRanksList) {
+      String candidateCode = candidateWithRanks.getKey();
+
+      String isAllocable = "unknown";
+      BigDecimal numberVotes = BigDecimal.ONE;
+
+      if (currentRoundSnapshotData != null) {
+        // scanning the list isn't actually expensive because it will almost always be very short
+        for (Pair<String, BigDecimal> allocation : currentRoundSnapshotData) {
+          if (allocation.getKey().equals(candidateCode)) {
+            isAllocable = "yes";
+            numberVotes = allocation.getValue();
+            break;
           }
         }
-        Map<String, Object> selectionPositionMap =
+        // didn't find an allocation, i.e. this ballot didn't contribute all or part of a vote to
+        // this candidate in this round
+        if (isAllocable.equals("unknown")) {
+          isAllocable = "no";
+          // not sure what numberVotes should be in this situation
+        }
+      }
+
+      List<Map<String, Object>> selectionPositionMaps = new LinkedList<>();
+      for (int rank : candidateWithRanks.getValue()) {
+        selectionPositionMaps.add(
             Map.ofEntries(
                 entry("HasIndication", "yes"),
                 entry("IsAllocable", isAllocable),
                 entry("NumberVotes", numberVotes),
                 entry("Rank", rank),
-                entry("@type", "CVR.SelectionPosition"));
-
-        selectionMapList.add(
-            Map.ofEntries(
-                entry("ContestSelectionId", getCdfIdForCandidateCode(candidateCode)),
-                entry("SelectionPosition", new Map[]{selectionPositionMap}),
-                entry("@type", "CVR.CVRContestSelection")));
+                entry("@type", "CVR.SelectionPosition")));
+        if (isAllocable.equals("yes")) {
+          // If there are duplicate rankings for the candidate on this ballot, only the first one
+          // can be allocable.
+          isAllocable = "no";
+        }
       }
+
+      selectionMapList.add(
+          Map.ofEntries(
+              entry("ContestSelectionId", getCdfIdForCandidateCode(candidateCode)),
+              entry("SelectionPosition", selectionPositionMaps),
+              entry("@type", "CVR.CVRContestSelection")));
     }
 
     Map<String, Object> contestMap =

--- a/src/main/java/com/rcv/ResultsWriter.java
+++ b/src/main/java/com/rcv/ResultsWriter.java
@@ -707,15 +707,26 @@ class ResultsWriter {
         }
       }
 
-      List<Map<String, Object>> selectionPositionMaps = new LinkedList<>();
+      String fractionalVotes = null;
+      if (!numberVotes.equals(BigDecimal.ONE)) {
+        BigDecimal remainder = numberVotes.remainder(BigDecimal.ONE);
+        if (remainder.signum() == 1) {
+          fractionalVotes = remainder.toString().substring(1); // remove the 0 before the decimal
+        }
+      }
+
+      List<Map<String, Object>> selectionPositionMapList = new LinkedList<>();
       for (int rank : candidateWithRanks.getValue()) {
-        selectionPositionMaps.add(
-            Map.ofEntries(
-                entry("HasIndication", "yes"),
-                entry("IsAllocable", isAllocable),
-                entry("NumberVotes", numberVotes),
-                entry("Rank", rank),
-                entry("@type", "CVR.SelectionPosition")));
+        Map<String, Object> selectionPositionMap = new HashMap<>();
+        selectionPositionMap.put("HasIndication", "yes");
+        selectionPositionMap.put("IsAllocable", isAllocable);
+        selectionPositionMap.put("NumberVotes", numberVotes.intValue());
+        selectionPositionMap.put("Rank", rank);
+        selectionPositionMap.put("@type", "CVR.SelectionPosition");
+        if (fractionalVotes != null) {
+          selectionPositionMap.put("FractionalVotes", fractionalVotes);
+        }
+        selectionPositionMapList.add(selectionPositionMap);
         if (isAllocable.equals("yes")) {
           // If there are duplicate rankings for the candidate on this ballot, only the first one
           // can be allocable.
@@ -726,7 +737,7 @@ class ResultsWriter {
       selectionMapList.add(
           Map.ofEntries(
               entry("ContestSelectionId", getCdfIdForCandidateCode(candidateCode)),
-              entry("SelectionPosition", selectionPositionMaps),
+              entry("SelectionPosition", selectionPositionMapList),
               entry("@type", "CVR.CVRContestSelection")));
     }
 

--- a/src/main/java/com/rcv/ResultsWriter.java
+++ b/src/main/java/com/rcv/ResultsWriter.java
@@ -588,7 +588,7 @@ class ResultsWriter {
             Map.ofEntries(
                 entry("@id", CDF_REPORTING_DEVICE_ID),
                 entry("@type", "CVR.ReportingDevice"),
-                entry("Application", "RCV Universal Tabulator"),
+                entry("Application", "RCVRC Tabulator"),
                 entry("Manufacturer", "Bright Spots"))
         });
     outputJson.put("Version", "1.0.0");
@@ -733,7 +733,7 @@ class ResultsWriter {
     Map<String, Object> contestMap =
         Map.ofEntries(
             entry("ContestId", CDF_CONTEST_ID),
-            entry("ContestSelection", selectionMapList),
+            entry("CVRContestSelection", selectionMapList),
             entry("@type", "CVR.CVRContest"));
 
     return Map.ofEntries(

--- a/src/test/resources/test_data/precinct_example/precinct_example_expected_cvr_cdf.json
+++ b/src/test/resources/test_data/precinct_example/precinct_example_expected_cvr_cdf.json
@@ -9,15 +9,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -27,7 +26,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -37,10 +36,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -48,15 +48,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -66,7 +65,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -76,10 +75,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -87,15 +87,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -105,7 +104,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -115,10 +114,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -126,15 +126,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -144,7 +143,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -154,10 +153,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -165,15 +165,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -183,7 +182,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -193,10 +192,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -204,15 +204,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -222,7 +221,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -232,10 +231,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -250,15 +250,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -268,7 +267,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -278,10 +277,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -289,15 +289,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -307,7 +306,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -317,10 +316,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -328,15 +328,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -346,7 +345,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -356,10 +355,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -367,15 +367,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -385,7 +384,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -395,10 +394,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -406,15 +406,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -424,7 +423,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -434,10 +433,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -445,15 +445,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -463,7 +462,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -473,10 +472,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -491,18 +491,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -510,18 +510,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -529,18 +529,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -548,18 +548,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -567,18 +567,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -586,18 +586,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -612,15 +612,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -630,7 +629,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -640,10 +639,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -651,15 +651,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -669,7 +668,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -679,10 +678,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -690,15 +690,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -708,7 +707,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -718,10 +717,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -729,15 +729,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -747,7 +746,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -757,10 +756,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -768,15 +768,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -786,7 +785,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -796,10 +795,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -807,15 +807,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -825,7 +824,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -835,10 +834,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -853,18 +853,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -872,18 +872,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -891,18 +891,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -910,18 +910,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -929,18 +929,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -948,18 +948,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -974,15 +974,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -992,7 +991,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1002,10 +1001,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1013,15 +1013,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1031,7 +1030,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1041,10 +1040,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1052,15 +1052,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1070,7 +1069,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1080,10 +1079,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1091,15 +1091,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1109,7 +1108,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1119,10 +1118,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1130,15 +1130,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1148,7 +1147,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1158,10 +1157,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1169,15 +1169,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1187,7 +1186,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1197,10 +1196,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1215,18 +1215,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1234,18 +1234,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1253,18 +1253,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1272,18 +1272,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1291,18 +1291,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1310,18 +1310,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1336,15 +1336,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1354,7 +1353,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1364,10 +1363,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1375,15 +1375,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1393,7 +1392,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1403,10 +1402,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1414,15 +1414,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1432,7 +1431,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1442,10 +1441,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1453,15 +1453,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1471,7 +1470,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1481,10 +1480,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1492,15 +1492,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1510,7 +1509,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1520,10 +1519,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1531,15 +1531,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1549,7 +1548,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1559,10 +1558,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1577,15 +1577,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1595,10 +1594,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1606,15 +1606,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1624,10 +1623,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1635,15 +1635,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1653,10 +1652,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1664,15 +1664,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1682,10 +1681,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1693,15 +1693,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1711,10 +1710,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1722,15 +1722,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1740,10 +1739,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1758,15 +1758,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1776,7 +1775,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1786,10 +1785,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1797,15 +1797,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1815,7 +1814,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1825,10 +1824,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1836,15 +1836,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1854,7 +1853,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1864,10 +1863,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1875,15 +1875,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1893,7 +1892,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1903,10 +1902,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1914,15 +1914,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1932,7 +1931,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1942,10 +1941,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1953,15 +1953,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1971,7 +1970,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1981,10 +1980,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1999,18 +1999,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-uwi",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -2018,18 +2018,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-uwi",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2037,18 +2037,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-uwi",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2056,18 +2056,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-uwi",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2075,18 +2075,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-uwi",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2094,18 +2094,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-uwi",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -2120,15 +2120,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2138,7 +2137,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2148,10 +2147,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -2159,15 +2159,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2177,7 +2176,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2187,10 +2186,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2198,15 +2198,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2216,7 +2215,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2226,10 +2225,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2237,15 +2237,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2255,7 +2254,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2265,10 +2264,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2276,15 +2276,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2294,7 +2293,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2304,10 +2303,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2315,15 +2315,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2333,7 +2332,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2343,10 +2342,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -2361,15 +2361,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2379,7 +2378,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2389,10 +2388,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -2400,15 +2400,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2418,7 +2417,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2428,10 +2427,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2439,15 +2439,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2457,7 +2456,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2467,10 +2466,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2478,15 +2478,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2496,7 +2495,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2506,10 +2505,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2517,15 +2517,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2535,7 +2534,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2545,10 +2544,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2556,15 +2556,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2574,7 +2573,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2584,10 +2583,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -2602,15 +2602,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2620,7 +2619,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2630,10 +2629,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -2641,15 +2641,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2659,7 +2658,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2669,10 +2668,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2680,15 +2680,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2698,7 +2697,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2708,10 +2707,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2719,15 +2719,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2737,7 +2736,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2747,10 +2746,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2758,15 +2758,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2776,7 +2775,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2786,10 +2785,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2797,15 +2797,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2815,7 +2814,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2825,10 +2824,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -2843,15 +2843,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2861,7 +2860,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2871,10 +2870,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -2882,15 +2882,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2900,7 +2899,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2910,10 +2909,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2921,15 +2921,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2939,7 +2938,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2949,10 +2948,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2960,15 +2960,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2978,7 +2977,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2988,10 +2987,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2999,15 +2999,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -3017,7 +3016,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -3027,10 +3026,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3038,15 +3038,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -3056,7 +3055,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -3066,10 +3065,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -3084,18 +3084,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -3103,18 +3103,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3122,18 +3122,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3141,18 +3141,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3160,18 +3160,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3179,18 +3179,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -3205,15 +3205,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -3223,7 +3222,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -3233,10 +3232,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -3244,15 +3244,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -3262,7 +3261,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -3272,10 +3271,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3283,15 +3283,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -3301,7 +3300,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -3311,10 +3310,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3322,15 +3322,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -3340,7 +3339,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -3350,10 +3349,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3361,15 +3361,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -3379,7 +3378,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -3389,10 +3388,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3400,15 +3400,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -3418,7 +3417,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -3428,10 +3427,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -3446,15 +3446,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -3464,10 +3463,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -3475,15 +3475,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -3493,10 +3492,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3504,15 +3504,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -3522,10 +3521,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3533,15 +3533,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -3551,10 +3550,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3562,15 +3562,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -3580,10 +3579,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3591,15 +3591,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -3609,10 +3608,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -3627,15 +3627,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -3645,7 +3644,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -3655,10 +3654,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -3666,15 +3666,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -3684,7 +3683,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -3694,10 +3693,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3705,15 +3705,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -3723,7 +3722,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -3733,10 +3732,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3744,15 +3744,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -3762,7 +3761,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -3772,10 +3771,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3783,15 +3783,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -3801,7 +3800,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -3811,10 +3810,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3822,15 +3822,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -3840,7 +3839,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -3850,10 +3849,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -3868,15 +3868,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -3886,7 +3885,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -3896,10 +3895,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -3907,15 +3907,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -3925,7 +3924,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -3935,10 +3934,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3946,15 +3946,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -3964,7 +3963,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -3974,10 +3973,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3985,15 +3985,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -4003,7 +4002,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -4013,10 +4012,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -4024,15 +4024,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -4042,7 +4041,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -4052,10 +4051,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -4063,15 +4063,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -4081,7 +4080,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -4091,10 +4090,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -4109,15 +4109,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -4127,7 +4126,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -4137,10 +4136,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -4148,15 +4148,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -4166,7 +4165,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -4176,10 +4175,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -4187,15 +4187,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -4205,7 +4204,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -4215,10 +4214,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -4226,15 +4226,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -4244,7 +4243,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -4254,10 +4253,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -4265,15 +4265,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -4283,7 +4282,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -4293,10 +4292,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -4304,15 +4304,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -4322,7 +4321,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -4332,10 +4331,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -4350,15 +4350,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -4368,7 +4367,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -4378,10 +4377,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -4389,15 +4389,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -4407,7 +4406,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -4417,10 +4416,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -4428,15 +4428,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -4446,7 +4445,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -4456,10 +4455,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -4467,15 +4467,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -4485,7 +4484,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -4495,10 +4494,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -4506,15 +4506,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -4524,7 +4523,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -4534,10 +4533,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -4545,15 +4545,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -4563,7 +4562,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -4573,10 +4572,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -4591,18 +4591,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -4610,18 +4610,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -4629,18 +4629,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -4648,18 +4648,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -4667,18 +4667,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -4686,18 +4686,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -4712,15 +4712,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -4730,7 +4729,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -4740,10 +4739,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -4751,15 +4751,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -4769,7 +4768,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -4779,10 +4778,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -4790,15 +4790,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -4808,7 +4807,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -4818,10 +4817,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -4829,15 +4829,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -4847,7 +4846,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -4857,10 +4856,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -4868,15 +4868,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -4886,7 +4885,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -4896,10 +4895,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -4907,15 +4907,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -4925,7 +4924,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -4935,10 +4934,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -4953,15 +4953,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -4971,7 +4970,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -4981,10 +4980,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -4992,15 +4992,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5010,7 +5009,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -5020,10 +5019,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -5031,15 +5031,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5049,7 +5048,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -5059,10 +5058,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -5070,15 +5070,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5088,7 +5087,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -5098,10 +5097,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -5109,15 +5109,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5127,7 +5126,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -5137,10 +5136,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -5148,15 +5148,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5166,7 +5165,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -5176,10 +5175,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -5194,15 +5194,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5212,10 +5211,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -5223,15 +5223,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5241,10 +5240,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -5252,15 +5252,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5270,10 +5269,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -5281,15 +5281,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5299,10 +5298,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -5310,15 +5310,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5328,10 +5327,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -5339,15 +5339,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5357,10 +5356,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -5375,15 +5375,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5393,7 +5392,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -5403,10 +5402,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -5414,15 +5414,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5432,7 +5431,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -5442,10 +5441,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -5453,15 +5453,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5471,7 +5470,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -5481,10 +5480,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -5492,15 +5492,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5510,7 +5509,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -5520,10 +5519,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -5531,15 +5531,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5549,7 +5548,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -5559,10 +5558,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -5570,15 +5570,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5588,7 +5587,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -5598,10 +5597,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -5616,15 +5616,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5634,7 +5633,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -5644,10 +5643,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -5655,15 +5655,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5673,7 +5672,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -5683,10 +5682,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -5694,15 +5694,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5712,7 +5711,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -5722,10 +5721,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -5733,15 +5733,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5751,7 +5750,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -5761,10 +5760,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -5772,15 +5772,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5790,7 +5789,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -5800,10 +5799,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -5811,15 +5811,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5829,7 +5828,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -5839,10 +5838,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -5857,15 +5857,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-david_rosenfeld",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5875,7 +5874,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -5885,10 +5884,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -5896,15 +5896,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-david_rosenfeld",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5914,7 +5913,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -5924,10 +5923,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -5935,15 +5935,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-david_rosenfeld",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5953,7 +5952,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -5963,10 +5962,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -5974,15 +5974,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-david_rosenfeld",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5992,7 +5991,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -6002,10 +6001,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -6013,15 +6013,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-david_rosenfeld",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6031,7 +6030,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -6041,10 +6040,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -6052,15 +6052,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-david_rosenfeld",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6070,7 +6069,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -6080,10 +6079,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -6098,15 +6098,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6116,10 +6115,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -6127,15 +6127,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6145,10 +6144,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -6156,15 +6156,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6174,10 +6173,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -6185,15 +6185,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6203,10 +6202,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -6214,15 +6214,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6232,10 +6231,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -6243,15 +6243,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6261,10 +6260,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -6279,15 +6279,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6297,7 +6296,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -6307,10 +6306,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -6318,15 +6318,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6336,7 +6335,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -6346,10 +6345,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -6357,15 +6357,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6375,7 +6374,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -6385,10 +6384,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -6396,15 +6396,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6414,7 +6413,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -6424,10 +6423,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -6435,15 +6435,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6453,7 +6452,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -6463,10 +6462,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -6474,15 +6474,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6492,7 +6491,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -6502,10 +6501,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -6520,15 +6520,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6538,10 +6537,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -6549,15 +6549,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6567,10 +6566,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -6578,15 +6578,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6596,10 +6595,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -6607,15 +6607,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6625,10 +6624,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -6636,15 +6636,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6654,10 +6653,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -6665,15 +6665,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6683,10 +6682,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -6701,18 +6701,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -6720,18 +6720,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -6739,18 +6739,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -6758,18 +6758,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -6777,18 +6777,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -6796,18 +6796,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -6822,15 +6822,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6840,10 +6839,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -6851,15 +6851,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6869,10 +6868,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -6880,15 +6880,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6898,10 +6897,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -6909,15 +6909,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6927,10 +6926,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -6938,15 +6938,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6956,10 +6955,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -6967,15 +6967,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6985,10 +6984,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -7003,15 +7003,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7021,7 +7020,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -7031,10 +7030,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -7042,15 +7042,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7060,7 +7059,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -7070,10 +7069,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -7081,15 +7081,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7099,7 +7098,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -7109,10 +7108,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -7120,15 +7120,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7138,7 +7137,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -7148,10 +7147,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -7159,15 +7159,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7177,7 +7176,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -7187,10 +7186,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -7198,15 +7198,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7216,7 +7215,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -7226,10 +7225,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -7244,15 +7244,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7262,10 +7261,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -7273,15 +7273,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7291,10 +7290,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -7302,15 +7302,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7320,10 +7319,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -7331,15 +7331,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7349,10 +7348,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -7360,15 +7360,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7378,10 +7377,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -7389,15 +7389,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7407,10 +7406,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -7425,15 +7425,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7443,10 +7442,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -7454,15 +7454,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7472,10 +7471,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -7483,15 +7483,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7501,10 +7500,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -7512,15 +7512,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7530,10 +7529,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -7541,15 +7541,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7559,10 +7558,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -7570,15 +7570,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7588,10 +7587,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -7606,18 +7606,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -7625,18 +7625,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -7644,18 +7644,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -7663,18 +7663,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -7682,18 +7682,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -7701,18 +7701,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -7727,15 +7727,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7745,7 +7744,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -7755,10 +7754,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -7766,15 +7766,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7784,7 +7783,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -7794,10 +7793,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -7805,15 +7805,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7823,7 +7822,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -7833,10 +7832,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -7844,15 +7844,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7862,7 +7861,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -7872,10 +7871,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -7883,15 +7883,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7901,7 +7900,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -7911,10 +7910,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -7922,15 +7922,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7940,7 +7939,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -7950,10 +7949,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -7968,15 +7968,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7986,7 +7985,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -7996,10 +7995,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -8007,15 +8007,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8025,7 +8024,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8035,10 +8034,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -8046,15 +8046,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8064,7 +8063,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8074,10 +8073,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -8085,15 +8085,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8103,7 +8102,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8113,10 +8112,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -8124,15 +8124,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8142,7 +8141,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8152,10 +8151,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -8163,15 +8163,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8181,7 +8180,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8191,10 +8190,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -8209,18 +8209,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -8228,18 +8228,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -8247,18 +8247,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -8266,18 +8266,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -8285,18 +8285,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -8304,18 +8304,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -8330,15 +8330,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8348,7 +8347,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8358,10 +8357,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -8369,15 +8369,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8387,7 +8386,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8397,10 +8396,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -8408,15 +8408,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8426,7 +8425,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8436,10 +8435,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -8447,15 +8447,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8465,7 +8464,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8475,10 +8474,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -8486,15 +8486,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8504,7 +8503,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8514,10 +8513,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -8525,15 +8525,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8543,7 +8542,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8553,10 +8552,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -8571,15 +8571,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8589,7 +8588,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8599,10 +8598,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -8610,15 +8610,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8628,7 +8627,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8638,10 +8637,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -8649,15 +8649,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8667,7 +8666,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8677,10 +8676,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -8688,15 +8688,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8706,7 +8705,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8716,10 +8715,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -8727,15 +8727,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8745,7 +8744,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8755,10 +8754,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -8766,15 +8766,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8784,7 +8783,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8794,10 +8793,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -8812,15 +8812,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8830,7 +8829,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8840,10 +8839,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -8851,15 +8851,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8869,7 +8868,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8879,10 +8878,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -8890,15 +8890,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8908,7 +8907,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8918,10 +8917,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -8929,15 +8929,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8947,7 +8946,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8957,10 +8956,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -8968,15 +8968,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8986,7 +8985,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8996,10 +8995,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -9007,15 +9007,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9025,7 +9024,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -9035,10 +9034,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -9053,15 +9053,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9071,7 +9070,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -9081,10 +9080,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -9092,15 +9092,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9110,7 +9109,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -9120,10 +9119,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -9131,15 +9131,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9149,7 +9148,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -9159,10 +9158,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -9170,15 +9170,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9188,7 +9187,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -9198,10 +9197,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -9209,15 +9209,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9227,7 +9226,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -9237,10 +9236,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -9248,15 +9248,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9266,7 +9265,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -9276,10 +9275,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -9294,15 +9294,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9312,7 +9311,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -9322,10 +9321,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -9333,15 +9333,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9351,7 +9350,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -9361,10 +9360,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -9372,15 +9372,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9390,7 +9389,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -9400,10 +9399,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -9411,15 +9411,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9429,7 +9428,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -9439,10 +9438,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -9450,15 +9450,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9468,7 +9467,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -9478,10 +9477,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -9489,15 +9489,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9507,7 +9506,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -9517,10 +9516,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -9535,15 +9535,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9553,7 +9552,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -9563,10 +9562,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -9574,15 +9574,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9592,7 +9591,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -9602,10 +9601,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -9613,15 +9613,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9631,7 +9630,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -9641,10 +9640,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -9652,15 +9652,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9670,7 +9669,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -9680,10 +9679,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -9691,15 +9691,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9709,7 +9708,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -9719,10 +9718,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -9730,15 +9730,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9748,7 +9747,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -9758,10 +9757,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -9776,15 +9776,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9794,7 +9793,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -9804,10 +9803,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -9815,15 +9815,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9833,7 +9832,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -9843,10 +9842,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -9854,15 +9854,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9872,7 +9871,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -9882,10 +9881,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -9893,15 +9893,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9911,7 +9910,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -9921,10 +9920,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -9932,15 +9932,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9950,7 +9949,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -9960,10 +9959,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -9971,15 +9971,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9989,7 +9988,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -9999,10 +9998,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -10017,15 +10017,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -10035,7 +10034,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -10045,10 +10044,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -10056,15 +10056,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -10074,7 +10073,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -10084,10 +10083,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -10095,15 +10095,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -10113,7 +10112,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -10123,10 +10122,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -10134,15 +10134,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -10152,7 +10151,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -10162,10 +10161,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -10173,15 +10173,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -10191,7 +10190,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -10201,10 +10200,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -10212,15 +10212,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -10230,7 +10229,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -10240,10 +10239,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -10258,18 +10258,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -10277,18 +10277,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -10296,18 +10296,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -10315,18 +10315,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -10334,18 +10334,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -10353,18 +10353,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -10379,18 +10379,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -10398,18 +10398,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -10417,18 +10417,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -10436,18 +10436,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -10455,18 +10455,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -10474,18 +10474,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -10500,15 +10500,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -10518,7 +10517,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -10528,10 +10527,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -10539,15 +10539,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -10557,7 +10556,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -10567,10 +10566,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -10578,15 +10578,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -10596,7 +10595,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -10606,10 +10605,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -10617,15 +10617,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -10635,7 +10634,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -10645,10 +10644,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -10656,15 +10656,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -10674,7 +10673,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -10684,10 +10683,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -10695,15 +10695,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -10713,7 +10712,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -10723,10 +10722,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -10741,15 +10741,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -10759,10 +10758,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -10770,15 +10770,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -10788,10 +10787,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -10799,15 +10799,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -10817,10 +10816,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -10828,15 +10828,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -10846,10 +10845,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -10857,15 +10857,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -10875,10 +10874,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -10886,15 +10886,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -10904,10 +10903,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -10922,15 +10922,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -10940,7 +10939,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -10950,10 +10949,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -10961,15 +10961,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -10979,7 +10978,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -10989,10 +10988,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -11000,15 +11000,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -11018,7 +11017,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -11028,10 +11027,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -11039,15 +11039,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -11057,7 +11056,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -11067,10 +11066,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -11078,15 +11078,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -11096,7 +11095,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -11106,10 +11105,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -11117,15 +11117,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -11135,7 +11134,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -11145,10 +11144,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -11163,15 +11163,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -11181,7 +11180,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -11191,10 +11190,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -11202,15 +11202,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -11220,7 +11219,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -11230,10 +11229,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -11241,15 +11241,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -11259,7 +11258,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -11269,10 +11268,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -11280,15 +11280,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -11298,7 +11297,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -11308,10 +11307,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -11319,15 +11319,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -11337,7 +11336,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -11347,10 +11346,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -11358,15 +11358,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -11376,7 +11375,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -11386,10 +11385,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -11404,15 +11404,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -11422,7 +11421,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -11432,10 +11431,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -11443,15 +11443,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -11461,7 +11460,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -11471,10 +11470,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -11482,15 +11482,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -11500,7 +11499,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -11510,10 +11509,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -11521,15 +11521,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -11539,7 +11538,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -11549,10 +11548,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -11560,15 +11560,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -11578,7 +11577,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -11588,10 +11587,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -11599,15 +11599,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -11617,7 +11616,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -11627,10 +11626,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -11645,15 +11645,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -11663,7 +11662,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -11673,10 +11672,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -11684,15 +11684,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -11702,7 +11701,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -11712,10 +11711,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -11723,15 +11723,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -11741,7 +11740,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -11751,10 +11750,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -11762,15 +11762,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -11780,7 +11779,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -11790,10 +11789,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -11801,15 +11801,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -11819,7 +11818,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -11829,10 +11828,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -11840,15 +11840,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -11858,7 +11857,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -11868,10 +11867,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -11886,15 +11886,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -11904,7 +11903,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -11914,10 +11913,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -11925,15 +11925,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -11943,7 +11942,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -11953,10 +11952,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -11964,15 +11964,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -11982,7 +11981,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -11992,10 +11991,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -12003,15 +12003,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -12021,7 +12020,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -12031,10 +12030,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -12042,15 +12042,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -12060,7 +12059,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -12070,10 +12069,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -12081,15 +12081,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -12099,7 +12098,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -12109,10 +12108,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -12127,15 +12127,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -12145,10 +12144,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -12156,15 +12156,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -12174,10 +12173,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -12185,15 +12185,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -12203,10 +12202,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -12214,15 +12214,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -12232,10 +12231,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -12243,15 +12243,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -12261,10 +12260,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -12272,15 +12272,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -12290,10 +12289,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -12308,15 +12308,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -12326,7 +12325,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -12336,10 +12335,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -12347,15 +12347,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -12365,7 +12364,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -12375,10 +12374,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -12386,15 +12386,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -12404,7 +12403,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -12414,10 +12413,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -12425,15 +12425,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -12443,7 +12442,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -12453,10 +12452,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -12464,15 +12464,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -12482,7 +12481,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -12492,10 +12491,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -12503,15 +12503,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -12521,7 +12520,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -12531,10 +12530,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -12549,15 +12549,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -12567,7 +12566,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -12577,10 +12576,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -12588,15 +12588,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -12606,7 +12605,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -12616,10 +12615,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -12627,15 +12627,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -12645,7 +12644,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -12655,10 +12654,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -12666,15 +12666,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -12684,7 +12683,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -12694,10 +12693,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -12705,15 +12705,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -12723,7 +12722,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -12733,10 +12732,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -12744,15 +12744,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -12762,7 +12761,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -12772,10 +12771,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -12790,15 +12790,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -12808,10 +12807,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -12819,15 +12819,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -12837,10 +12836,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -12848,15 +12848,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -12866,10 +12865,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -12877,15 +12877,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -12895,10 +12894,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -12906,15 +12906,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -12924,10 +12923,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -12935,15 +12935,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -12953,10 +12952,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -12971,18 +12971,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -12990,18 +12990,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -13009,18 +13009,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -13028,18 +13028,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -13047,18 +13047,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -13066,18 +13066,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -13092,15 +13092,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -13110,7 +13109,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -13120,10 +13119,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -13131,15 +13131,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -13149,7 +13148,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -13159,10 +13158,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -13170,15 +13170,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -13188,7 +13187,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -13198,10 +13197,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -13209,15 +13209,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -13227,7 +13226,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -13237,10 +13236,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -13248,15 +13248,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -13266,7 +13265,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -13276,10 +13275,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -13287,15 +13287,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -13305,7 +13304,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -13315,10 +13314,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -13333,18 +13333,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -13352,18 +13352,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -13371,18 +13371,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -13390,18 +13390,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -13409,18 +13409,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -13428,18 +13428,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -13454,15 +13454,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -13472,7 +13471,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -13482,10 +13481,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -13493,15 +13493,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -13511,7 +13510,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -13521,10 +13520,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -13532,15 +13532,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -13550,7 +13549,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -13560,10 +13559,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -13571,15 +13571,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -13589,7 +13588,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -13599,10 +13598,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -13610,15 +13610,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -13628,7 +13627,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -13638,10 +13637,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -13649,15 +13649,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -13667,7 +13666,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -13677,10 +13676,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -13695,30 +13695,30 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -13726,30 +13726,30 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -13757,30 +13757,30 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -13788,30 +13788,30 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -13819,30 +13819,30 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -13850,30 +13850,30 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -13888,15 +13888,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -13906,7 +13905,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -13916,10 +13915,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -13927,15 +13927,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -13945,7 +13944,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -13955,10 +13954,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -13966,15 +13966,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -13984,7 +13983,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -13994,10 +13993,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -14005,15 +14005,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -14023,7 +14022,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -14033,10 +14032,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -14044,15 +14044,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -14062,7 +14061,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -14072,10 +14071,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -14083,15 +14083,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -14101,7 +14100,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -14111,10 +14110,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -14129,15 +14129,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -14147,7 +14146,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -14157,10 +14156,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -14168,15 +14168,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -14186,7 +14185,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -14196,10 +14195,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -14207,15 +14207,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -14225,7 +14224,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -14235,10 +14234,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -14246,15 +14246,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -14264,7 +14263,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -14274,10 +14273,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -14285,15 +14285,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -14303,7 +14302,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -14313,10 +14312,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -14324,15 +14324,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -14342,7 +14341,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -14352,10 +14351,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -14370,15 +14370,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -14388,7 +14387,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -14398,10 +14397,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -14409,15 +14409,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -14427,7 +14426,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -14437,10 +14436,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -14448,15 +14448,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -14466,7 +14465,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -14476,10 +14475,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -14487,15 +14487,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -14505,7 +14504,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -14515,10 +14514,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -14526,15 +14526,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -14544,7 +14543,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -14554,10 +14553,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -14565,15 +14565,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -14583,7 +14582,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -14593,10 +14592,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -14611,15 +14611,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -14629,7 +14628,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -14639,10 +14638,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -14650,15 +14650,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -14668,7 +14667,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -14678,10 +14677,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -14689,15 +14689,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -14707,7 +14706,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -14717,10 +14716,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -14728,15 +14728,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -14746,7 +14745,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -14756,10 +14755,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -14767,15 +14767,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -14785,7 +14784,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -14795,10 +14794,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -14806,15 +14806,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -14824,7 +14823,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -14834,10 +14833,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -14852,18 +14852,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -14871,18 +14871,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -14890,18 +14890,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -14909,18 +14909,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -14928,18 +14928,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -14947,18 +14947,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -14973,18 +14973,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -14992,18 +14992,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -15011,18 +15011,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -15030,18 +15030,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -15049,18 +15049,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -15068,18 +15068,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -15094,15 +15094,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-captain_jack_sparrow",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -15112,7 +15111,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -15122,10 +15121,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -15133,15 +15133,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-captain_jack_sparrow",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -15151,7 +15150,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -15161,10 +15160,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -15172,15 +15172,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-captain_jack_sparrow",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -15190,7 +15189,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -15200,10 +15199,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -15211,15 +15211,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-captain_jack_sparrow",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -15229,7 +15228,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -15239,10 +15238,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -15250,15 +15250,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-captain_jack_sparrow",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -15268,7 +15267,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -15278,10 +15277,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -15289,15 +15289,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-captain_jack_sparrow",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -15307,7 +15306,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -15317,10 +15316,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -15335,18 +15335,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -15354,18 +15354,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -15373,18 +15373,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -15392,18 +15392,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -15411,18 +15411,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -15430,18 +15430,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -15456,15 +15456,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -15474,7 +15473,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -15484,10 +15483,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -15495,15 +15495,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -15513,7 +15512,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -15523,10 +15522,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -15534,15 +15534,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -15552,7 +15551,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -15562,10 +15561,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -15573,15 +15573,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -15591,7 +15590,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -15601,10 +15600,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -15612,15 +15612,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -15630,7 +15629,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -15640,10 +15639,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -15651,15 +15651,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -15669,7 +15668,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -15679,10 +15678,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -15697,15 +15697,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -15715,7 +15714,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -15725,10 +15724,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -15736,15 +15736,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -15754,7 +15753,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -15764,10 +15763,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -15775,15 +15775,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -15793,7 +15792,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -15803,10 +15802,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -15814,15 +15814,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -15832,7 +15831,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -15842,10 +15841,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -15853,15 +15853,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -15871,7 +15870,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -15881,10 +15880,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -15892,15 +15892,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -15910,7 +15909,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -15920,10 +15919,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -15938,15 +15938,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -15956,7 +15955,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -15966,10 +15965,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -15977,15 +15977,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -15995,7 +15994,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -16005,10 +16004,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -16016,15 +16016,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -16034,7 +16033,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -16044,10 +16043,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -16055,15 +16055,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -16073,7 +16072,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -16083,10 +16082,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -16094,15 +16094,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -16112,7 +16111,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -16122,10 +16121,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -16133,15 +16133,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -16151,7 +16150,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -16161,10 +16160,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -16179,15 +16179,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -16197,7 +16196,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -16207,10 +16206,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -16218,15 +16218,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -16236,7 +16235,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -16246,10 +16245,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -16257,15 +16257,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -16275,7 +16274,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -16285,10 +16284,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -16296,15 +16296,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -16314,7 +16313,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -16324,10 +16323,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -16335,15 +16335,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -16353,7 +16352,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -16363,10 +16362,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -16374,15 +16374,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -16392,7 +16391,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -16402,10 +16401,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -16420,18 +16420,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -16439,18 +16439,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -16458,18 +16458,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -16477,18 +16477,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -16496,18 +16496,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -16515,18 +16515,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -16541,15 +16541,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -16559,7 +16558,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -16569,10 +16568,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -16580,15 +16580,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -16598,7 +16597,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -16608,10 +16607,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -16619,15 +16619,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -16637,7 +16636,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -16647,10 +16646,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -16658,15 +16658,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -16676,7 +16675,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -16686,10 +16685,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -16697,15 +16697,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -16715,7 +16714,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -16725,10 +16724,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -16736,15 +16736,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -16754,7 +16753,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -16764,10 +16763,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -16782,21 +16782,20 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-al_flowers",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -16806,10 +16805,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -16817,21 +16817,20 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-al_flowers",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -16841,10 +16840,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -16852,21 +16852,20 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-al_flowers",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -16876,10 +16875,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -16887,21 +16887,20 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-al_flowers",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -16911,10 +16910,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -16922,21 +16922,20 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-al_flowers",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -16946,10 +16945,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -16957,21 +16957,20 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-al_flowers",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -16981,10 +16980,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -16999,15 +16999,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -17017,7 +17016,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -17027,10 +17026,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -17038,15 +17038,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -17056,7 +17055,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -17066,10 +17065,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -17077,15 +17077,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -17095,7 +17094,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -17105,10 +17104,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -17116,15 +17116,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -17134,7 +17133,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -17144,10 +17143,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -17155,15 +17155,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -17173,7 +17172,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -17183,10 +17182,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -17194,15 +17194,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -17212,7 +17211,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -17222,10 +17221,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -17240,18 +17240,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -17259,18 +17259,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -17278,18 +17278,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -17297,18 +17297,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -17316,18 +17316,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -17335,18 +17335,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -17361,15 +17361,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -17379,7 +17378,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -17389,10 +17388,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -17400,15 +17400,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -17418,7 +17417,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -17428,10 +17427,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -17439,15 +17439,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -17457,7 +17456,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -17467,10 +17466,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -17478,15 +17478,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -17496,7 +17495,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -17506,10 +17505,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -17517,15 +17517,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -17535,7 +17534,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -17545,10 +17544,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -17556,15 +17556,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -17574,7 +17573,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -17584,10 +17583,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -17602,15 +17602,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -17620,7 +17619,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -17630,10 +17629,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -17641,15 +17641,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -17659,7 +17658,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -17669,10 +17668,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -17680,15 +17680,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -17698,7 +17697,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -17708,10 +17707,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -17719,15 +17719,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -17737,7 +17736,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -17747,10 +17746,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -17758,15 +17758,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -17776,7 +17775,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -17786,10 +17785,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -17797,15 +17797,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -17815,7 +17814,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -17825,10 +17824,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -17843,15 +17843,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -17861,10 +17860,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -17872,15 +17872,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -17890,10 +17889,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -17901,15 +17901,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -17919,10 +17918,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -17930,15 +17930,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -17948,10 +17947,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -17959,15 +17959,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -17977,10 +17976,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -17988,15 +17988,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -18006,10 +18005,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -18024,18 +18024,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -18043,18 +18043,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -18062,18 +18062,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -18081,18 +18081,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -18100,18 +18100,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -18119,18 +18119,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -18145,15 +18145,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -18163,10 +18162,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -18174,15 +18174,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -18192,10 +18191,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -18203,15 +18203,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -18221,10 +18220,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -18232,15 +18232,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -18250,10 +18249,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -18261,15 +18261,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -18279,10 +18278,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -18290,15 +18290,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -18308,10 +18307,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -18326,15 +18326,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -18344,7 +18343,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -18354,10 +18353,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -18365,15 +18365,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -18383,7 +18382,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -18393,10 +18392,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -18404,15 +18404,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -18422,7 +18421,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -18432,10 +18431,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -18443,15 +18443,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -18461,7 +18460,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -18471,10 +18470,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -18482,15 +18482,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -18500,7 +18499,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -18510,10 +18509,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -18521,15 +18521,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -18539,7 +18538,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -18549,10 +18548,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -18567,30 +18567,30 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -18598,30 +18598,30 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -18629,30 +18629,30 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -18660,30 +18660,30 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -18691,30 +18691,30 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -18722,30 +18722,30 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -18760,15 +18760,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -18778,7 +18777,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -18788,10 +18787,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -18799,15 +18799,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -18817,7 +18816,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -18827,10 +18826,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -18838,15 +18838,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -18856,7 +18855,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -18866,10 +18865,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -18877,15 +18877,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -18895,7 +18894,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -18905,10 +18904,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -18916,15 +18916,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -18934,7 +18933,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -18944,10 +18943,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -18955,15 +18955,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-tom_hoch",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -18973,7 +18972,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -18983,10 +18982,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -19001,15 +19001,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -19019,10 +19018,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -19030,15 +19030,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -19048,10 +19047,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -19059,15 +19059,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -19077,10 +19076,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -19088,15 +19088,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -19106,10 +19105,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -19117,15 +19117,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -19135,10 +19134,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -19146,15 +19146,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-nekima_levy-pounds",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -19164,10 +19163,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -19182,30 +19182,30 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -19213,30 +19213,30 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -19244,30 +19244,30 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -19275,30 +19275,30 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -19306,30 +19306,30 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -19337,30 +19337,30 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-betsy_hodges",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -19375,15 +19375,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -19393,7 +19392,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -19403,10 +19402,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -19414,15 +19414,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -19432,7 +19431,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -19442,10 +19441,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -19453,15 +19453,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -19471,7 +19470,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -19481,10 +19480,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -19492,15 +19492,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -19510,7 +19509,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -19520,10 +19519,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -19531,15 +19531,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -19549,7 +19548,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -19559,10 +19558,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -19570,15 +19570,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -19588,7 +19587,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -19598,10 +19597,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -19616,18 +19616,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-charlie_gers",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -19635,18 +19635,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-charlie_gers",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -19654,18 +19654,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-charlie_gers",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -19673,18 +19673,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-charlie_gers",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -19692,18 +19692,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-charlie_gers",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -19711,18 +19711,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-charlie_gers",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -19737,8 +19737,8 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ ]
+        "CVRContestSelection" : [ ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -19746,8 +19746,8 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ ]
+        "CVRContestSelection" : [ ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -19755,8 +19755,8 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ ]
+        "CVRContestSelection" : [ ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -19764,8 +19764,8 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ ]
+        "CVRContestSelection" : [ ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -19773,8 +19773,8 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ ]
+        "CVRContestSelection" : [ ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -19782,8 +19782,8 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ ]
+        "CVRContestSelection" : [ ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -19798,15 +19798,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -19816,7 +19815,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -19826,10 +19825,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -19837,15 +19837,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -19855,7 +19854,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -19865,10 +19864,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -19876,15 +19876,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -19894,7 +19893,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -19904,10 +19903,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -19915,15 +19915,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -19933,7 +19932,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -19943,10 +19942,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -19954,15 +19954,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -19972,7 +19971,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -19982,10 +19981,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -19993,15 +19993,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -20011,7 +20010,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -20021,10 +20020,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -20039,15 +20039,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -20057,7 +20056,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -20067,10 +20066,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -20078,15 +20078,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -20096,7 +20095,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -20106,10 +20105,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -20117,15 +20117,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -20135,7 +20134,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -20145,10 +20144,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -20156,15 +20156,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -20174,7 +20173,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -20184,10 +20183,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -20195,15 +20195,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -20213,7 +20212,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -20223,10 +20222,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -20234,15 +20234,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-jacob_frey",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -20252,7 +20251,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -20262,10 +20261,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -20280,15 +20280,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -20298,7 +20297,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -20308,10 +20307,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -20319,15 +20319,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -20337,7 +20336,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -20347,10 +20346,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -20358,15 +20358,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -20376,7 +20375,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -20386,10 +20385,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -20397,15 +20397,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -20415,7 +20414,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -20425,10 +20424,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -20436,15 +20436,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -20454,7 +20453,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -20464,10 +20463,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -20475,15 +20475,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-raymond_dehn",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -20493,7 +20492,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -20503,10 +20502,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -20520,6 +20520,15 @@
       "@id" : "contest-001",
       "@type" : "CVR.CandidateContest",
       "ContestSelection" : [ {
+        "@id" : "cs-al_flowers",
+        "@type" : "CVR.ContestSelection",
+        "Code" : [ {
+          "@type" : "CVR.Code",
+          "OtherType" : "vendor-label",
+          "Type" : "other",
+          "Value" : "Al Flowers"
+        } ]
+      }, {
         "@id" : "cs-aswar_rahman",
         "@type" : "CVR.ContestSelection",
         "Code" : [ {
@@ -20527,60 +20536,6 @@
           "OtherType" : "vendor-label",
           "Type" : "other",
           "Value" : "Aswar Rahman"
-        } ]
-      }, {
-        "@id" : "cs-tom_hoch",
-        "@type" : "CVR.ContestSelection",
-        "Code" : [ {
-          "@type" : "CVR.Code",
-          "OtherType" : "vendor-label",
-          "Type" : "other",
-          "Value" : "Tom Hoch"
-        } ]
-      }, {
-        "@id" : "cs-david_rosenfeld",
-        "@type" : "CVR.ContestSelection",
-        "Code" : [ {
-          "@type" : "CVR.Code",
-          "OtherType" : "vendor-label",
-          "Type" : "other",
-          "Value" : "David Rosenfeld"
-        } ]
-      }, {
-        "@id" : "cs-raymond_dehn",
-        "@type" : "CVR.ContestSelection",
-        "Code" : [ {
-          "@type" : "CVR.Code",
-          "OtherType" : "vendor-label",
-          "Type" : "other",
-          "Value" : "Raymond Dehn"
-        } ]
-      }, {
-        "@id" : "cs-l.a._nik",
-        "@type" : "CVR.ContestSelection",
-        "Code" : [ {
-          "@type" : "CVR.Code",
-          "OtherType" : "vendor-label",
-          "Type" : "other",
-          "Value" : "L.A. Nik"
-        } ]
-      }, {
-        "@id" : "cs-uwi",
-        "@type" : "CVR.ContestSelection",
-        "Code" : [ {
-          "@type" : "CVR.Code",
-          "OtherType" : "vendor-label",
-          "Type" : "other",
-          "Value" : "Undeclared"
-        } ]
-      }, {
-        "@id" : "cs-christopher_zimmerman",
-        "@type" : "CVR.ContestSelection",
-        "Code" : [ {
-          "@type" : "CVR.Code",
-          "OtherType" : "vendor-label",
-          "Type" : "other",
-          "Value" : "Christopher Zimmerman"
         } ]
       }, {
         "@id" : "cs-betsy_hodges",
@@ -20592,31 +20547,13 @@
           "Value" : "Betsy Hodges"
         } ]
       }, {
-        "@id" : "cs-ronald_lischeid",
+        "@id" : "cs-captain_jack_sparrow",
         "@type" : "CVR.ContestSelection",
         "Code" : [ {
           "@type" : "CVR.Code",
           "OtherType" : "vendor-label",
           "Type" : "other",
-          "Value" : "Ronald Lischeid"
-        } ]
-      }, {
-        "@id" : "cs-jacob_frey",
-        "@type" : "CVR.ContestSelection",
-        "Code" : [ {
-          "@type" : "CVR.Code",
-          "OtherType" : "vendor-label",
-          "Type" : "other",
-          "Value" : "Jacob Frey"
-        } ]
-      }, {
-        "@id" : "cs-ian_simpson",
-        "@type" : "CVR.ContestSelection",
-        "Code" : [ {
-          "@type" : "CVR.Code",
-          "OtherType" : "vendor-label",
-          "Type" : "other",
-          "Value" : "Ian Simpson"
+          "Value" : "Captain Jack Sparrow"
         } ]
       }, {
         "@id" : "cs-charlie_gers",
@@ -20628,22 +20565,13 @@
           "Value" : "Charlie Gers"
         } ]
       }, {
-        "@id" : "cs-captain_jack_sparrow",
+        "@id" : "cs-christopher_zimmerman",
         "@type" : "CVR.ContestSelection",
         "Code" : [ {
           "@type" : "CVR.Code",
           "OtherType" : "vendor-label",
           "Type" : "other",
-          "Value" : "Captain Jack Sparrow"
-        } ]
-      }, {
-        "@id" : "cs-theron_preston_washington",
-        "@type" : "CVR.ContestSelection",
-        "Code" : [ {
-          "@type" : "CVR.Code",
-          "OtherType" : "vendor-label",
-          "Type" : "other",
-          "Value" : "Theron Preston Washington"
+          "Value" : "Christopher Zimmerman"
         } ]
       }, {
         "@id" : "cs-david_john_wilson",
@@ -20655,6 +20583,15 @@
           "Value" : "David John Wilson"
         } ]
       }, {
+        "@id" : "cs-david_rosenfeld",
+        "@type" : "CVR.ContestSelection",
+        "Code" : [ {
+          "@type" : "CVR.Code",
+          "OtherType" : "vendor-label",
+          "Type" : "other",
+          "Value" : "David Rosenfeld"
+        } ]
+      }, {
         "@id" : "cs-gregg_a._iverson",
         "@type" : "CVR.ContestSelection",
         "Code" : [ {
@@ -20662,6 +20599,78 @@
           "OtherType" : "vendor-label",
           "Type" : "other",
           "Value" : "Gregg A. Iverson"
+        } ]
+      }, {
+        "@id" : "cs-ian_simpson",
+        "@type" : "CVR.ContestSelection",
+        "Code" : [ {
+          "@type" : "CVR.Code",
+          "OtherType" : "vendor-label",
+          "Type" : "other",
+          "Value" : "Ian Simpson"
+        } ]
+      }, {
+        "@id" : "cs-jacob_frey",
+        "@type" : "CVR.ContestSelection",
+        "Code" : [ {
+          "@type" : "CVR.Code",
+          "OtherType" : "vendor-label",
+          "Type" : "other",
+          "Value" : "Jacob Frey"
+        } ]
+      }, {
+        "@id" : "cs-l.a._nik",
+        "@type" : "CVR.ContestSelection",
+        "Code" : [ {
+          "@type" : "CVR.Code",
+          "OtherType" : "vendor-label",
+          "Type" : "other",
+          "Value" : "L.A. Nik"
+        } ]
+      }, {
+        "@id" : "cs-nekima_levy-pounds",
+        "@type" : "CVR.ContestSelection",
+        "Code" : [ {
+          "@type" : "CVR.Code",
+          "OtherType" : "vendor-label",
+          "Type" : "other",
+          "Value" : "Nekima Levy-Pounds"
+        } ]
+      }, {
+        "@id" : "cs-raymond_dehn",
+        "@type" : "CVR.ContestSelection",
+        "Code" : [ {
+          "@type" : "CVR.Code",
+          "OtherType" : "vendor-label",
+          "Type" : "other",
+          "Value" : "Raymond Dehn"
+        } ]
+      }, {
+        "@id" : "cs-ronald_lischeid",
+        "@type" : "CVR.ContestSelection",
+        "Code" : [ {
+          "@type" : "CVR.Code",
+          "OtherType" : "vendor-label",
+          "Type" : "other",
+          "Value" : "Ronald Lischeid"
+        } ]
+      }, {
+        "@id" : "cs-theron_preston_washington",
+        "@type" : "CVR.ContestSelection",
+        "Code" : [ {
+          "@type" : "CVR.Code",
+          "OtherType" : "vendor-label",
+          "Type" : "other",
+          "Value" : "Theron Preston Washington"
+        } ]
+      }, {
+        "@id" : "cs-tom_hoch",
+        "@type" : "CVR.ContestSelection",
+        "Code" : [ {
+          "@type" : "CVR.Code",
+          "OtherType" : "vendor-label",
+          "Type" : "other",
+          "Value" : "Tom Hoch"
         } ]
       }, {
         "@id" : "cs-troy_benjegerdes",
@@ -20673,28 +20682,19 @@
           "Value" : "Troy Benjegerdes"
         } ]
       }, {
-        "@id" : "cs-al_flowers",
+        "@id" : "cs-uwi",
         "@type" : "CVR.ContestSelection",
         "Code" : [ {
           "@type" : "CVR.Code",
           "OtherType" : "vendor-label",
           "Type" : "other",
-          "Value" : "Al Flowers"
-        } ]
-      }, {
-        "@id" : "cs-nekima_levy-pounds",
-        "@type" : "CVR.ContestSelection",
-        "Code" : [ {
-          "@type" : "CVR.Code",
-          "OtherType" : "vendor-label",
-          "Type" : "other",
-          "Value" : "Nekima Levy-Pounds"
+          "Value" : "Undeclared"
         } ]
       } ]
     } ],
     "ElectionScopeId" : "gpu-election"
   } ],
-  "GeneratedDate" : "2019-04-26T00:21:36-07:00",
+  "GeneratedDate" : "2019-05-01T17:44:26-07:00",
   "GpUnit" : [ {
     "@id" : "gpu-election",
     "@type" : "CVR.GpUnit",
@@ -20996,7 +20996,7 @@
   "ReportingDevice" : [ {
     "@id" : "rd-001",
     "@type" : "CVR.ReportingDevice",
-    "Application" : "RCV Universal Tabulator",
+    "Application" : "RCVRC Tabulator",
     "Manufacturer" : "Bright Spots"
   } ],
   "Version" : "1.0.0"

--- a/src/test/resources/test_data/precinct_example/precinct_example_expected_cvr_cdf.json
+++ b/src/test/resources/test_data/precinct_example/precinct_example_expected_cvr_cdf.json
@@ -13705,21 +13705,13 @@
             "IsAllocable" : "unknown",
             "NumberVotes" : "1",
             "Rank" : 1
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-betsy_hodges",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
             "NumberVotes" : "1",
             "Rank" : 2
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-betsy_hodges",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
@@ -13744,24 +13736,16 @@
             "IsAllocable" : "yes",
             "NumberVotes" : "1",
             "Rank" : 1
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-betsy_hodges",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
-            "IsAllocable" : "yes",
+            "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 2
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-betsy_hodges",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
-            "IsAllocable" : "yes",
+            "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 3
           } ]
@@ -13783,24 +13767,16 @@
             "IsAllocable" : "yes",
             "NumberVotes" : "1",
             "Rank" : 1
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-betsy_hodges",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
-            "IsAllocable" : "yes",
+            "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 2
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-betsy_hodges",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
-            "IsAllocable" : "yes",
+            "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 3
           } ]
@@ -13822,24 +13798,16 @@
             "IsAllocable" : "yes",
             "NumberVotes" : "1",
             "Rank" : 1
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-betsy_hodges",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
-            "IsAllocable" : "yes",
+            "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 2
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-betsy_hodges",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
-            "IsAllocable" : "yes",
+            "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 3
           } ]
@@ -13861,24 +13829,16 @@
             "IsAllocable" : "yes",
             "NumberVotes" : "1",
             "Rank" : 1
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-betsy_hodges",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
-            "IsAllocable" : "yes",
+            "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 2
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-betsy_hodges",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
-            "IsAllocable" : "yes",
+            "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 3
           } ]
@@ -13900,24 +13860,16 @@
             "IsAllocable" : "yes",
             "NumberVotes" : "1",
             "Rank" : 1
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-betsy_hodges",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
-            "IsAllocable" : "yes",
+            "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 2
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-betsy_hodges",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
-            "IsAllocable" : "yes",
+            "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 3
           } ]
@@ -16840,11 +16792,7 @@
             "IsAllocable" : "unknown",
             "NumberVotes" : "1",
             "Rank" : 1
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-al_flowers",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
@@ -16879,14 +16827,10 @@
             "IsAllocable" : "yes",
             "NumberVotes" : "1",
             "Rank" : 1
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-al_flowers",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
-            "IsAllocable" : "yes",
+            "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 2
           } ]
@@ -16918,14 +16862,10 @@
             "IsAllocable" : "yes",
             "NumberVotes" : "1",
             "Rank" : 1
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-al_flowers",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
-            "IsAllocable" : "yes",
+            "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 2
           } ]
@@ -16957,11 +16897,7 @@
             "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 1
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-al_flowers",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
@@ -16996,11 +16932,7 @@
             "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 1
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-al_flowers",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
@@ -17035,11 +16967,7 @@
             "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 1
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-al_flowers",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
@@ -18649,21 +18577,13 @@
             "IsAllocable" : "unknown",
             "NumberVotes" : "1",
             "Rank" : 1
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-jacob_frey",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
             "NumberVotes" : "1",
             "Rank" : 2
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-jacob_frey",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
@@ -18688,24 +18608,16 @@
             "IsAllocable" : "yes",
             "NumberVotes" : "1",
             "Rank" : 1
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-jacob_frey",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
-            "IsAllocable" : "yes",
+            "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 2
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-jacob_frey",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
-            "IsAllocable" : "yes",
+            "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 3
           } ]
@@ -18727,24 +18639,16 @@
             "IsAllocable" : "yes",
             "NumberVotes" : "1",
             "Rank" : 1
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-jacob_frey",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
-            "IsAllocable" : "yes",
+            "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 2
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-jacob_frey",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
-            "IsAllocable" : "yes",
+            "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 3
           } ]
@@ -18766,24 +18670,16 @@
             "IsAllocable" : "yes",
             "NumberVotes" : "1",
             "Rank" : 1
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-jacob_frey",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
-            "IsAllocable" : "yes",
+            "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 2
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-jacob_frey",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
-            "IsAllocable" : "yes",
+            "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 3
           } ]
@@ -18805,24 +18701,16 @@
             "IsAllocable" : "yes",
             "NumberVotes" : "1",
             "Rank" : 1
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-jacob_frey",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
-            "IsAllocable" : "yes",
+            "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 2
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-jacob_frey",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
-            "IsAllocable" : "yes",
+            "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 3
           } ]
@@ -18844,24 +18732,16 @@
             "IsAllocable" : "yes",
             "NumberVotes" : "1",
             "Rank" : 1
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-jacob_frey",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
-            "IsAllocable" : "yes",
+            "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 2
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-jacob_frey",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
-            "IsAllocable" : "yes",
+            "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 3
           } ]
@@ -19312,21 +19192,13 @@
             "IsAllocable" : "unknown",
             "NumberVotes" : "1",
             "Rank" : 1
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-betsy_hodges",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
             "NumberVotes" : "1",
             "Rank" : 2
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-betsy_hodges",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
@@ -19351,24 +19223,16 @@
             "IsAllocable" : "yes",
             "NumberVotes" : "1",
             "Rank" : 1
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-betsy_hodges",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
-            "IsAllocable" : "yes",
+            "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 2
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-betsy_hodges",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
-            "IsAllocable" : "yes",
+            "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 3
           } ]
@@ -19390,24 +19254,16 @@
             "IsAllocable" : "yes",
             "NumberVotes" : "1",
             "Rank" : 1
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-betsy_hodges",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
-            "IsAllocable" : "yes",
+            "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 2
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-betsy_hodges",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
-            "IsAllocable" : "yes",
+            "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 3
           } ]
@@ -19429,24 +19285,16 @@
             "IsAllocable" : "yes",
             "NumberVotes" : "1",
             "Rank" : 1
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-betsy_hodges",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
-            "IsAllocable" : "yes",
+            "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 2
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-betsy_hodges",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
-            "IsAllocable" : "yes",
+            "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 3
           } ]
@@ -19468,24 +19316,16 @@
             "IsAllocable" : "yes",
             "NumberVotes" : "1",
             "Rank" : 1
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-betsy_hodges",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
-            "IsAllocable" : "yes",
+            "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 2
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-betsy_hodges",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
-            "IsAllocable" : "yes",
+            "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 3
           } ]
@@ -19507,24 +19347,16 @@
             "IsAllocable" : "yes",
             "NumberVotes" : "1",
             "Rank" : 1
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-betsy_hodges",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
-            "IsAllocable" : "yes",
+            "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 2
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-betsy_hodges",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
-            "IsAllocable" : "yes",
+            "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 3
           } ]
@@ -20862,7 +20694,7 @@
     } ],
     "ElectionScopeId" : "gpu-election"
   } ],
-  "GeneratedDate" : "2019-04-24T22:58:13-07:00",
+  "GeneratedDate" : "2019-04-26T00:21:36-07:00",
   "GpUnit" : [ {
     "@id" : "gpu-election",
     "@type" : "CVR.GpUnit",

--- a/src/test/resources/test_data/test_set_0_skipped_first_choice/test_set_0_skipped_first_choice_cvr.json
+++ b/src/test/resources/test_data/test_set_0_skipped_first_choice/test_set_0_skipped_first_choice_cvr.json
@@ -8,15 +8,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -26,7 +25,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -36,7 +35,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -46,10 +45,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -63,15 +63,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -81,7 +80,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -91,7 +90,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -101,10 +100,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -118,15 +118,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -136,7 +135,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -146,7 +145,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -156,10 +155,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -173,15 +173,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -191,7 +190,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -201,7 +200,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -211,10 +210,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -228,15 +228,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -246,7 +245,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -256,7 +255,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -266,10 +265,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -283,15 +283,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -301,7 +300,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -311,10 +310,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -328,15 +328,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -346,7 +345,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -356,7 +355,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -366,10 +365,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -383,15 +383,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -401,7 +400,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -411,7 +410,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -421,10 +420,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -438,15 +438,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -456,7 +455,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -466,7 +465,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -476,10 +475,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -493,15 +493,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -511,7 +510,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -521,7 +520,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -531,10 +530,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -548,15 +548,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -566,7 +565,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -576,7 +575,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -586,10 +585,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -603,15 +603,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -621,7 +620,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -631,16 +630,17 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -693,7 +693,7 @@
     } ],
     "ElectionScopeId" : "gpu-election"
   } ],
-  "GeneratedDate" : "2019-04-25T23:28:48-07:00",
+  "GeneratedDate" : "2019-05-01T16:36:42-07:00",
   "GpUnit" : [ {
     "@id" : "gpu-election",
     "@type" : "CVR.GpUnit",
@@ -705,7 +705,7 @@
   "ReportingDevice" : [ {
     "@id" : "rd-001",
     "@type" : "CVR.ReportingDevice",
-    "Application" : "RCV Universal Tabulator",
+    "Application" : "RCVRC Tabulator",
     "Manufacturer" : "Bright Spots"
   } ],
   "Version" : "1.0.0"

--- a/src/test/resources/test_data/test_set_0_skipped_first_choice/test_set_0_skipped_first_choice_cvr.json
+++ b/src/test/resources/test_data/test_set_0_skipped_first_choice/test_set_0_skipped_first_choice_cvr.json
@@ -633,11 +633,7 @@
             "IsAllocable" : "unknown",
             "NumberVotes" : "1",
             "Rank" : 3
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-c",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
@@ -649,21 +645,6 @@
       "Type" : "original"
     } ],
     "CurrentSnapshotId" : "ballot-12",
-    "ElectionId" : "election-001"
-  }, {
-    "@type" : "CVR.CVR",
-    "BallotPrePrintedId" : "test_set_0_skipped_first_choice_cvr.xlsx-13",
-    "CVRSnapshot" : [ {
-      "@id" : "ballot-test_set_0_skipped_first_choice_cvr.xlsx-13",
-      "@type" : "CVR.CVRSnapshot",
-      "CVRContest" : [ {
-        "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ ]
-      } ],
-      "Type" : "original"
-    } ],
-    "CurrentSnapshotId" : "ballot-test_set_0_skipped_first_choice_cvr.xlsx-13",
     "ElectionId" : "election-001"
   } ],
   "Election" : [ {
@@ -712,7 +693,7 @@
     } ],
     "ElectionScopeId" : "gpu-election"
   } ],
-  "GeneratedDate" : "2019-04-22T21:55:39-07:00",
+  "GeneratedDate" : "2019-04-25T23:28:48-07:00",
   "GpUnit" : [ {
     "@id" : "gpu-election",
     "@type" : "CVR.GpUnit",

--- a/src/test/resources/test_data/test_set_0_skipped_first_choice/test_set_0_skipped_first_choice_expected_cvr_cdf.json
+++ b/src/test/resources/test_data/test_set_0_skipped_first_choice/test_set_0_skipped_first_choice_expected_cvr_cdf.json
@@ -8,15 +8,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -26,7 +25,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -36,7 +35,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -46,10 +45,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -57,15 +57,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -75,7 +74,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -85,7 +84,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -95,10 +94,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -106,15 +106,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -124,7 +123,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -134,7 +133,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -144,10 +143,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -155,15 +155,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -173,7 +172,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -183,7 +182,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -193,10 +192,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -210,15 +210,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -228,7 +227,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -238,7 +237,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -248,10 +247,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -259,15 +259,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -277,7 +276,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -287,7 +286,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -297,10 +296,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -308,15 +308,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -326,7 +325,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -336,7 +335,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -346,10 +345,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -357,15 +357,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -375,7 +374,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -385,7 +384,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -395,10 +394,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -412,15 +412,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -430,7 +429,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -440,7 +439,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -450,10 +449,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -461,15 +461,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -479,7 +478,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -489,7 +488,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -499,10 +498,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -510,15 +510,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -528,7 +527,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -538,7 +537,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -548,10 +547,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -559,15 +559,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -577,7 +576,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -587,7 +586,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -597,10 +596,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -614,15 +614,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -632,7 +631,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -642,7 +641,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -652,10 +651,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -663,15 +663,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -681,7 +680,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -691,7 +690,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -701,10 +700,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -712,15 +712,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -730,7 +729,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -740,7 +739,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -750,10 +749,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -761,15 +761,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -779,7 +778,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -789,7 +788,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -799,10 +798,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -816,15 +816,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -834,7 +833,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -844,7 +843,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -854,10 +853,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -865,15 +865,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -883,7 +882,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -893,7 +892,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -903,10 +902,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -914,15 +914,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -932,7 +931,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -942,7 +941,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -952,10 +951,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -963,15 +963,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -981,7 +980,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -991,7 +990,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1001,10 +1000,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1018,15 +1018,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1036,7 +1035,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1046,10 +1045,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1057,15 +1057,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1075,7 +1074,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1085,10 +1084,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1096,15 +1096,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1114,7 +1113,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1124,10 +1123,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1135,15 +1135,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1153,7 +1152,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1163,10 +1162,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1180,15 +1180,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1198,7 +1197,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1208,7 +1207,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1218,10 +1217,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1229,15 +1229,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1247,7 +1246,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1257,7 +1256,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1267,10 +1266,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1278,15 +1278,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1296,7 +1295,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1306,7 +1305,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1316,10 +1315,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1327,15 +1327,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1345,7 +1344,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1355,7 +1354,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1365,10 +1364,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1382,15 +1382,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1400,7 +1399,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1410,7 +1409,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1420,10 +1419,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1431,15 +1431,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1449,7 +1448,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1459,7 +1458,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1469,10 +1468,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1480,15 +1480,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1498,7 +1497,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1508,7 +1507,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1518,10 +1517,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1529,15 +1529,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1547,7 +1546,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1557,7 +1556,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1567,10 +1566,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1584,15 +1584,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1602,7 +1601,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1612,7 +1611,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1622,10 +1621,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1633,15 +1633,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1651,7 +1650,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1661,7 +1660,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1671,10 +1670,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1682,15 +1682,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1700,7 +1699,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1710,7 +1709,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1720,10 +1719,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1731,15 +1731,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1749,7 +1748,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1759,7 +1758,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1769,10 +1768,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1786,15 +1786,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1804,7 +1803,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1814,7 +1813,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1824,10 +1823,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1835,15 +1835,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1853,7 +1852,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1863,7 +1862,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1873,10 +1872,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1884,15 +1884,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1902,7 +1901,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1912,7 +1911,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1922,10 +1921,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1933,15 +1933,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1951,7 +1950,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1961,7 +1960,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1971,10 +1970,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1988,15 +1988,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2006,7 +2005,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2016,7 +2015,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2026,10 +2025,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -2037,15 +2037,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2055,7 +2054,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2065,7 +2064,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2075,10 +2074,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2086,15 +2086,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2104,7 +2103,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2114,7 +2113,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2124,10 +2123,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2135,15 +2135,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2153,7 +2152,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2163,7 +2162,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2173,10 +2172,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -2190,15 +2190,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2208,7 +2207,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2218,16 +2217,17 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -2235,15 +2235,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2253,7 +2252,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2263,16 +2262,17 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2280,15 +2280,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2298,7 +2297,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2308,16 +2307,17 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2325,15 +2325,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2343,7 +2342,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2353,16 +2352,17 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -2376,24 +2376,6 @@
       "@id" : "contest-001",
       "@type" : "CVR.CandidateContest",
       "ContestSelection" : [ {
-        "@id" : "cs-c",
-        "@type" : "CVR.ContestSelection",
-        "Code" : [ {
-          "@type" : "CVR.Code",
-          "OtherType" : "vendor-label",
-          "Type" : "other",
-          "Value" : "C"
-        } ]
-      }, {
-        "@id" : "cs-d",
-        "@type" : "CVR.ContestSelection",
-        "Code" : [ {
-          "@type" : "CVR.Code",
-          "OtherType" : "vendor-label",
-          "Type" : "other",
-          "Value" : "D"
-        } ]
-      }, {
         "@id" : "cs-a",
         "@type" : "CVR.ContestSelection",
         "Code" : [ {
@@ -2411,11 +2393,29 @@
           "Type" : "other",
           "Value" : "B"
         } ]
+      }, {
+        "@id" : "cs-c",
+        "@type" : "CVR.ContestSelection",
+        "Code" : [ {
+          "@type" : "CVR.Code",
+          "OtherType" : "vendor-label",
+          "Type" : "other",
+          "Value" : "C"
+        } ]
+      }, {
+        "@id" : "cs-d",
+        "@type" : "CVR.ContestSelection",
+        "Code" : [ {
+          "@type" : "CVR.Code",
+          "OtherType" : "vendor-label",
+          "Type" : "other",
+          "Value" : "D"
+        } ]
       } ]
     } ],
     "ElectionScopeId" : "gpu-election"
   } ],
-  "GeneratedDate" : "2019-04-25T23:40:07-07:00",
+  "GeneratedDate" : "2019-05-01T17:40:53-07:00",
   "GpUnit" : [ {
     "@id" : "gpu-election",
     "@type" : "CVR.GpUnit",
@@ -2427,7 +2427,7 @@
   "ReportingDevice" : [ {
     "@id" : "rd-001",
     "@type" : "CVR.ReportingDevice",
-    "Application" : "RCV Universal Tabulator",
+    "Application" : "RCVRC Tabulator",
     "Manufacturer" : "Bright Spots"
   } ],
   "Version" : "1.0.0"

--- a/src/test/resources/test_data/test_set_0_skipped_first_choice/test_set_0_skipped_first_choice_expected_cvr_cdf.json
+++ b/src/test/resources/test_data/test_set_0_skipped_first_choice/test_set_0_skipped_first_choice_expected_cvr_cdf.json
@@ -1597,7 +1597,7 @@
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-d",
+          "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
@@ -1607,7 +1607,7 @@
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-a",
+          "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
@@ -1646,7 +1646,7 @@
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-d",
+          "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
@@ -1656,7 +1656,7 @@
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-a",
+          "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
@@ -1695,7 +1695,7 @@
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-d",
+          "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
@@ -1705,7 +1705,7 @@
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-a",
+          "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
@@ -1744,7 +1744,7 @@
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-d",
+          "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
@@ -1754,7 +1754,7 @@
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-a",
+          "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
@@ -2220,11 +2220,7 @@
             "IsAllocable" : "unknown",
             "NumberVotes" : "1",
             "Rank" : 3
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-c",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
@@ -2269,11 +2265,7 @@
             "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 3
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-c",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
@@ -2318,11 +2310,7 @@
             "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 3
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-c",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
@@ -2367,11 +2355,7 @@
             "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 3
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-c",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
@@ -2383,48 +2367,6 @@
       "Type" : "interpreted"
     } ],
     "CurrentSnapshotId" : "ballot-12-round-3",
-    "ElectionId" : "election-001"
-  }, {
-    "@type" : "CVR.CVR",
-    "BallotPrePrintedId" : "test_set_0_skipped_first_choice_cvr.xlsx-13",
-    "CVRSnapshot" : [ {
-      "@id" : "ballot-test_set_0_skipped_first_choice_cvr.xlsx-13",
-      "@type" : "CVR.CVRSnapshot",
-      "CVRContest" : [ {
-        "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ ]
-      } ],
-      "Type" : "original"
-    }, {
-      "@id" : "ballot-test_set_0_skipped_first_choice_cvr.xlsx-13-round-1",
-      "@type" : "CVR.CVRSnapshot",
-      "CVRContest" : [ {
-        "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ ]
-      } ],
-      "Type" : "interpreted"
-    }, {
-      "@id" : "ballot-test_set_0_skipped_first_choice_cvr.xlsx-13-round-2",
-      "@type" : "CVR.CVRSnapshot",
-      "CVRContest" : [ {
-        "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ ]
-      } ],
-      "Type" : "interpreted"
-    }, {
-      "@id" : "ballot-test_set_0_skipped_first_choice_cvr.xlsx-13-round-3",
-      "@type" : "CVR.CVRSnapshot",
-      "CVRContest" : [ {
-        "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ ]
-      } ],
-      "Type" : "interpreted"
-    } ],
-    "CurrentSnapshotId" : "ballot-test_set_0_skipped_first_choice_cvr.xlsx-13-round-3",
     "ElectionId" : "election-001"
   } ],
   "Election" : [ {
@@ -2473,7 +2415,7 @@
     } ],
     "ElectionScopeId" : "gpu-election"
   } ],
-  "GeneratedDate" : "2019-04-22T22:25:50-07:00",
+  "GeneratedDate" : "2019-04-25T23:40:07-07:00",
   "GpUnit" : [ {
     "@id" : "gpu-election",
     "@type" : "CVR.GpUnit",

--- a/src/test/resources/test_data/test_set_1_exhaust_at_overvote/test_set_1_exhaust_at_overvote_cvr.json
+++ b/src/test/resources/test_data/test_set_1_exhaust_at_overvote/test_set_1_exhaust_at_overvote_cvr.json
@@ -8,15 +8,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -26,7 +25,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -36,7 +35,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -46,10 +45,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -63,15 +63,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -81,7 +80,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -91,7 +90,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -101,10 +100,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -118,15 +118,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -136,7 +135,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -146,7 +145,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -156,10 +155,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -173,15 +173,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -191,7 +190,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -201,7 +200,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -211,10 +210,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -228,15 +228,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -246,7 +245,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -256,7 +255,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -266,10 +265,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -283,15 +283,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -301,7 +300,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -311,7 +310,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -321,10 +320,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -338,15 +338,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -356,7 +355,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -366,7 +365,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -376,10 +375,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -393,15 +393,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -411,7 +410,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -421,7 +420,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -431,10 +430,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -448,15 +448,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -466,7 +465,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -476,7 +475,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -486,10 +485,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -503,15 +503,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -521,7 +520,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -531,7 +530,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -541,10 +540,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -558,15 +558,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -576,7 +575,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -586,7 +585,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -596,10 +595,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -613,15 +613,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -631,7 +630,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -641,7 +640,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -651,10 +650,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -668,15 +668,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -686,10 +685,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -703,15 +703,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -721,7 +720,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -731,10 +730,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -748,15 +748,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -766,7 +765,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -776,7 +775,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -786,10 +785,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -842,7 +842,7 @@
     } ],
     "ElectionScopeId" : "gpu-election"
   } ],
-  "GeneratedDate" : "2019-04-24T22:04:08-07:00",
+  "GeneratedDate" : "2019-05-01T16:50:33-07:00",
   "GpUnit" : [ {
     "@id" : "gpu-election",
     "@type" : "CVR.GpUnit",
@@ -854,7 +854,7 @@
   "ReportingDevice" : [ {
     "@id" : "rd-001",
     "@type" : "CVR.ReportingDevice",
-    "Application" : "RCV Universal Tabulator",
+    "Application" : "RCVRC Tabulator",
     "Manufacturer" : "Bright Spots"
   } ],
   "Version" : "1.0.0"

--- a/src/test/resources/test_data/test_set_1_exhaust_at_overvote/test_set_1_exhaust_at_overvote_expected_cvr_cdf.json
+++ b/src/test/resources/test_data/test_set_1_exhaust_at_overvote/test_set_1_exhaust_at_overvote_expected_cvr_cdf.json
@@ -1435,7 +1435,7 @@
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-d",
+          "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
@@ -1445,7 +1445,7 @@
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-b",
+          "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
@@ -1484,7 +1484,7 @@
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-d",
+          "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
@@ -1494,7 +1494,7 @@
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-b",
+          "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
@@ -1533,7 +1533,7 @@
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-d",
+          "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
@@ -1543,7 +1543,7 @@
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-b",
+          "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
@@ -1582,7 +1582,7 @@
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-d",
+          "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
@@ -1592,7 +1592,7 @@
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-b",
+          "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
@@ -2957,7 +2957,7 @@
     } ],
     "ElectionScopeId" : "gpu-election"
   } ],
-  "GeneratedDate" : "2019-04-24T22:07:43-07:00",
+  "GeneratedDate" : "2019-04-26T00:18:59-07:00",
   "GpUnit" : [ {
     "@id" : "gpu-election",
     "@type" : "CVR.GpUnit",

--- a/src/test/resources/test_data/test_set_1_exhaust_at_overvote/test_set_1_exhaust_at_overvote_expected_cvr_cdf.json
+++ b/src/test/resources/test_data/test_set_1_exhaust_at_overvote/test_set_1_exhaust_at_overvote_expected_cvr_cdf.json
@@ -8,15 +8,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -26,7 +25,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -36,7 +35,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -46,10 +45,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -57,15 +57,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -75,7 +74,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -85,7 +84,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -95,10 +94,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -106,15 +106,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -124,7 +123,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -134,7 +133,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -144,10 +143,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -155,15 +155,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -173,7 +172,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -183,7 +182,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -193,10 +192,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -210,15 +210,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -228,7 +227,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -238,7 +237,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -248,10 +247,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -259,15 +259,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -277,7 +276,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -287,7 +286,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -297,10 +296,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -308,15 +308,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -326,7 +325,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -336,7 +335,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -346,10 +345,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -357,15 +357,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -375,7 +374,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -385,7 +384,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -395,10 +394,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -412,15 +412,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -430,7 +429,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -440,7 +439,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -450,10 +449,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -461,15 +461,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -479,7 +478,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -489,7 +488,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -499,10 +498,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -510,15 +510,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -528,7 +527,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -538,7 +537,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -548,10 +547,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -559,15 +559,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -577,7 +576,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -587,7 +586,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -597,10 +596,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -614,15 +614,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -632,7 +631,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -642,7 +641,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -652,10 +651,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -663,15 +663,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -681,7 +680,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -691,7 +690,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -701,10 +700,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -712,15 +712,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -730,7 +729,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -740,7 +739,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -750,10 +749,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -761,15 +761,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -779,7 +778,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -789,7 +788,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -799,10 +798,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -816,15 +816,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -834,7 +833,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -844,7 +843,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -854,10 +853,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -865,15 +865,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -883,7 +882,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -893,7 +892,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -903,10 +902,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -914,15 +914,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -932,7 +931,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -942,7 +941,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -952,10 +951,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -963,15 +963,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -981,7 +980,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -991,7 +990,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1001,10 +1000,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1018,15 +1018,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1036,7 +1035,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1046,7 +1045,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1056,10 +1055,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1067,15 +1067,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1085,7 +1084,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1095,7 +1094,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1105,10 +1104,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1116,15 +1116,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1134,7 +1133,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1144,7 +1143,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1154,10 +1153,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1165,15 +1165,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1183,7 +1182,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1193,7 +1192,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1203,10 +1202,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1220,15 +1220,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1238,7 +1237,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1248,7 +1247,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1258,10 +1257,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1269,15 +1269,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1287,7 +1286,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1297,7 +1296,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1307,10 +1306,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1318,15 +1318,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1336,7 +1335,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1346,7 +1345,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1356,10 +1355,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1367,15 +1367,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1385,7 +1384,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1395,7 +1394,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1405,10 +1404,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1422,15 +1422,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1440,7 +1439,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1450,7 +1449,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1460,10 +1459,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1471,15 +1471,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1489,7 +1488,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1499,7 +1498,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1509,10 +1508,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1520,15 +1520,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1538,7 +1537,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1548,7 +1547,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1558,10 +1557,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1569,15 +1569,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1587,7 +1586,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1597,7 +1596,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1607,10 +1606,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1624,15 +1624,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1642,7 +1641,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1652,7 +1651,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1662,10 +1661,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1673,15 +1673,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1691,7 +1690,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1701,7 +1700,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1711,10 +1710,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1722,15 +1722,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1740,7 +1739,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1750,7 +1749,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1760,10 +1759,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1771,15 +1771,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1789,7 +1788,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1799,7 +1798,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1809,10 +1808,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1826,15 +1826,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1844,7 +1843,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1854,7 +1853,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1864,10 +1863,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1875,15 +1875,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1893,7 +1892,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1903,7 +1902,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1913,10 +1912,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1924,15 +1924,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1942,7 +1941,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1952,7 +1951,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1962,10 +1961,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1973,15 +1973,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1991,7 +1990,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2001,7 +2000,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2011,10 +2010,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -2028,15 +2028,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2046,7 +2045,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2056,7 +2055,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2066,10 +2065,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -2077,15 +2077,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2095,7 +2094,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2105,7 +2104,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2115,10 +2114,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2126,15 +2126,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2144,7 +2143,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2154,7 +2153,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2164,10 +2163,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2175,15 +2175,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2193,7 +2192,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2203,7 +2202,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2213,10 +2212,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -2230,15 +2230,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2248,7 +2247,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2258,7 +2257,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2268,10 +2267,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -2279,15 +2279,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2297,7 +2296,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2307,7 +2306,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2317,10 +2316,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2328,15 +2328,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2346,7 +2345,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2356,7 +2355,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2366,10 +2365,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2377,15 +2377,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2395,7 +2394,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2405,7 +2404,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2415,10 +2414,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -2432,15 +2432,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2450,10 +2449,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -2461,15 +2461,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2479,10 +2478,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2490,15 +2490,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2508,10 +2507,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2519,15 +2519,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2537,10 +2536,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -2554,15 +2554,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2572,7 +2571,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2582,10 +2581,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -2593,15 +2593,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2611,7 +2610,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2621,10 +2620,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2632,15 +2632,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2650,7 +2649,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2660,10 +2659,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2671,15 +2671,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2689,7 +2688,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2699,10 +2698,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -2716,15 +2716,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2734,7 +2733,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2744,7 +2743,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2754,10 +2753,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -2765,15 +2765,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2783,7 +2782,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2793,7 +2792,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2803,10 +2802,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2814,15 +2814,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2832,7 +2831,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2842,7 +2841,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2852,10 +2851,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2863,15 +2863,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2881,7 +2880,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2891,7 +2890,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2901,10 +2900,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -2918,24 +2918,6 @@
       "@id" : "contest-001",
       "@type" : "CVR.CandidateContest",
       "ContestSelection" : [ {
-        "@id" : "cs-c",
-        "@type" : "CVR.ContestSelection",
-        "Code" : [ {
-          "@type" : "CVR.Code",
-          "OtherType" : "vendor-label",
-          "Type" : "other",
-          "Value" : "C"
-        } ]
-      }, {
-        "@id" : "cs-d",
-        "@type" : "CVR.ContestSelection",
-        "Code" : [ {
-          "@type" : "CVR.Code",
-          "OtherType" : "vendor-label",
-          "Type" : "other",
-          "Value" : "D"
-        } ]
-      }, {
         "@id" : "cs-a",
         "@type" : "CVR.ContestSelection",
         "Code" : [ {
@@ -2953,11 +2935,29 @@
           "Type" : "other",
           "Value" : "B"
         } ]
+      }, {
+        "@id" : "cs-c",
+        "@type" : "CVR.ContestSelection",
+        "Code" : [ {
+          "@type" : "CVR.Code",
+          "OtherType" : "vendor-label",
+          "Type" : "other",
+          "Value" : "C"
+        } ]
+      }, {
+        "@id" : "cs-d",
+        "@type" : "CVR.ContestSelection",
+        "Code" : [ {
+          "@type" : "CVR.Code",
+          "OtherType" : "vendor-label",
+          "Type" : "other",
+          "Value" : "D"
+        } ]
       } ]
     } ],
     "ElectionScopeId" : "gpu-election"
   } ],
-  "GeneratedDate" : "2019-04-26T00:18:59-07:00",
+  "GeneratedDate" : "2019-05-01T17:41:41-07:00",
   "GpUnit" : [ {
     "@id" : "gpu-election",
     "@type" : "CVR.GpUnit",
@@ -2969,7 +2969,7 @@
   "ReportingDevice" : [ {
     "@id" : "rd-001",
     "@type" : "CVR.ReportingDevice",
-    "Application" : "RCV Universal Tabulator",
+    "Application" : "RCVRC Tabulator",
     "Manufacturer" : "Bright Spots"
   } ],
   "Version" : "1.0.0"

--- a/src/test/resources/test_data/test_set_2_overvote_skip_to_next/test_set_2_overvote_skip_to_next_cvr.json
+++ b/src/test/resources/test_data/test_set_2_overvote_skip_to_next/test_set_2_overvote_skip_to_next_cvr.json
@@ -8,15 +8,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -26,7 +25,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -36,7 +35,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -46,10 +45,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -63,15 +63,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -81,7 +80,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -91,7 +90,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -101,10 +100,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -118,15 +118,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -136,7 +135,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -146,7 +145,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -156,10 +155,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -173,15 +173,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -191,7 +190,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -201,7 +200,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -211,10 +210,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -228,15 +228,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -246,7 +245,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -256,7 +255,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -266,10 +265,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -283,15 +283,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -301,7 +300,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -311,7 +310,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -321,10 +320,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -338,15 +338,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -356,7 +355,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -366,7 +365,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -376,10 +375,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -393,15 +393,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -411,7 +410,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -421,7 +420,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -431,10 +430,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -448,15 +448,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -466,7 +465,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -476,7 +475,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -486,10 +485,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -503,15 +503,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -521,7 +520,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -531,7 +530,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -541,10 +540,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -558,15 +558,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -576,7 +575,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -586,7 +585,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -596,10 +595,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -613,15 +613,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -631,7 +630,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -641,7 +640,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -651,10 +650,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -668,15 +668,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -686,10 +685,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -703,15 +703,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -721,7 +720,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -731,10 +730,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -748,15 +748,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -766,7 +765,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -776,7 +775,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -786,10 +785,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -842,7 +842,7 @@
     } ],
     "ElectionScopeId" : "gpu-election"
   } ],
-  "GeneratedDate" : "2019-04-24T22:14:33-07:00",
+  "GeneratedDate" : "2019-05-01T16:59:44-07:00",
   "GpUnit" : [ {
     "@id" : "gpu-election",
     "@type" : "CVR.GpUnit",
@@ -854,7 +854,7 @@
   "ReportingDevice" : [ {
     "@id" : "rd-001",
     "@type" : "CVR.ReportingDevice",
-    "Application" : "RCV Universal Tabulator",
+    "Application" : "RCVRC Tabulator",
     "Manufacturer" : "Bright Spots"
   } ],
   "Version" : "1.0.0"

--- a/src/test/resources/test_data/test_set_2_overvote_skip_to_next/test_set_2_overvote_skip_to_next_expected_cvr_cdf.json
+++ b/src/test/resources/test_data/test_set_2_overvote_skip_to_next/test_set_2_overvote_skip_to_next_expected_cvr_cdf.json
@@ -1435,7 +1435,7 @@
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-d",
+          "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
@@ -1445,7 +1445,7 @@
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-b",
+          "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
@@ -1484,7 +1484,7 @@
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-d",
+          "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
@@ -1494,7 +1494,7 @@
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-b",
+          "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
@@ -1533,7 +1533,7 @@
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-d",
+          "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
@@ -1543,7 +1543,7 @@
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-b",
+          "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
@@ -1582,7 +1582,7 @@
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-d",
+          "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
@@ -1592,7 +1592,7 @@
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-b",
+          "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
@@ -2957,7 +2957,7 @@
     } ],
     "ElectionScopeId" : "gpu-election"
   } ],
-  "GeneratedDate" : "2019-04-24T22:16:27-07:00",
+  "GeneratedDate" : "2019-04-26T00:20:44-07:00",
   "GpUnit" : [ {
     "@id" : "gpu-election",
     "@type" : "CVR.GpUnit",

--- a/src/test/resources/test_data/test_set_2_overvote_skip_to_next/test_set_2_overvote_skip_to_next_expected_cvr_cdf.json
+++ b/src/test/resources/test_data/test_set_2_overvote_skip_to_next/test_set_2_overvote_skip_to_next_expected_cvr_cdf.json
@@ -8,15 +8,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -26,7 +25,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -36,7 +35,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -46,10 +45,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -57,15 +57,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -75,7 +74,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -85,7 +84,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -95,10 +94,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -106,15 +106,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -124,7 +123,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -134,7 +133,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -144,10 +143,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -155,15 +155,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -173,7 +172,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -183,7 +182,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -193,10 +192,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -210,15 +210,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -228,7 +227,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -238,7 +237,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -248,10 +247,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -259,15 +259,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -277,7 +276,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -287,7 +286,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -297,10 +296,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -308,15 +308,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -326,7 +325,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -336,7 +335,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -346,10 +345,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -357,15 +357,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -375,7 +374,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -385,7 +384,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -395,10 +394,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -412,15 +412,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -430,7 +429,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -440,7 +439,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -450,10 +449,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -461,15 +461,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -479,7 +478,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -489,7 +488,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -499,10 +498,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -510,15 +510,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -528,7 +527,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -538,7 +537,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -548,10 +547,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -559,15 +559,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -577,7 +576,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -587,7 +586,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -597,10 +596,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -614,15 +614,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -632,7 +631,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -642,7 +641,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -652,10 +651,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -663,15 +663,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -681,7 +680,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -691,7 +690,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -701,10 +700,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -712,15 +712,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -730,7 +729,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -740,7 +739,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -750,10 +749,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -761,15 +761,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -779,7 +778,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -789,7 +788,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -799,10 +798,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -816,15 +816,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -834,7 +833,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -844,7 +843,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -854,10 +853,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -865,15 +865,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -883,7 +882,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -893,7 +892,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -903,10 +902,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -914,15 +914,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -932,7 +931,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -942,7 +941,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -952,10 +951,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -963,15 +963,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -981,7 +980,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -991,7 +990,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1001,10 +1000,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1018,15 +1018,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1036,7 +1035,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1046,7 +1045,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1056,10 +1055,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1067,15 +1067,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1085,7 +1084,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1095,7 +1094,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1105,10 +1104,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1116,15 +1116,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1134,7 +1133,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1144,7 +1143,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1154,10 +1153,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1165,15 +1165,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1183,7 +1182,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1193,7 +1192,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1203,10 +1202,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1220,15 +1220,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1238,7 +1237,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1248,7 +1247,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1258,10 +1257,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1269,15 +1269,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1287,7 +1286,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1297,7 +1296,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1307,10 +1306,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1318,15 +1318,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1336,7 +1335,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1346,7 +1345,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1356,10 +1355,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1367,15 +1367,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1385,7 +1384,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1395,7 +1394,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1405,10 +1404,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1422,15 +1422,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1440,7 +1439,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1450,7 +1449,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1460,10 +1459,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1471,15 +1471,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1489,7 +1488,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1499,7 +1498,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1509,10 +1508,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1520,15 +1520,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1538,7 +1537,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1548,7 +1547,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1558,10 +1557,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1569,15 +1569,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1587,7 +1586,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1597,7 +1596,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1607,10 +1606,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1624,15 +1624,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1642,7 +1641,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1652,7 +1651,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1662,10 +1661,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1673,15 +1673,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1691,7 +1690,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1701,7 +1700,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1711,10 +1710,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1722,15 +1722,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1740,7 +1739,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1750,7 +1749,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1760,10 +1759,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1771,15 +1771,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1789,7 +1788,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1799,7 +1798,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1809,10 +1808,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1826,15 +1826,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1844,7 +1843,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1854,7 +1853,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1864,10 +1863,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1875,15 +1875,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1893,7 +1892,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1903,7 +1902,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1913,10 +1912,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1924,15 +1924,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1942,7 +1941,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1952,7 +1951,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1962,10 +1961,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1973,15 +1973,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1991,7 +1990,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2001,7 +2000,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2011,10 +2010,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -2028,15 +2028,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2046,7 +2045,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2056,7 +2055,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2066,10 +2065,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -2077,15 +2077,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2095,7 +2094,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2105,7 +2104,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2115,10 +2114,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2126,15 +2126,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2144,7 +2143,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2154,7 +2153,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2164,10 +2163,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2175,15 +2175,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2193,7 +2192,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2203,7 +2202,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2213,10 +2212,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -2230,15 +2230,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2248,7 +2247,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2258,7 +2257,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2268,10 +2267,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -2279,15 +2279,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2297,7 +2296,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2307,7 +2306,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2317,10 +2316,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2328,15 +2328,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2346,7 +2345,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2356,7 +2355,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2366,10 +2365,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2377,15 +2377,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2395,7 +2394,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2405,7 +2404,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2415,10 +2414,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -2432,15 +2432,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2450,10 +2449,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -2461,15 +2461,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2479,10 +2478,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2490,15 +2490,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2508,10 +2507,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2519,15 +2519,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2537,10 +2536,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -2554,15 +2554,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2572,7 +2571,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2582,10 +2581,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -2593,15 +2593,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2611,7 +2610,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2621,10 +2620,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2632,15 +2632,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2650,7 +2649,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2660,10 +2659,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2671,15 +2671,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2689,7 +2688,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2699,10 +2698,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -2716,15 +2716,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2734,7 +2733,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2744,7 +2743,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2754,10 +2753,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -2765,15 +2765,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2783,7 +2782,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2793,7 +2792,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2803,10 +2802,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2814,15 +2814,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2832,7 +2831,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2842,7 +2841,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2852,10 +2851,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2863,15 +2863,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2881,7 +2880,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2891,7 +2890,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2901,10 +2900,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -2918,24 +2918,6 @@
       "@id" : "contest-001",
       "@type" : "CVR.CandidateContest",
       "ContestSelection" : [ {
-        "@id" : "cs-c",
-        "@type" : "CVR.ContestSelection",
-        "Code" : [ {
-          "@type" : "CVR.Code",
-          "OtherType" : "vendor-label",
-          "Type" : "other",
-          "Value" : "C"
-        } ]
-      }, {
-        "@id" : "cs-d",
-        "@type" : "CVR.ContestSelection",
-        "Code" : [ {
-          "@type" : "CVR.Code",
-          "OtherType" : "vendor-label",
-          "Type" : "other",
-          "Value" : "D"
-        } ]
-      }, {
         "@id" : "cs-a",
         "@type" : "CVR.ContestSelection",
         "Code" : [ {
@@ -2953,11 +2935,29 @@
           "Type" : "other",
           "Value" : "B"
         } ]
+      }, {
+        "@id" : "cs-c",
+        "@type" : "CVR.ContestSelection",
+        "Code" : [ {
+          "@type" : "CVR.Code",
+          "OtherType" : "vendor-label",
+          "Type" : "other",
+          "Value" : "C"
+        } ]
+      }, {
+        "@id" : "cs-d",
+        "@type" : "CVR.ContestSelection",
+        "Code" : [ {
+          "@type" : "CVR.Code",
+          "OtherType" : "vendor-label",
+          "Type" : "other",
+          "Value" : "D"
+        } ]
       } ]
     } ],
     "ElectionScopeId" : "gpu-election"
   } ],
-  "GeneratedDate" : "2019-04-26T00:20:44-07:00",
+  "GeneratedDate" : "2019-05-01T17:42:07-07:00",
   "GpUnit" : [ {
     "@id" : "gpu-election",
     "@type" : "CVR.GpUnit",
@@ -2969,7 +2969,7 @@
   "ReportingDevice" : [ {
     "@id" : "rd-001",
     "@type" : "CVR.ReportingDevice",
-    "Application" : "RCV Universal Tabulator",
+    "Application" : "RCVRC Tabulator",
     "Manufacturer" : "Bright Spots"
   } ],
   "Version" : "1.0.0"

--- a/src/test/resources/test_data/test_set_3_skipped_choice_exhaust/test_set_3_skipped_choice_exhaust_cvr.json
+++ b/src/test/resources/test_data/test_set_3_skipped_choice_exhaust/test_set_3_skipped_choice_exhaust_cvr.json
@@ -8,15 +8,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -26,10 +25,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -43,15 +43,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -61,7 +60,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -71,7 +70,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -81,10 +80,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -98,15 +98,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -116,7 +115,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -126,7 +125,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -136,10 +135,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -153,15 +153,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -171,7 +170,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -181,7 +180,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -191,10 +190,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -208,15 +208,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -226,7 +225,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -236,7 +235,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -246,10 +245,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -263,15 +263,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -281,7 +280,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -291,7 +290,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -301,10 +300,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -318,15 +318,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -336,7 +335,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -346,7 +345,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -356,10 +355,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -373,15 +373,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -391,7 +390,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -401,10 +400,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -418,15 +418,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -436,7 +435,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -446,7 +445,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -456,10 +455,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -473,15 +473,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -491,7 +490,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -501,7 +500,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -511,10 +510,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -528,15 +528,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -546,7 +545,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -556,7 +555,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -566,10 +565,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -583,15 +583,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -601,7 +600,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -611,7 +610,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -621,10 +620,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -638,15 +638,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -656,10 +655,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -673,15 +673,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -691,7 +690,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -701,10 +700,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -718,15 +718,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -736,7 +735,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -746,7 +745,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -756,10 +755,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -812,7 +812,7 @@
     } ],
     "ElectionScopeId" : "gpu-election"
   } ],
-  "GeneratedDate" : "2019-04-24T22:19:57-07:00",
+  "GeneratedDate" : "2019-05-01T17:04:24-07:00",
   "GpUnit" : [ {
     "@id" : "gpu-election",
     "@type" : "CVR.GpUnit",
@@ -824,7 +824,7 @@
   "ReportingDevice" : [ {
     "@id" : "rd-001",
     "@type" : "CVR.ReportingDevice",
-    "Application" : "RCV Universal Tabulator",
+    "Application" : "RCVRC Tabulator",
     "Manufacturer" : "Bright Spots"
   } ],
   "Version" : "1.0.0"

--- a/src/test/resources/test_data/test_set_3_skipped_choice_exhaust/test_set_3_skipped_choice_exhaust_expected_cvr_cdf.json
+++ b/src/test/resources/test_data/test_set_3_skipped_choice_exhaust/test_set_3_skipped_choice_exhaust_expected_cvr_cdf.json
@@ -8,15 +8,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -26,10 +25,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -37,15 +37,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -55,10 +54,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -66,15 +66,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -84,10 +83,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -95,15 +95,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -113,10 +112,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -130,15 +130,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -148,7 +147,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -158,7 +157,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -168,10 +167,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -179,15 +179,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -197,7 +196,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -207,7 +206,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -217,10 +216,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -228,15 +228,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -246,7 +245,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -256,7 +255,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -266,10 +265,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -277,15 +277,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -295,7 +294,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -305,7 +304,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -315,10 +314,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -332,15 +332,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -350,7 +349,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -360,7 +359,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -370,10 +369,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -381,15 +381,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -399,7 +398,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -409,7 +408,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -419,10 +418,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -430,15 +430,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -448,7 +447,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -458,7 +457,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -468,10 +467,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -479,15 +479,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -497,7 +496,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -507,7 +506,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -517,10 +516,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -534,15 +534,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -552,7 +551,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -562,7 +561,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -572,10 +571,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -583,15 +583,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -601,7 +600,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -611,7 +610,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -621,10 +620,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -632,15 +632,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -650,7 +649,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -660,7 +659,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -670,10 +669,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -681,15 +681,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -699,7 +698,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -709,7 +708,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -719,10 +718,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -736,15 +736,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -754,7 +753,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -764,7 +763,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -774,10 +773,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -785,15 +785,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -803,7 +802,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -813,7 +812,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -823,10 +822,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -834,15 +834,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -852,7 +851,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -862,7 +861,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -872,10 +871,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -883,15 +883,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -901,7 +900,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -911,7 +910,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -921,10 +920,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -938,15 +938,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -956,7 +955,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -966,7 +965,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -976,10 +975,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -987,15 +987,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1005,7 +1004,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1015,7 +1014,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1025,10 +1024,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1036,15 +1036,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1054,7 +1053,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1064,7 +1063,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1074,10 +1073,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1085,15 +1085,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1103,7 +1102,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1113,7 +1112,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1123,10 +1122,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1140,15 +1140,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1158,7 +1157,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1168,7 +1167,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1178,10 +1177,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1189,15 +1189,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1207,7 +1206,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1217,7 +1216,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1227,10 +1226,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1238,15 +1238,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1256,7 +1255,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1266,7 +1265,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1276,10 +1275,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1287,15 +1287,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1305,7 +1304,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1315,7 +1314,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1325,10 +1324,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1342,15 +1342,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1360,7 +1359,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1370,10 +1369,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1381,15 +1381,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1399,7 +1398,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1409,10 +1408,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1420,15 +1420,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1438,7 +1437,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1448,10 +1447,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1459,15 +1459,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1477,7 +1476,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1487,10 +1486,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1504,15 +1504,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1522,7 +1521,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1532,7 +1531,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1542,10 +1541,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1553,15 +1553,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1571,7 +1570,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1581,7 +1580,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1591,10 +1590,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1602,15 +1602,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1620,7 +1619,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1630,7 +1629,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1640,10 +1639,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1651,15 +1651,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1669,7 +1668,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1679,7 +1678,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1689,10 +1688,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1706,15 +1706,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1724,7 +1723,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1734,7 +1733,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1744,10 +1743,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1755,15 +1755,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1773,7 +1772,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1783,7 +1782,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1793,10 +1792,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1804,15 +1804,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1822,7 +1821,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1832,7 +1831,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1842,10 +1841,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1853,15 +1853,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1871,7 +1870,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1881,7 +1880,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1891,10 +1890,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1908,15 +1908,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1926,7 +1925,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1936,7 +1935,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1946,10 +1945,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1957,15 +1957,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1975,7 +1974,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1985,7 +1984,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1995,10 +1994,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2006,15 +2006,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2024,7 +2023,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2034,7 +2033,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2044,10 +2043,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2055,15 +2055,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2073,7 +2072,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2083,7 +2082,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2093,10 +2092,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -2110,15 +2110,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2128,7 +2127,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2138,7 +2137,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2148,10 +2147,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -2159,15 +2159,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2177,7 +2176,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2187,7 +2186,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2197,10 +2196,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2208,15 +2208,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2226,7 +2225,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2236,7 +2235,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2246,10 +2245,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2257,15 +2257,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2275,7 +2274,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2285,7 +2284,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2295,10 +2294,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -2312,15 +2312,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2330,10 +2329,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -2341,15 +2341,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2359,10 +2358,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2370,15 +2370,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2388,10 +2387,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2399,15 +2399,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2417,10 +2416,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -2434,15 +2434,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2452,7 +2451,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2462,10 +2461,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -2473,15 +2473,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2491,7 +2490,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2501,10 +2500,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2512,15 +2512,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2530,7 +2529,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2540,10 +2539,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2551,15 +2551,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2569,7 +2568,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2579,10 +2578,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -2596,15 +2596,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2614,7 +2613,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2624,7 +2623,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2634,10 +2633,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -2645,15 +2645,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2663,7 +2662,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2673,7 +2672,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2683,10 +2682,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2694,15 +2694,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2712,7 +2711,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2722,7 +2721,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2732,10 +2731,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2743,15 +2743,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2761,7 +2760,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2771,7 +2770,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2781,10 +2780,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -2798,24 +2798,6 @@
       "@id" : "contest-001",
       "@type" : "CVR.CandidateContest",
       "ContestSelection" : [ {
-        "@id" : "cs-c",
-        "@type" : "CVR.ContestSelection",
-        "Code" : [ {
-          "@type" : "CVR.Code",
-          "OtherType" : "vendor-label",
-          "Type" : "other",
-          "Value" : "C"
-        } ]
-      }, {
-        "@id" : "cs-d",
-        "@type" : "CVR.ContestSelection",
-        "Code" : [ {
-          "@type" : "CVR.Code",
-          "OtherType" : "vendor-label",
-          "Type" : "other",
-          "Value" : "D"
-        } ]
-      }, {
         "@id" : "cs-a",
         "@type" : "CVR.ContestSelection",
         "Code" : [ {
@@ -2833,11 +2815,29 @@
           "Type" : "other",
           "Value" : "B"
         } ]
+      }, {
+        "@id" : "cs-c",
+        "@type" : "CVR.ContestSelection",
+        "Code" : [ {
+          "@type" : "CVR.Code",
+          "OtherType" : "vendor-label",
+          "Type" : "other",
+          "Value" : "C"
+        } ]
+      }, {
+        "@id" : "cs-d",
+        "@type" : "CVR.ContestSelection",
+        "Code" : [ {
+          "@type" : "CVR.Code",
+          "OtherType" : "vendor-label",
+          "Type" : "other",
+          "Value" : "D"
+        } ]
       } ]
     } ],
     "ElectionScopeId" : "gpu-election"
   } ],
-  "GeneratedDate" : "2019-04-24T22:41:34-07:00",
+  "GeneratedDate" : "2019-05-01T17:42:25-07:00",
   "GpUnit" : [ {
     "@id" : "gpu-election",
     "@type" : "CVR.GpUnit",
@@ -2849,7 +2849,7 @@
   "ReportingDevice" : [ {
     "@id" : "rd-001",
     "@type" : "CVR.ReportingDevice",
-    "Application" : "RCV Universal Tabulator",
+    "Application" : "RCVRC Tabulator",
     "Manufacturer" : "Bright Spots"
   } ],
   "Version" : "1.0.0"

--- a/src/test/resources/test_data/test_set_4_skipped_choice_next/test_set_4_skipped_choice_next_cvr.json
+++ b/src/test/resources/test_data/test_set_4_skipped_choice_next/test_set_4_skipped_choice_next_cvr.json
@@ -8,15 +8,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -26,10 +25,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -43,15 +43,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -61,7 +60,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -71,7 +70,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -81,10 +80,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -98,15 +98,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -116,7 +115,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -126,7 +125,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -136,10 +135,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -153,15 +153,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -171,7 +170,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -181,7 +180,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -191,10 +190,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -208,15 +208,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -226,7 +225,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -236,7 +235,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -246,10 +245,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -263,15 +263,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -281,7 +280,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -291,7 +290,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -301,10 +300,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -318,15 +318,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -336,7 +335,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -346,7 +345,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -356,10 +355,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -373,15 +373,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -391,7 +390,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -401,10 +400,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -418,15 +418,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -436,7 +435,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -446,7 +445,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -456,10 +455,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -473,15 +473,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -491,7 +490,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -501,7 +500,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -511,10 +510,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -528,15 +528,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -546,7 +545,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -556,7 +555,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -566,10 +565,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -583,15 +583,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -601,7 +600,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -611,7 +610,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -621,10 +620,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -638,15 +638,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -656,10 +655,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -673,15 +673,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -691,7 +690,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -701,10 +700,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -718,15 +718,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -736,7 +735,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -746,7 +745,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -756,10 +755,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -812,7 +812,7 @@
     } ],
     "ElectionScopeId" : "gpu-election"
   } ],
-  "GeneratedDate" : "2019-04-24T22:45:27-07:00",
+  "GeneratedDate" : "2019-05-01T17:06:11-07:00",
   "GpUnit" : [ {
     "@id" : "gpu-election",
     "@type" : "CVR.GpUnit",
@@ -824,7 +824,7 @@
   "ReportingDevice" : [ {
     "@id" : "rd-001",
     "@type" : "CVR.ReportingDevice",
-    "Application" : "RCV Universal Tabulator",
+    "Application" : "RCVRC Tabulator",
     "Manufacturer" : "Bright Spots"
   } ],
   "Version" : "1.0.0"

--- a/src/test/resources/test_data/test_set_4_skipped_choice_next/test_set_4_skipped_choice_next_expected_cvr_cdf.json
+++ b/src/test/resources/test_data/test_set_4_skipped_choice_next/test_set_4_skipped_choice_next_expected_cvr_cdf.json
@@ -8,15 +8,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -26,10 +25,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -37,15 +37,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -55,10 +54,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -66,15 +66,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -84,10 +83,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -95,15 +95,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -113,10 +112,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -130,15 +130,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -148,7 +147,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -158,7 +157,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -168,10 +167,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -179,15 +179,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -197,7 +196,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -207,7 +206,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -217,10 +216,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -228,15 +228,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -246,7 +245,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -256,7 +255,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -266,10 +265,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -277,15 +277,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -295,7 +294,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -305,7 +304,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -315,10 +314,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -332,15 +332,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -350,7 +349,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -360,7 +359,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -370,10 +369,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -381,15 +381,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -399,7 +398,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -409,7 +408,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -419,10 +418,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -430,15 +430,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -448,7 +447,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -458,7 +457,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -468,10 +467,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -479,15 +479,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -497,7 +496,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -507,7 +506,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -517,10 +516,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -534,15 +534,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -552,7 +551,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -562,7 +561,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -572,10 +571,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -583,15 +583,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -601,7 +600,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -611,7 +610,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -621,10 +620,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -632,15 +632,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -650,7 +649,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -660,7 +659,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -670,10 +669,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -681,15 +681,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -699,7 +698,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -709,7 +708,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -719,10 +718,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -736,15 +736,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -754,7 +753,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -764,7 +763,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -774,10 +773,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -785,15 +785,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -803,7 +802,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -813,7 +812,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -823,10 +822,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -834,15 +834,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -852,7 +851,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -862,7 +861,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -872,10 +871,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -883,15 +883,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -901,7 +900,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -911,7 +910,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -921,10 +920,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -938,15 +938,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -956,7 +955,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -966,7 +965,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -976,10 +975,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -987,15 +987,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1005,7 +1004,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1015,7 +1014,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1025,10 +1024,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1036,15 +1036,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1054,7 +1053,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1064,7 +1063,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1074,10 +1073,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1085,15 +1085,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1103,7 +1102,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1113,7 +1112,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1123,10 +1122,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1140,15 +1140,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1158,7 +1157,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1168,7 +1167,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1178,10 +1177,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1189,15 +1189,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1207,7 +1206,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1217,7 +1216,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1227,10 +1226,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1238,15 +1238,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1256,7 +1255,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1266,7 +1265,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1276,10 +1275,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1287,15 +1287,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1305,7 +1304,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1315,7 +1314,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1325,10 +1324,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1342,15 +1342,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1360,7 +1359,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1370,10 +1369,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1381,15 +1381,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1399,7 +1398,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1409,10 +1408,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1420,15 +1420,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1438,7 +1437,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1448,10 +1447,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1459,15 +1459,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1477,7 +1476,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1487,10 +1486,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1504,15 +1504,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1522,7 +1521,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1532,7 +1531,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1542,10 +1541,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1553,15 +1553,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1571,7 +1570,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1581,7 +1580,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1591,10 +1590,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1602,15 +1602,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1620,7 +1619,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1630,7 +1629,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1640,10 +1639,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1651,15 +1651,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1669,7 +1668,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1679,7 +1678,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1689,10 +1688,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1706,15 +1706,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1724,7 +1723,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1734,7 +1733,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1744,10 +1743,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1755,15 +1755,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1773,7 +1772,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1783,7 +1782,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1793,10 +1792,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1804,15 +1804,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1822,7 +1821,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1832,7 +1831,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1842,10 +1841,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1853,15 +1853,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1871,7 +1870,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1881,7 +1880,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1891,10 +1890,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1908,15 +1908,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1926,7 +1925,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1936,7 +1935,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1946,10 +1945,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1957,15 +1957,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1975,7 +1974,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1985,7 +1984,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1995,10 +1994,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2006,15 +2006,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2024,7 +2023,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2034,7 +2033,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2044,10 +2043,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2055,15 +2055,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2073,7 +2072,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2083,7 +2082,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2093,10 +2092,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -2110,15 +2110,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2128,7 +2127,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2138,7 +2137,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2148,10 +2147,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -2159,15 +2159,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2177,7 +2176,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2187,7 +2186,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2197,10 +2196,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2208,15 +2208,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2226,7 +2225,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2236,7 +2235,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2246,10 +2245,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2257,15 +2257,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2275,7 +2274,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2285,7 +2284,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2295,10 +2294,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -2312,15 +2312,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2330,10 +2329,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -2341,15 +2341,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2359,10 +2358,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2370,15 +2370,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2388,10 +2387,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2399,15 +2399,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2417,10 +2416,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -2434,15 +2434,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2452,7 +2451,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2462,10 +2461,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -2473,15 +2473,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2491,7 +2490,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2501,10 +2500,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2512,15 +2512,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2530,7 +2529,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2540,10 +2539,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2551,15 +2551,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2569,7 +2568,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2579,10 +2578,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -2596,15 +2596,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2614,7 +2613,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2624,7 +2623,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2634,10 +2633,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -2645,15 +2645,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2663,7 +2662,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2673,7 +2672,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2683,10 +2682,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2694,15 +2694,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2712,7 +2711,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2722,7 +2721,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2732,10 +2731,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2743,15 +2743,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2761,7 +2760,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2771,7 +2770,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2781,10 +2780,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -2798,24 +2798,6 @@
       "@id" : "contest-001",
       "@type" : "CVR.CandidateContest",
       "ContestSelection" : [ {
-        "@id" : "cs-c",
-        "@type" : "CVR.ContestSelection",
-        "Code" : [ {
-          "@type" : "CVR.Code",
-          "OtherType" : "vendor-label",
-          "Type" : "other",
-          "Value" : "C"
-        } ]
-      }, {
-        "@id" : "cs-d",
-        "@type" : "CVR.ContestSelection",
-        "Code" : [ {
-          "@type" : "CVR.Code",
-          "OtherType" : "vendor-label",
-          "Type" : "other",
-          "Value" : "D"
-        } ]
-      }, {
         "@id" : "cs-a",
         "@type" : "CVR.ContestSelection",
         "Code" : [ {
@@ -2833,11 +2815,29 @@
           "Type" : "other",
           "Value" : "B"
         } ]
+      }, {
+        "@id" : "cs-c",
+        "@type" : "CVR.ContestSelection",
+        "Code" : [ {
+          "@type" : "CVR.Code",
+          "OtherType" : "vendor-label",
+          "Type" : "other",
+          "Value" : "C"
+        } ]
+      }, {
+        "@id" : "cs-d",
+        "@type" : "CVR.ContestSelection",
+        "Code" : [ {
+          "@type" : "CVR.Code",
+          "OtherType" : "vendor-label",
+          "Type" : "other",
+          "Value" : "D"
+        } ]
       } ]
     } ],
     "ElectionScopeId" : "gpu-election"
   } ],
-  "GeneratedDate" : "2019-04-24T22:46:15-07:00",
+  "GeneratedDate" : "2019-05-01T17:42:56-07:00",
   "GpUnit" : [ {
     "@id" : "gpu-election",
     "@type" : "CVR.GpUnit",
@@ -2849,7 +2849,7 @@
   "ReportingDevice" : [ {
     "@id" : "rd-001",
     "@type" : "CVR.ReportingDevice",
-    "Application" : "RCV Universal Tabulator",
+    "Application" : "RCVRC Tabulator",
     "Manufacturer" : "Bright Spots"
   } ],
   "Version" : "1.0.0"

--- a/src/test/resources/test_data/test_set_5_two_skipped_choice_exhaust/test_set_5_two_skipped_choice_exhaust_cvr.json
+++ b/src/test/resources/test_data/test_set_5_two_skipped_choice_exhaust/test_set_5_two_skipped_choice_exhaust_cvr.json
@@ -8,15 +8,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -26,10 +25,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -43,15 +43,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -61,7 +60,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -71,7 +70,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -81,10 +80,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -98,15 +98,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -116,7 +115,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -126,7 +125,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -136,10 +135,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -153,15 +153,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -171,7 +170,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -181,7 +180,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -191,10 +190,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -208,15 +208,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -226,7 +225,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -236,7 +235,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -246,10 +245,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -263,15 +263,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -281,7 +280,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -291,7 +290,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -301,10 +300,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -318,15 +318,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -336,7 +335,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -346,7 +345,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -356,10 +355,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -373,15 +373,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -391,7 +390,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -401,10 +400,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -418,15 +418,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -436,7 +435,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -446,7 +445,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -456,10 +455,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -473,15 +473,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -491,7 +490,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -501,7 +500,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -511,10 +510,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -528,15 +528,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -546,7 +545,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -556,7 +555,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -566,10 +565,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -583,15 +583,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -601,7 +600,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -611,7 +610,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -621,10 +620,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -638,15 +638,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -656,10 +655,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -673,15 +673,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -691,7 +690,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -701,10 +700,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -718,15 +718,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -736,7 +735,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -746,7 +745,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -756,10 +755,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -812,7 +812,7 @@
     } ],
     "ElectionScopeId" : "gpu-election"
   } ],
-  "GeneratedDate" : "2019-04-24T22:48:27-07:00",
+  "GeneratedDate" : "2019-05-01T17:07:39-07:00",
   "GpUnit" : [ {
     "@id" : "gpu-election",
     "@type" : "CVR.GpUnit",
@@ -824,7 +824,7 @@
   "ReportingDevice" : [ {
     "@id" : "rd-001",
     "@type" : "CVR.ReportingDevice",
-    "Application" : "RCV Universal Tabulator",
+    "Application" : "RCVRC Tabulator",
     "Manufacturer" : "Bright Spots"
   } ],
   "Version" : "1.0.0"

--- a/src/test/resources/test_data/test_set_5_two_skipped_choice_exhaust/test_set_5_two_skipped_choice_exhaust_expected_cvr_cdf.json
+++ b/src/test/resources/test_data/test_set_5_two_skipped_choice_exhaust/test_set_5_two_skipped_choice_exhaust_expected_cvr_cdf.json
@@ -8,15 +8,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -26,10 +25,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -37,15 +37,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -55,10 +54,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -66,15 +66,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -84,10 +83,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -95,15 +95,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -113,10 +112,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -130,15 +130,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -148,7 +147,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -158,7 +157,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -168,10 +167,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -179,15 +179,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -197,7 +196,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -207,7 +206,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -217,10 +216,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -228,15 +228,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -246,7 +245,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -256,7 +255,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -266,10 +265,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -277,15 +277,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -295,7 +294,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -305,7 +304,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -315,10 +314,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -332,15 +332,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -350,7 +349,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -360,7 +359,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -370,10 +369,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -381,15 +381,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -399,7 +398,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -409,7 +408,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -419,10 +418,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -430,15 +430,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -448,7 +447,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -458,7 +457,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -468,10 +467,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -479,15 +479,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -497,7 +496,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -507,7 +506,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -517,10 +516,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -534,15 +534,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -552,7 +551,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -562,7 +561,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -572,10 +571,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -583,15 +583,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -601,7 +600,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -611,7 +610,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -621,10 +620,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -632,15 +632,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -650,7 +649,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -660,7 +659,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -670,10 +669,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -681,15 +681,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -699,7 +698,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -709,7 +708,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -719,10 +718,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -736,15 +736,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -754,7 +753,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -764,7 +763,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -774,10 +773,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -785,15 +785,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -803,7 +802,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -813,7 +812,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -823,10 +822,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -834,15 +834,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -852,7 +851,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -862,7 +861,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -872,10 +871,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -883,15 +883,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -901,7 +900,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -911,7 +910,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -921,10 +920,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -938,15 +938,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -956,7 +955,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -966,7 +965,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -976,10 +975,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -987,15 +987,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1005,7 +1004,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1015,7 +1014,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1025,10 +1024,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1036,15 +1036,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1054,7 +1053,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1064,7 +1063,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1074,10 +1073,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1085,15 +1085,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1103,7 +1102,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1113,7 +1112,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1123,10 +1122,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1140,15 +1140,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1158,7 +1157,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1168,7 +1167,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1178,10 +1177,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1189,15 +1189,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1207,7 +1206,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1217,7 +1216,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1227,10 +1226,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1238,15 +1238,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1256,7 +1255,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1266,7 +1265,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1276,10 +1275,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1287,15 +1287,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1305,7 +1304,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1315,7 +1314,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1325,10 +1324,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1342,15 +1342,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1360,7 +1359,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1370,10 +1369,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1381,15 +1381,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1399,7 +1398,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1409,10 +1408,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1420,15 +1420,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1438,7 +1437,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1448,10 +1447,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1459,15 +1459,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1477,7 +1476,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1487,10 +1486,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1504,15 +1504,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1522,7 +1521,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1532,7 +1531,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1542,10 +1541,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1553,15 +1553,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1571,7 +1570,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1581,7 +1580,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1591,10 +1590,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1602,15 +1602,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1620,7 +1619,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1630,7 +1629,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1640,10 +1639,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1651,15 +1651,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1669,7 +1668,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1679,7 +1678,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1689,10 +1688,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1706,15 +1706,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1724,7 +1723,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1734,7 +1733,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1744,10 +1743,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1755,15 +1755,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1773,7 +1772,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1783,7 +1782,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1793,10 +1792,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1804,15 +1804,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1822,7 +1821,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1832,7 +1831,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1842,10 +1841,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1853,15 +1853,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1871,7 +1870,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1881,7 +1880,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1891,10 +1890,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1908,15 +1908,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1926,7 +1925,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1936,7 +1935,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1946,10 +1945,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1957,15 +1957,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1975,7 +1974,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1985,7 +1984,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1995,10 +1994,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2006,15 +2006,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2024,7 +2023,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2034,7 +2033,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2044,10 +2043,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2055,15 +2055,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2073,7 +2072,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2083,7 +2082,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2093,10 +2092,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -2110,15 +2110,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2128,7 +2127,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2138,7 +2137,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2148,10 +2147,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -2159,15 +2159,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2177,7 +2176,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2187,7 +2186,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2197,10 +2196,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2208,15 +2208,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2226,7 +2225,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2236,7 +2235,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2246,10 +2245,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2257,15 +2257,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2275,7 +2274,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2285,7 +2284,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2295,10 +2294,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -2312,15 +2312,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2330,10 +2329,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -2341,15 +2341,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2359,10 +2358,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2370,15 +2370,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2388,10 +2387,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2399,15 +2399,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2417,10 +2416,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -2434,15 +2434,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2452,7 +2451,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2462,10 +2461,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -2473,15 +2473,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2491,7 +2490,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2501,10 +2500,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2512,15 +2512,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2530,7 +2529,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2540,10 +2539,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2551,15 +2551,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2569,7 +2568,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2579,10 +2578,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -2596,15 +2596,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2614,7 +2613,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2624,7 +2623,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2634,10 +2633,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -2645,15 +2645,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2663,7 +2662,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2673,7 +2672,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2683,10 +2682,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2694,15 +2694,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2712,7 +2711,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2722,7 +2721,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2732,10 +2731,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2743,15 +2743,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2761,7 +2760,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2771,7 +2770,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2781,10 +2780,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -2798,24 +2798,6 @@
       "@id" : "contest-001",
       "@type" : "CVR.CandidateContest",
       "ContestSelection" : [ {
-        "@id" : "cs-c",
-        "@type" : "CVR.ContestSelection",
-        "Code" : [ {
-          "@type" : "CVR.Code",
-          "OtherType" : "vendor-label",
-          "Type" : "other",
-          "Value" : "C"
-        } ]
-      }, {
-        "@id" : "cs-d",
-        "@type" : "CVR.ContestSelection",
-        "Code" : [ {
-          "@type" : "CVR.Code",
-          "OtherType" : "vendor-label",
-          "Type" : "other",
-          "Value" : "D"
-        } ]
-      }, {
         "@id" : "cs-a",
         "@type" : "CVR.ContestSelection",
         "Code" : [ {
@@ -2833,11 +2815,29 @@
           "Type" : "other",
           "Value" : "B"
         } ]
+      }, {
+        "@id" : "cs-c",
+        "@type" : "CVR.ContestSelection",
+        "Code" : [ {
+          "@type" : "CVR.Code",
+          "OtherType" : "vendor-label",
+          "Type" : "other",
+          "Value" : "C"
+        } ]
+      }, {
+        "@id" : "cs-d",
+        "@type" : "CVR.ContestSelection",
+        "Code" : [ {
+          "@type" : "CVR.Code",
+          "OtherType" : "vendor-label",
+          "Type" : "other",
+          "Value" : "D"
+        } ]
       } ]
     } ],
     "ElectionScopeId" : "gpu-election"
   } ],
-  "GeneratedDate" : "2019-04-24T22:49:35-07:00",
+  "GeneratedDate" : "2019-05-01T17:43:15-07:00",
   "GpUnit" : [ {
     "@id" : "gpu-election",
     "@type" : "CVR.GpUnit",
@@ -2849,7 +2849,7 @@
   "ReportingDevice" : [ {
     "@id" : "rd-001",
     "@type" : "CVR.ReportingDevice",
-    "Application" : "RCV Universal Tabulator",
+    "Application" : "RCVRC Tabulator",
     "Manufacturer" : "Bright Spots"
   } ],
   "Version" : "1.0.0"

--- a/src/test/resources/test_data/test_set_6_duplicate_exhaust/test_set_6_duplicate_exhaust_cvr.json
+++ b/src/test/resources/test_data/test_set_6_duplicate_exhaust/test_set_6_duplicate_exhaust_cvr.json
@@ -8,21 +8,20 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -32,10 +31,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -49,21 +49,20 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -73,7 +72,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -83,10 +82,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -100,15 +100,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -118,7 +117,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -128,7 +127,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -138,10 +137,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -155,15 +155,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -173,7 +172,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -183,7 +182,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -193,10 +192,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -210,15 +210,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -228,7 +227,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -238,7 +237,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -248,10 +247,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -265,15 +265,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -283,7 +282,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -293,7 +292,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -303,10 +302,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -320,15 +320,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -338,7 +337,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -348,7 +347,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -358,10 +357,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -375,15 +375,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -393,7 +392,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -403,10 +402,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -420,15 +420,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -438,7 +437,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -448,7 +447,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -458,10 +457,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -475,15 +475,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -493,7 +492,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -503,7 +502,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -513,10 +512,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -530,15 +530,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -548,13 +547,13 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -564,10 +563,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -581,15 +581,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -599,7 +598,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -609,7 +608,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -619,10 +618,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -636,15 +636,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -654,10 +653,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -671,15 +671,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -689,7 +688,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -699,10 +698,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -716,15 +716,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -734,7 +733,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -744,7 +743,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -754,10 +753,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -810,7 +810,7 @@
     } ],
     "ElectionScopeId" : "gpu-election"
   } ],
-  "GeneratedDate" : "2019-04-25T23:45:38-07:00",
+  "GeneratedDate" : "2019-05-01T17:09:13-07:00",
   "GpUnit" : [ {
     "@id" : "gpu-election",
     "@type" : "CVR.GpUnit",
@@ -822,7 +822,7 @@
   "ReportingDevice" : [ {
     "@id" : "rd-001",
     "@type" : "CVR.ReportingDevice",
-    "Application" : "RCV Universal Tabulator",
+    "Application" : "RCVRC Tabulator",
     "Manufacturer" : "Bright Spots"
   } ],
   "Version" : "1.0.0"

--- a/src/test/resources/test_data/test_set_6_duplicate_exhaust/test_set_6_duplicate_exhaust_cvr.json
+++ b/src/test/resources/test_data/test_set_6_duplicate_exhaust/test_set_6_duplicate_exhaust_cvr.json
@@ -18,11 +18,7 @@
             "IsAllocable" : "unknown",
             "NumberVotes" : "1",
             "Rank" : 1
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-d",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
@@ -63,6 +59,12 @@
             "IsAllocable" : "unknown",
             "NumberVotes" : "1",
             "Rank" : 1
+          }, {
+            "@type" : "CVR.SelectionPosition",
+            "HasIndication" : "yes",
+            "IsAllocable" : "unknown",
+            "NumberVotes" : "1",
+            "Rank" : 3
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
@@ -73,16 +75,6 @@
             "IsAllocable" : "unknown",
             "NumberVotes" : "1",
             "Rank" : 2
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-c",
-          "SelectionPosition" : [ {
-            "@type" : "CVR.SelectionPosition",
-            "HasIndication" : "yes",
-            "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
-            "Rank" : 3
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
@@ -558,11 +550,7 @@
             "IsAllocable" : "unknown",
             "NumberVotes" : "1",
             "Rank" : 2
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-d",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
@@ -822,7 +810,7 @@
     } ],
     "ElectionScopeId" : "gpu-election"
   } ],
-  "GeneratedDate" : "2019-04-24T22:51:26-07:00",
+  "GeneratedDate" : "2019-04-25T23:45:38-07:00",
   "GpUnit" : [ {
     "@id" : "gpu-election",
     "@type" : "CVR.GpUnit",

--- a/src/test/resources/test_data/test_set_6_duplicate_exhaust/test_set_6_duplicate_exhaust_expected_cvr_cdf.json
+++ b/src/test/resources/test_data/test_set_6_duplicate_exhaust/test_set_6_duplicate_exhaust_expected_cvr_cdf.json
@@ -8,21 +8,20 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -32,10 +31,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -43,21 +43,20 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -67,10 +66,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -78,21 +78,20 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -102,10 +101,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -113,21 +113,20 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -137,10 +136,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -154,21 +154,20 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -178,7 +177,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -188,10 +187,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -199,21 +199,20 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -223,7 +222,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -233,10 +232,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -244,21 +244,20 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -268,7 +267,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -278,10 +277,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -289,21 +289,20 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -313,7 +312,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -323,10 +322,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -340,15 +340,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -358,7 +357,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -368,7 +367,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -378,10 +377,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -389,15 +389,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -407,7 +406,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -417,7 +416,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -427,10 +426,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -438,15 +438,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -456,7 +455,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -466,7 +465,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -476,10 +475,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -487,15 +487,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -505,7 +504,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -515,7 +514,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -525,10 +524,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -542,15 +542,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -560,7 +559,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -570,7 +569,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -580,10 +579,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -591,15 +591,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -609,7 +608,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -619,7 +618,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -629,10 +628,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -640,15 +640,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -658,7 +657,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -668,7 +667,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -678,10 +677,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -689,15 +689,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -707,7 +706,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -717,7 +716,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -727,10 +726,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -744,15 +744,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -762,7 +761,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -772,7 +771,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -782,10 +781,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -793,15 +793,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -811,7 +810,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -821,7 +820,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -831,10 +830,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -842,15 +842,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -860,7 +859,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -870,7 +869,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -880,10 +879,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -891,15 +891,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -909,7 +908,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -919,7 +918,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -929,10 +928,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -946,15 +946,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -964,7 +963,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -974,7 +973,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -984,10 +983,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -995,15 +995,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1013,7 +1012,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1023,7 +1022,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1033,10 +1032,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1044,15 +1044,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1062,7 +1061,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1072,7 +1071,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1082,10 +1081,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1093,15 +1093,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1111,7 +1110,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1121,7 +1120,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1131,10 +1130,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1148,15 +1148,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1166,7 +1165,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1176,7 +1175,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1186,10 +1185,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1197,15 +1197,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1215,7 +1214,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1225,7 +1224,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1235,10 +1234,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1246,15 +1246,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1264,7 +1263,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1274,7 +1273,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1284,10 +1283,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1295,15 +1295,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1313,7 +1312,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1323,7 +1322,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1333,10 +1332,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1350,15 +1350,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1368,7 +1367,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1378,10 +1377,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1389,15 +1389,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1407,7 +1406,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1417,10 +1416,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1428,15 +1428,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1446,7 +1445,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1456,10 +1455,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1467,15 +1467,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1485,7 +1484,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1495,10 +1494,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1512,15 +1512,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1530,7 +1529,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1540,7 +1539,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1550,10 +1549,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1561,15 +1561,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1579,7 +1578,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1589,7 +1588,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1599,10 +1598,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1610,15 +1610,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1628,7 +1627,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1638,7 +1637,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1648,10 +1647,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1659,15 +1659,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1677,7 +1676,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1687,7 +1686,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1697,10 +1696,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1714,15 +1714,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1732,7 +1731,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1742,7 +1741,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1752,10 +1751,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1763,15 +1763,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1781,7 +1780,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1791,7 +1790,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1801,10 +1800,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1812,15 +1812,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1830,7 +1829,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1840,7 +1839,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1850,10 +1849,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1861,15 +1861,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1879,7 +1878,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1889,7 +1888,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1899,10 +1898,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1916,15 +1916,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1934,13 +1933,13 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1950,10 +1949,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1961,15 +1961,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1979,13 +1978,13 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1995,10 +1994,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2006,15 +2006,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2024,13 +2023,13 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2040,10 +2039,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2051,15 +2051,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2069,13 +2068,13 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2085,10 +2084,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -2102,15 +2102,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2120,7 +2119,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2130,7 +2129,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2140,10 +2139,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -2151,15 +2151,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2169,7 +2168,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2179,7 +2178,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2189,10 +2188,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2200,15 +2200,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2218,7 +2217,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2228,7 +2227,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2238,10 +2237,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2249,15 +2249,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2267,7 +2266,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2277,7 +2276,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2287,10 +2286,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -2304,15 +2304,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2322,10 +2321,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -2333,15 +2333,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2351,10 +2350,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2362,15 +2362,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2380,10 +2379,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2391,15 +2391,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2409,10 +2408,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -2426,15 +2426,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2444,7 +2443,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2454,10 +2453,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -2465,15 +2465,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2483,7 +2482,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2493,10 +2492,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2504,15 +2504,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2522,7 +2521,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2532,10 +2531,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2543,15 +2543,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2561,7 +2560,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2571,10 +2570,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -2588,15 +2588,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2606,7 +2605,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2616,7 +2615,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2626,10 +2625,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -2637,15 +2637,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2655,7 +2654,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2665,7 +2664,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2675,10 +2674,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2686,15 +2686,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2704,7 +2703,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2714,7 +2713,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2724,10 +2723,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2735,15 +2735,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2753,7 +2752,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2763,7 +2762,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2773,10 +2772,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -2790,24 +2790,6 @@
       "@id" : "contest-001",
       "@type" : "CVR.CandidateContest",
       "ContestSelection" : [ {
-        "@id" : "cs-c",
-        "@type" : "CVR.ContestSelection",
-        "Code" : [ {
-          "@type" : "CVR.Code",
-          "OtherType" : "vendor-label",
-          "Type" : "other",
-          "Value" : "C"
-        } ]
-      }, {
-        "@id" : "cs-d",
-        "@type" : "CVR.ContestSelection",
-        "Code" : [ {
-          "@type" : "CVR.Code",
-          "OtherType" : "vendor-label",
-          "Type" : "other",
-          "Value" : "D"
-        } ]
-      }, {
         "@id" : "cs-a",
         "@type" : "CVR.ContestSelection",
         "Code" : [ {
@@ -2825,11 +2807,29 @@
           "Type" : "other",
           "Value" : "B"
         } ]
+      }, {
+        "@id" : "cs-c",
+        "@type" : "CVR.ContestSelection",
+        "Code" : [ {
+          "@type" : "CVR.Code",
+          "OtherType" : "vendor-label",
+          "Type" : "other",
+          "Value" : "C"
+        } ]
+      }, {
+        "@id" : "cs-d",
+        "@type" : "CVR.ContestSelection",
+        "Code" : [ {
+          "@type" : "CVR.Code",
+          "OtherType" : "vendor-label",
+          "Type" : "other",
+          "Value" : "D"
+        } ]
       } ]
     } ],
     "ElectionScopeId" : "gpu-election"
   } ],
-  "GeneratedDate" : "2019-04-26T00:05:58-07:00",
+  "GeneratedDate" : "2019-05-01T17:43:33-07:00",
   "GpUnit" : [ {
     "@id" : "gpu-election",
     "@type" : "CVR.GpUnit",
@@ -2841,7 +2841,7 @@
   "ReportingDevice" : [ {
     "@id" : "rd-001",
     "@type" : "CVR.ReportingDevice",
-    "Application" : "RCV Universal Tabulator",
+    "Application" : "RCVRC Tabulator",
     "Manufacturer" : "Bright Spots"
   } ],
   "Version" : "1.0.0"

--- a/src/test/resources/test_data/test_set_6_duplicate_exhaust/test_set_6_duplicate_exhaust_expected_cvr_cdf.json
+++ b/src/test/resources/test_data/test_set_6_duplicate_exhaust/test_set_6_duplicate_exhaust_expected_cvr_cdf.json
@@ -18,11 +18,7 @@
             "IsAllocable" : "unknown",
             "NumberVotes" : "1",
             "Rank" : 1
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-d",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
@@ -57,14 +53,10 @@
             "IsAllocable" : "yes",
             "NumberVotes" : "1",
             "Rank" : 1
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-d",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
-            "IsAllocable" : "yes",
+            "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 2
           } ]
@@ -96,11 +88,7 @@
             "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 1
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-d",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
@@ -135,11 +123,7 @@
             "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 1
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-d",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
@@ -180,6 +164,12 @@
             "IsAllocable" : "unknown",
             "NumberVotes" : "1",
             "Rank" : 1
+          }, {
+            "@type" : "CVR.SelectionPosition",
+            "HasIndication" : "yes",
+            "IsAllocable" : "unknown",
+            "NumberVotes" : "1",
+            "Rank" : 3
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
@@ -190,16 +180,6 @@
             "IsAllocable" : "unknown",
             "NumberVotes" : "1",
             "Rank" : 2
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-c",
-          "SelectionPosition" : [ {
-            "@type" : "CVR.SelectionPosition",
-            "HasIndication" : "yes",
-            "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
-            "Rank" : 3
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
@@ -229,6 +209,12 @@
             "IsAllocable" : "yes",
             "NumberVotes" : "1",
             "Rank" : 1
+          }, {
+            "@type" : "CVR.SelectionPosition",
+            "HasIndication" : "yes",
+            "IsAllocable" : "no",
+            "NumberVotes" : "1",
+            "Rank" : 3
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
@@ -239,16 +225,6 @@
             "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 2
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-c",
-          "SelectionPosition" : [ {
-            "@type" : "CVR.SelectionPosition",
-            "HasIndication" : "yes",
-            "IsAllocable" : "yes",
-            "NumberVotes" : "1",
-            "Rank" : 3
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
@@ -278,6 +254,12 @@
             "IsAllocable" : "yes",
             "NumberVotes" : "1",
             "Rank" : 1
+          }, {
+            "@type" : "CVR.SelectionPosition",
+            "HasIndication" : "yes",
+            "IsAllocable" : "no",
+            "NumberVotes" : "1",
+            "Rank" : 3
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
@@ -288,16 +270,6 @@
             "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 2
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-c",
-          "SelectionPosition" : [ {
-            "@type" : "CVR.SelectionPosition",
-            "HasIndication" : "yes",
-            "IsAllocable" : "yes",
-            "NumberVotes" : "1",
-            "Rank" : 3
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
@@ -327,6 +299,12 @@
             "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 1
+          }, {
+            "@type" : "CVR.SelectionPosition",
+            "HasIndication" : "yes",
+            "IsAllocable" : "no",
+            "NumberVotes" : "1",
+            "Rank" : 3
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
@@ -337,16 +315,6 @@
             "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 2
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-c",
-          "SelectionPosition" : [ {
-            "@type" : "CVR.SelectionPosition",
-            "HasIndication" : "yes",
-            "IsAllocable" : "no",
-            "NumberVotes" : "1",
-            "Rank" : 3
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
@@ -1968,11 +1936,7 @@
             "IsAllocable" : "unknown",
             "NumberVotes" : "1",
             "Rank" : 2
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-d",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
@@ -2017,11 +1981,7 @@
             "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 2
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-d",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
@@ -2066,11 +2026,7 @@
             "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 2
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-d",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
@@ -2115,11 +2071,7 @@
             "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 2
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-d",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
@@ -2877,7 +2829,7 @@
     } ],
     "ElectionScopeId" : "gpu-election"
   } ],
-  "GeneratedDate" : "2019-04-24T22:51:59-07:00",
+  "GeneratedDate" : "2019-04-26T00:05:58-07:00",
   "GpUnit" : [ {
     "@id" : "gpu-election",
     "@type" : "CVR.GpUnit",

--- a/src/test/resources/test_data/test_set_7_duplicate_skip_to_next/test_set_7_duplicate_skip_to_next_cvr.json
+++ b/src/test/resources/test_data/test_set_7_duplicate_skip_to_next/test_set_7_duplicate_skip_to_next_cvr.json
@@ -18,11 +18,7 @@
             "IsAllocable" : "unknown",
             "NumberVotes" : "1",
             "Rank" : 1
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-d",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
@@ -822,7 +818,7 @@
     } ],
     "ElectionScopeId" : "gpu-election"
   } ],
-  "GeneratedDate" : "2019-04-24T22:53:48-07:00",
+  "GeneratedDate" : "2019-04-26T00:09:08-07:00",
   "GpUnit" : [ {
     "@id" : "gpu-election",
     "@type" : "CVR.GpUnit",

--- a/src/test/resources/test_data/test_set_7_duplicate_skip_to_next/test_set_7_duplicate_skip_to_next_cvr.json
+++ b/src/test/resources/test_data/test_set_7_duplicate_skip_to_next/test_set_7_duplicate_skip_to_next_cvr.json
@@ -8,21 +8,20 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -32,10 +31,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -49,15 +49,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -67,7 +66,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -77,7 +76,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -87,10 +86,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -104,15 +104,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -122,7 +121,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -132,7 +131,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -142,10 +141,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -159,15 +159,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -177,7 +176,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -187,7 +186,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -197,10 +196,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -214,15 +214,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -232,7 +231,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -242,7 +241,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -252,10 +251,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -269,15 +269,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -287,7 +286,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -297,7 +296,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -307,10 +306,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -324,15 +324,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -342,7 +341,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -352,7 +351,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -362,10 +361,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -379,15 +379,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -397,7 +396,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -407,10 +406,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -424,15 +424,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -442,7 +441,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -452,7 +451,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -462,10 +461,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -479,15 +479,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -497,7 +496,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -507,7 +506,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -517,10 +516,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -534,15 +534,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -552,7 +551,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -562,7 +561,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -572,10 +571,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -589,15 +589,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -607,7 +606,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -617,7 +616,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -627,10 +626,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -644,15 +644,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -662,10 +661,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -679,15 +679,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -697,7 +696,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -707,10 +706,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -724,15 +724,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -742,7 +741,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -752,7 +751,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -762,10 +761,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -818,7 +818,7 @@
     } ],
     "ElectionScopeId" : "gpu-election"
   } ],
-  "GeneratedDate" : "2019-04-26T00:09:08-07:00",
+  "GeneratedDate" : "2019-05-01T17:10:50-07:00",
   "GpUnit" : [ {
     "@id" : "gpu-election",
     "@type" : "CVR.GpUnit",
@@ -830,7 +830,7 @@
   "ReportingDevice" : [ {
     "@id" : "rd-001",
     "@type" : "CVR.ReportingDevice",
-    "Application" : "RCV Universal Tabulator",
+    "Application" : "RCVRC Tabulator",
     "Manufacturer" : "Bright Spots"
   } ],
   "Version" : "1.0.0"

--- a/src/test/resources/test_data/test_set_7_duplicate_skip_to_next/test_set_7_duplicate_skip_to_next_expected_cvr_cdf.json
+++ b/src/test/resources/test_data/test_set_7_duplicate_skip_to_next/test_set_7_duplicate_skip_to_next_expected_cvr_cdf.json
@@ -8,21 +8,20 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -32,10 +31,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -43,21 +43,20 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -67,10 +66,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -78,21 +78,20 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -102,10 +101,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -113,21 +113,20 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -137,10 +136,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -154,15 +154,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -172,7 +171,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -182,7 +181,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -192,10 +191,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -203,15 +203,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -221,7 +220,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -231,7 +230,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -241,10 +240,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -252,15 +252,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -270,7 +269,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -280,7 +279,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -290,10 +289,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -301,15 +301,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -319,7 +318,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -329,7 +328,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -339,10 +338,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -356,15 +356,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -374,7 +373,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -384,7 +383,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -394,10 +393,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -405,15 +405,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -423,7 +422,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -433,7 +432,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -443,10 +442,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -454,15 +454,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -472,7 +471,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -482,7 +481,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -492,10 +491,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -503,15 +503,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -521,7 +520,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -531,7 +530,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -541,10 +540,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -558,15 +558,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -576,7 +575,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -586,7 +585,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -596,10 +595,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -607,15 +607,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -625,7 +624,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -635,7 +634,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -645,10 +644,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -656,15 +656,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -674,7 +673,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -684,7 +683,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -694,10 +693,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -705,15 +705,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -723,7 +722,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -733,7 +732,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -743,10 +742,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -760,15 +760,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -778,7 +777,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -788,7 +787,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -798,10 +797,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -809,15 +809,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -827,7 +826,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -837,7 +836,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -847,10 +846,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -858,15 +858,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -876,7 +875,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -886,7 +885,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -896,10 +895,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -907,15 +907,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -925,7 +924,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -935,7 +934,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -945,10 +944,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -962,15 +962,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -980,7 +979,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -990,7 +989,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1000,10 +999,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1011,15 +1011,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1029,7 +1028,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1039,7 +1038,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1049,10 +1048,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1060,15 +1060,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1078,7 +1077,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1088,7 +1087,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1098,10 +1097,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1109,15 +1109,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1127,7 +1126,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1137,7 +1136,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1147,10 +1146,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1164,15 +1164,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1182,7 +1181,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1192,7 +1191,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1202,10 +1201,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1213,15 +1213,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1231,7 +1230,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1241,7 +1240,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1251,10 +1250,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1262,15 +1262,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1280,7 +1279,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1290,7 +1289,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1300,10 +1299,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1311,15 +1311,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1329,7 +1328,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1339,7 +1338,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1349,10 +1348,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1366,15 +1366,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1384,7 +1383,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1394,10 +1393,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1405,15 +1405,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1423,7 +1422,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1433,10 +1432,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1444,15 +1444,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1462,7 +1461,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1472,10 +1471,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1483,15 +1483,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1501,7 +1500,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1511,10 +1510,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1528,15 +1528,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1546,7 +1545,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1556,7 +1555,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1566,10 +1565,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1577,15 +1577,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1595,7 +1594,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1605,7 +1604,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1615,10 +1614,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1626,15 +1626,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1644,7 +1643,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1654,7 +1653,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1664,10 +1663,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1675,15 +1675,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1693,7 +1692,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1703,7 +1702,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1713,10 +1712,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1730,15 +1730,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1748,7 +1747,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1758,7 +1757,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1768,10 +1767,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1779,15 +1779,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1797,7 +1796,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1807,7 +1806,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1817,10 +1816,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1828,15 +1828,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1846,7 +1845,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1856,7 +1855,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1866,10 +1865,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1877,15 +1877,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1895,7 +1894,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1905,7 +1904,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1915,10 +1914,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1932,15 +1932,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1950,7 +1949,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1960,7 +1959,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1970,10 +1969,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1981,15 +1981,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1999,7 +1998,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2009,7 +2008,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2019,10 +2018,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2030,15 +2030,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2048,7 +2047,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2058,7 +2057,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2068,10 +2067,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2079,15 +2079,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2097,7 +2096,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2107,7 +2106,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2117,10 +2116,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -2134,15 +2134,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2152,7 +2151,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2162,7 +2161,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2172,10 +2171,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -2183,15 +2183,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2201,7 +2200,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2211,7 +2210,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2221,10 +2220,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2232,15 +2232,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2250,7 +2249,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2260,7 +2259,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2270,10 +2269,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2281,15 +2281,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2299,7 +2298,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2309,7 +2308,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2319,10 +2318,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -2336,15 +2336,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2354,10 +2353,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -2365,15 +2365,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2383,10 +2382,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2394,15 +2394,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2412,10 +2411,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2423,15 +2423,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2441,10 +2440,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -2458,15 +2458,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2476,7 +2475,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2486,10 +2485,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -2497,15 +2497,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2515,7 +2514,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2525,10 +2524,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2536,15 +2536,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2554,7 +2553,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2564,10 +2563,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2575,15 +2575,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2593,7 +2592,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2603,10 +2602,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -2620,15 +2620,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2638,7 +2637,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2648,7 +2647,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2658,10 +2657,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -2669,15 +2669,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2687,7 +2686,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2697,7 +2696,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2707,10 +2706,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2718,15 +2718,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2736,7 +2735,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2746,7 +2745,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2756,10 +2755,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2767,15 +2767,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2785,7 +2784,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2795,7 +2794,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2805,10 +2804,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -2822,24 +2822,6 @@
       "@id" : "contest-001",
       "@type" : "CVR.CandidateContest",
       "ContestSelection" : [ {
-        "@id" : "cs-c",
-        "@type" : "CVR.ContestSelection",
-        "Code" : [ {
-          "@type" : "CVR.Code",
-          "OtherType" : "vendor-label",
-          "Type" : "other",
-          "Value" : "C"
-        } ]
-      }, {
-        "@id" : "cs-d",
-        "@type" : "CVR.ContestSelection",
-        "Code" : [ {
-          "@type" : "CVR.Code",
-          "OtherType" : "vendor-label",
-          "Type" : "other",
-          "Value" : "D"
-        } ]
-      }, {
         "@id" : "cs-a",
         "@type" : "CVR.ContestSelection",
         "Code" : [ {
@@ -2857,11 +2839,29 @@
           "Type" : "other",
           "Value" : "B"
         } ]
+      }, {
+        "@id" : "cs-c",
+        "@type" : "CVR.ContestSelection",
+        "Code" : [ {
+          "@type" : "CVR.Code",
+          "OtherType" : "vendor-label",
+          "Type" : "other",
+          "Value" : "C"
+        } ]
+      }, {
+        "@id" : "cs-d",
+        "@type" : "CVR.ContestSelection",
+        "Code" : [ {
+          "@type" : "CVR.Code",
+          "OtherType" : "vendor-label",
+          "Type" : "other",
+          "Value" : "D"
+        } ]
       } ]
     } ],
     "ElectionScopeId" : "gpu-election"
   } ],
-  "GeneratedDate" : "2019-04-26T00:10:07-07:00",
+  "GeneratedDate" : "2019-05-01T17:43:53-07:00",
   "GpUnit" : [ {
     "@id" : "gpu-election",
     "@type" : "CVR.GpUnit",
@@ -2873,7 +2873,7 @@
   "ReportingDevice" : [ {
     "@id" : "rd-001",
     "@type" : "CVR.ReportingDevice",
-    "Application" : "RCV Universal Tabulator",
+    "Application" : "RCVRC Tabulator",
     "Manufacturer" : "Bright Spots"
   } ],
   "Version" : "1.0.0"

--- a/src/test/resources/test_data/test_set_7_duplicate_skip_to_next/test_set_7_duplicate_skip_to_next_expected_cvr_cdf.json
+++ b/src/test/resources/test_data/test_set_7_duplicate_skip_to_next/test_set_7_duplicate_skip_to_next_expected_cvr_cdf.json
@@ -18,11 +18,7 @@
             "IsAllocable" : "unknown",
             "NumberVotes" : "1",
             "Rank" : 1
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-d",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
@@ -57,14 +53,10 @@
             "IsAllocable" : "yes",
             "NumberVotes" : "1",
             "Rank" : 1
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-d",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
-            "IsAllocable" : "yes",
+            "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 2
           } ]
@@ -96,11 +88,7 @@
             "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 1
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-d",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
@@ -135,11 +123,7 @@
             "IsAllocable" : "no",
             "NumberVotes" : "1",
             "Rank" : 1
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-d",
-          "SelectionPosition" : [ {
+          }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
@@ -2877,7 +2861,7 @@
     } ],
     "ElectionScopeId" : "gpu-election"
   } ],
-  "GeneratedDate" : "2019-04-24T22:54:21-07:00",
+  "GeneratedDate" : "2019-04-26T00:10:07-07:00",
   "GpUnit" : [ {
     "@id" : "gpu-election",
     "@type" : "CVR.GpUnit",

--- a/src/test/resources/test_data/test_set_multi_winner_fractional_threshold/test_set_multi_winner_fractional_threshold_cvr.json
+++ b/src/test/resources/test_data/test_set_multi_winner_fractional_threshold/test_set_multi_winner_fractional_threshold_cvr.json
@@ -15,7 +15,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -25,7 +25,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -35,7 +35,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -45,7 +45,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -55,7 +55,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
         } ],
@@ -80,7 +80,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -90,7 +90,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -100,7 +100,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -110,7 +110,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -120,7 +120,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -130,7 +130,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
         } ],
@@ -155,7 +155,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -165,7 +165,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -175,7 +175,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -185,7 +185,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -195,7 +195,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -205,7 +205,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
         } ],
@@ -230,7 +230,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -240,7 +240,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -250,7 +250,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -260,7 +260,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         } ],
@@ -285,7 +285,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -295,7 +295,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
         } ],
@@ -320,7 +320,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -330,7 +330,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -340,7 +340,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -350,7 +350,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -360,7 +360,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -370,7 +370,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
         } ],
@@ -395,7 +395,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -405,7 +405,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -415,7 +415,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -425,7 +425,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         } ],
@@ -450,7 +450,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -460,7 +460,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -470,7 +470,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -480,7 +480,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -490,7 +490,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
         } ],
@@ -515,7 +515,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -525,7 +525,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -535,7 +535,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -545,7 +545,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -555,7 +555,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
         } ],
@@ -580,7 +580,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
         } ],
@@ -605,7 +605,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -615,7 +615,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -625,7 +625,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         } ],
@@ -650,13 +650,13 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           }, {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -666,7 +666,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -676,7 +676,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -686,7 +686,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -696,7 +696,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
         } ],
@@ -721,7 +721,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -731,7 +731,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -741,7 +741,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -751,7 +751,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
         } ],
@@ -776,7 +776,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -786,7 +786,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -796,7 +796,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -806,7 +806,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -816,7 +816,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
         } ],
@@ -841,7 +841,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -851,7 +851,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -861,7 +861,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -871,7 +871,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -881,7 +881,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -891,7 +891,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
         } ],
@@ -916,7 +916,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -926,7 +926,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -936,7 +936,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -946,7 +946,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
         } ],
@@ -971,7 +971,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -981,7 +981,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -991,7 +991,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1001,7 +1001,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -1011,7 +1011,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -1021,7 +1021,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
         } ],
@@ -1046,7 +1046,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1056,7 +1056,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1066,7 +1066,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1076,7 +1076,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -1086,7 +1086,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -1096,7 +1096,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
         } ],
@@ -1121,7 +1121,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1131,7 +1131,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1141,7 +1141,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1151,7 +1151,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         } ],
@@ -1176,7 +1176,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1186,7 +1186,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
         } ],
@@ -1211,7 +1211,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1221,7 +1221,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1231,7 +1231,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1241,7 +1241,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -1251,7 +1251,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -1261,7 +1261,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
         } ],
@@ -1286,7 +1286,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1296,7 +1296,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1306,7 +1306,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1316,7 +1316,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         } ],
@@ -1341,7 +1341,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1351,7 +1351,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1361,7 +1361,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1371,7 +1371,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -1381,7 +1381,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
         } ],
@@ -1406,7 +1406,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1416,7 +1416,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1426,7 +1426,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1436,7 +1436,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -1446,7 +1446,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -1456,7 +1456,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
         } ],
@@ -1481,7 +1481,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1491,7 +1491,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
         } ],
@@ -1516,7 +1516,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1526,7 +1526,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1536,7 +1536,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         } ],
@@ -1561,7 +1561,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1571,7 +1571,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1581,7 +1581,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1591,7 +1591,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -1601,7 +1601,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -1611,7 +1611,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
         } ],
@@ -1636,7 +1636,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1646,7 +1646,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1656,7 +1656,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -1666,7 +1666,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
         } ],
@@ -1691,7 +1691,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1701,7 +1701,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1711,7 +1711,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1721,7 +1721,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -1731,7 +1731,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
         } ],
@@ -1756,7 +1756,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1766,7 +1766,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1776,7 +1776,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1786,7 +1786,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -1796,7 +1796,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -1806,7 +1806,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
         } ],
@@ -1881,7 +1881,7 @@
     } ],
     "ElectionScopeId" : "gpu-election"
   } ],
-  "GeneratedDate" : "2019-05-01T12:59:07-07:00",
+  "GeneratedDate" : "2019-05-01T17:30:48-07:00",
   "GpUnit" : [ {
     "@id" : "gpu-election",
     "@type" : "CVR.GpUnit",

--- a/src/test/resources/test_data/test_set_multi_winner_fractional_threshold/test_set_multi_winner_fractional_threshold_cvr.json
+++ b/src/test/resources/test_data/test_set_multi_winner_fractional_threshold/test_set_multi_winner_fractional_threshold_cvr.json
@@ -8,8 +8,7 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
@@ -59,7 +58,8 @@
             "NumberVotes" : "1",
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -73,8 +73,7 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
@@ -134,7 +133,8 @@
             "NumberVotes" : "1",
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -148,8 +148,7 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
@@ -209,7 +208,8 @@
             "NumberVotes" : "1",
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -223,8 +223,7 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
@@ -264,7 +263,8 @@
             "NumberVotes" : "1",
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -278,8 +278,7 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
@@ -299,7 +298,8 @@
             "NumberVotes" : "1",
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -313,8 +313,7 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
@@ -374,7 +373,8 @@
             "NumberVotes" : "1",
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -388,8 +388,7 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
@@ -429,7 +428,8 @@
             "NumberVotes" : "1",
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -443,8 +443,7 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
@@ -494,7 +493,8 @@
             "NumberVotes" : "1",
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -508,8 +508,7 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
@@ -559,7 +558,8 @@
             "NumberVotes" : "1",
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -573,8 +573,7 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
@@ -584,7 +583,8 @@
             "NumberVotes" : "1",
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -598,8 +598,7 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
@@ -629,7 +628,8 @@
             "NumberVotes" : "1",
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -643,8 +643,7 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
@@ -700,7 +699,8 @@
             "NumberVotes" : "1",
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -714,8 +714,7 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
@@ -755,7 +754,8 @@
             "NumberVotes" : "1",
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -769,8 +769,7 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
@@ -820,7 +819,8 @@
             "NumberVotes" : "1",
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -834,8 +834,7 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
@@ -895,7 +894,8 @@
             "NumberVotes" : "1",
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -909,8 +909,7 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
@@ -950,7 +949,8 @@
             "NumberVotes" : "1",
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -964,8 +964,7 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
@@ -1025,7 +1024,8 @@
             "NumberVotes" : "1",
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -1039,8 +1039,7 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
@@ -1100,7 +1099,8 @@
             "NumberVotes" : "1",
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -1114,8 +1114,7 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
@@ -1155,7 +1154,8 @@
             "NumberVotes" : "1",
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -1169,8 +1169,7 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
@@ -1190,7 +1189,8 @@
             "NumberVotes" : "1",
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -1204,8 +1204,7 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
@@ -1265,7 +1264,8 @@
             "NumberVotes" : "1",
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -1279,8 +1279,7 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
@@ -1320,7 +1319,8 @@
             "NumberVotes" : "1",
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -1334,8 +1334,7 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
@@ -1385,7 +1384,8 @@
             "NumberVotes" : "1",
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -1399,8 +1399,7 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
@@ -1460,7 +1459,8 @@
             "NumberVotes" : "1",
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -1474,8 +1474,7 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
@@ -1495,7 +1494,8 @@
             "NumberVotes" : "1",
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -1509,8 +1509,7 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
@@ -1540,7 +1539,8 @@
             "NumberVotes" : "1",
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -1554,8 +1554,7 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
@@ -1615,7 +1614,8 @@
             "NumberVotes" : "1",
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -1629,8 +1629,7 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
@@ -1670,7 +1669,8 @@
             "NumberVotes" : "1",
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -1684,8 +1684,7 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
@@ -1735,7 +1734,8 @@
             "NumberVotes" : "1",
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -1749,8 +1749,7 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
@@ -1810,7 +1809,8 @@
             "NumberVotes" : "1",
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -1881,7 +1881,7 @@
     } ],
     "ElectionScopeId" : "gpu-election"
   } ],
-  "GeneratedDate" : "2019-04-26T23:01:11-07:00",
+  "GeneratedDate" : "2019-05-01T12:59:07-07:00",
   "GpUnit" : [ {
     "@id" : "gpu-election",
     "@type" : "CVR.GpUnit",
@@ -1893,7 +1893,7 @@
   "ReportingDevice" : [ {
     "@id" : "rd-001",
     "@type" : "CVR.ReportingDevice",
-    "Application" : "RCV Universal Tabulator",
+    "Application" : "RCVRC Tabulator",
     "Manufacturer" : "Bright Spots"
   } ],
   "Version" : "1.0.0"

--- a/src/test/resources/test_data/test_set_multi_winner_fractional_threshold/test_set_multi_winner_fractional_threshold_expected_cvr_cdf.json
+++ b/src/test/resources/test_data/test_set_multi_winner_fractional_threshold/test_set_multi_winner_fractional_threshold_expected_cvr_cdf.json
@@ -8,15 +8,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -26,7 +25,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -36,7 +35,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -46,7 +45,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -56,10 +55,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -67,15 +67,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -85,7 +84,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -95,7 +94,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -105,7 +104,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -115,10 +114,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -126,15 +126,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -144,7 +143,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -154,7 +153,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -164,7 +163,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -174,10 +173,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -185,15 +185,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -201,9 +200,10 @@
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".9063",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.9063",
+            "NumberVotes" : 0,
             "Rank" : 3
           } ]
         }, {
@@ -211,9 +211,10 @@
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".0937",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.0937",
+            "NumberVotes" : 0,
             "Rank" : 4
           } ]
         }, {
@@ -223,7 +224,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -233,10 +234,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -244,15 +246,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -260,9 +261,10 @@
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".9063",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.9063",
+            "NumberVotes" : 0,
             "Rank" : 3
           } ]
         }, {
@@ -270,9 +272,10 @@
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".0937",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.0937",
+            "NumberVotes" : 0,
             "Rank" : 4
           } ]
         }, {
@@ -282,7 +285,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -292,10 +295,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -303,15 +307,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -319,9 +322,10 @@
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".9063",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.9063",
+            "NumberVotes" : 0,
             "Rank" : 3
           } ]
         }, {
@@ -331,7 +335,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -341,7 +345,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -349,12 +353,14 @@
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".0937",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.0937",
+            "NumberVotes" : 0,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -362,15 +368,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -378,9 +383,10 @@
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".9063",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.9063",
+            "NumberVotes" : 0,
             "Rank" : 3
           } ]
         }, {
@@ -390,7 +396,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -400,7 +406,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -408,12 +414,14 @@
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".0661",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.0661",
+            "NumberVotes" : 0,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -427,15 +435,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -445,7 +452,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -455,7 +462,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -465,7 +472,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -475,7 +482,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -485,10 +492,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -496,15 +504,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -514,7 +521,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -524,7 +531,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -534,7 +541,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -544,7 +551,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -554,10 +561,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -565,15 +573,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -583,7 +590,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -593,7 +600,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -603,7 +610,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -613,7 +620,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -623,10 +630,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -634,15 +642,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -652,7 +659,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -662,7 +669,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -672,7 +679,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -682,7 +689,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -692,10 +699,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -703,15 +711,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -721,7 +728,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -731,7 +738,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -741,7 +748,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -751,7 +758,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -761,10 +768,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -772,15 +780,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -790,7 +797,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -800,7 +807,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -810,7 +817,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -820,7 +827,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -830,10 +837,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -841,15 +849,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -859,7 +866,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -869,7 +876,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -877,9 +884,10 @@
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".7052",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.7052",
+            "NumberVotes" : 0,
             "Rank" : 4
           } ]
         }, {
@@ -889,7 +897,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -899,10 +907,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -916,15 +925,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -934,7 +942,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -944,7 +952,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -954,7 +962,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -964,7 +972,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -974,10 +982,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -985,15 +994,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1003,7 +1011,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1013,7 +1021,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1023,7 +1031,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -1033,7 +1041,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -1043,10 +1051,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1054,15 +1063,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1072,7 +1080,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1082,7 +1090,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1092,7 +1100,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -1102,7 +1110,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -1112,10 +1120,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1123,15 +1132,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".9063",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.9063",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -1139,9 +1148,10 @@
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".0937",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.0937",
+            "NumberVotes" : 0,
             "Rank" : 2
           } ]
         }, {
@@ -1151,7 +1161,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1161,7 +1171,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -1171,7 +1181,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -1181,10 +1191,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1192,15 +1203,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".9063",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.9063",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -1208,9 +1219,10 @@
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".0937",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.0937",
+            "NumberVotes" : 0,
             "Rank" : 2
           } ]
         }, {
@@ -1220,7 +1232,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1230,7 +1242,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -1240,7 +1252,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -1250,10 +1262,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1261,15 +1274,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".9063",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.9063",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -1279,7 +1292,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1287,9 +1300,10 @@
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".0937",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.0937",
+            "NumberVotes" : 0,
             "Rank" : 3
           } ]
         }, {
@@ -1299,7 +1313,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -1309,7 +1323,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -1319,10 +1333,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1330,15 +1345,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".9063",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.9063",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -1348,7 +1363,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1356,9 +1371,10 @@
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".0661",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.0661",
+            "NumberVotes" : 0,
             "Rank" : 3
           } ]
         }, {
@@ -1368,7 +1384,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -1378,7 +1394,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -1388,10 +1404,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1405,15 +1422,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1423,7 +1439,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1433,7 +1449,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1443,10 +1459,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1454,15 +1471,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1472,7 +1488,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1482,7 +1498,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1492,10 +1508,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1503,15 +1520,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1521,7 +1537,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1531,7 +1547,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1541,10 +1557,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1552,15 +1569,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1570,7 +1586,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1580,7 +1596,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1590,10 +1606,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1601,15 +1618,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1619,7 +1635,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1629,7 +1645,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1639,10 +1655,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1650,15 +1667,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1668,7 +1684,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1678,7 +1694,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1688,10 +1704,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1699,15 +1716,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1717,7 +1733,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1725,9 +1741,10 @@
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".7183",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.7183",
+            "NumberVotes" : 0,
             "Rank" : 3
           } ]
         }, {
@@ -1737,10 +1754,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1754,15 +1772,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1772,10 +1789,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1783,15 +1801,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1801,10 +1818,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1812,15 +1830,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1830,10 +1847,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1841,15 +1859,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1859,10 +1876,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1870,15 +1888,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1888,10 +1905,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1899,15 +1917,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1917,10 +1934,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1928,15 +1946,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".7183",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.7183",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -1946,10 +1964,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1963,15 +1982,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1981,7 +1999,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1991,7 +2009,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2001,7 +2019,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -2011,7 +2029,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -2021,10 +2039,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -2032,15 +2051,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2050,7 +2068,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2060,7 +2078,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2070,7 +2088,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -2080,7 +2098,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -2090,10 +2108,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2101,15 +2120,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2119,7 +2137,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2129,7 +2147,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2139,7 +2157,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -2149,7 +2167,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -2159,10 +2177,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2170,15 +2189,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2188,7 +2206,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2198,7 +2216,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2208,7 +2226,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -2218,7 +2236,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -2228,10 +2246,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2239,15 +2258,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2257,7 +2275,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2267,7 +2285,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2277,7 +2295,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -2287,7 +2305,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -2297,10 +2315,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2308,15 +2327,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2326,7 +2344,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2336,7 +2354,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2346,7 +2364,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -2356,7 +2374,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -2366,10 +2384,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2377,15 +2396,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2393,9 +2411,10 @@
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".7052",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.7052",
+            "NumberVotes" : 0,
             "Rank" : 2
           } ]
         }, {
@@ -2405,7 +2424,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2415,7 +2434,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -2425,7 +2444,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -2435,10 +2454,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -2452,15 +2472,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2470,7 +2489,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2480,7 +2499,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2490,10 +2509,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -2501,15 +2521,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2519,7 +2538,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2529,7 +2548,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2539,10 +2558,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2550,15 +2570,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2568,7 +2587,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2578,7 +2597,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2588,10 +2607,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2599,15 +2619,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2617,7 +2636,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2627,7 +2646,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2637,10 +2656,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2648,15 +2668,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2666,7 +2685,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2676,7 +2695,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2686,10 +2705,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2697,15 +2717,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2715,7 +2734,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2725,7 +2744,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2735,10 +2754,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2746,15 +2766,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".7183",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.7183",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -2764,7 +2784,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2774,7 +2794,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2784,10 +2804,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -2801,15 +2822,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2819,7 +2839,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2829,7 +2849,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2839,7 +2859,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -2849,10 +2869,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -2860,15 +2881,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2878,7 +2898,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2888,7 +2908,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2898,7 +2918,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -2908,10 +2928,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2919,15 +2940,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2937,7 +2957,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2947,7 +2967,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2957,7 +2977,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -2967,10 +2987,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2978,15 +2999,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2996,7 +3016,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -3006,7 +3026,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -3016,7 +3036,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -3026,10 +3046,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3037,15 +3058,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -3055,7 +3075,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -3065,7 +3085,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -3075,7 +3095,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -3085,10 +3105,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3096,15 +3117,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -3114,7 +3134,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -3124,7 +3144,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -3134,7 +3154,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -3144,10 +3164,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3155,15 +3176,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".7052",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.7052",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -3173,7 +3194,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -3183,7 +3204,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -3193,7 +3214,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -3203,10 +3224,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -3220,15 +3242,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -3238,7 +3259,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -3248,7 +3269,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -3258,7 +3279,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -3268,10 +3289,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -3279,15 +3301,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -3297,7 +3318,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -3307,7 +3328,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -3317,7 +3338,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -3327,10 +3348,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3338,15 +3360,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -3356,7 +3377,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -3366,7 +3387,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -3376,7 +3397,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -3386,10 +3407,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3397,15 +3419,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".9063",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.9063",
+            "NumberVotes" : 0,
             "Rank" : 2
           } ]
         }, {
@@ -3413,9 +3435,10 @@
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".0937",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.0937",
+            "NumberVotes" : 0,
             "Rank" : 3
           } ]
         }, {
@@ -3425,7 +3448,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -3435,7 +3458,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -3445,10 +3468,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3456,15 +3480,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".9063",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.9063",
+            "NumberVotes" : 0,
             "Rank" : 2
           } ]
         }, {
@@ -3474,7 +3498,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -3484,7 +3508,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -3492,9 +3516,10 @@
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".0937",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.0937",
+            "NumberVotes" : 0,
             "Rank" : 5
           } ]
         }, {
@@ -3504,10 +3529,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3515,15 +3541,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".9063",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.9063",
+            "NumberVotes" : 0,
             "Rank" : 2
           } ]
         }, {
@@ -3533,7 +3559,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -3543,7 +3569,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -3551,9 +3577,10 @@
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".0937",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.0937",
+            "NumberVotes" : 0,
             "Rank" : 5
           } ]
         }, {
@@ -3563,10 +3590,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3574,15 +3602,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".9063",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.9063",
+            "NumberVotes" : 0,
             "Rank" : 2
           } ]
         }, {
@@ -3592,7 +3620,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -3602,7 +3630,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -3610,9 +3638,10 @@
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".0674",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.0674",
+            "NumberVotes" : 0,
             "Rank" : 5
           } ]
         }, {
@@ -3622,10 +3651,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -3639,18 +3669,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -3658,18 +3688,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3677,18 +3707,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3696,18 +3726,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3715,18 +3745,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3734,18 +3764,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3753,18 +3783,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -3778,15 +3808,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -3796,7 +3825,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -3806,10 +3835,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -3817,15 +3847,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -3835,7 +3864,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -3845,10 +3874,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3856,15 +3886,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -3874,7 +3903,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -3884,10 +3913,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3895,15 +3925,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".9063",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.9063",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -3911,9 +3941,10 @@
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".0937",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.0937",
+            "NumberVotes" : 0,
             "Rank" : 2
           } ]
         }, {
@@ -3923,10 +3954,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3934,15 +3966,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".9063",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.9063",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -3950,9 +3982,10 @@
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".0937",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.0937",
+            "NumberVotes" : 0,
             "Rank" : 2
           } ]
         }, {
@@ -3962,10 +3995,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3973,15 +4007,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".9063",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.9063",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -3991,7 +4025,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -4001,10 +4035,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -4012,15 +4047,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".9063",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.9063",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -4030,7 +4065,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -4040,10 +4075,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -4057,16 +4093,21 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
+          }, {
+            "@type" : "CVR.SelectionPosition",
+            "HasIndication" : "yes",
+            "IsAllocable" : "unknown",
+            "NumberVotes" : 1,
+            "Rank" : 3
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
@@ -4075,18 +4116,8 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-f",
-          "SelectionPosition" : [ {
-            "@type" : "CVR.SelectionPosition",
-            "HasIndication" : "yes",
-            "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
-            "Rank" : 3
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
@@ -4095,7 +4126,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -4105,7 +4136,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -4115,10 +4146,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -4126,16 +4158,21 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
+          }, {
+            "@type" : "CVR.SelectionPosition",
+            "HasIndication" : "yes",
+            "IsAllocable" : "no",
+            "NumberVotes" : 1,
+            "Rank" : 3
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
@@ -4144,18 +4181,8 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-f",
-          "SelectionPosition" : [ {
-            "@type" : "CVR.SelectionPosition",
-            "HasIndication" : "yes",
-            "IsAllocable" : "yes",
-            "NumberVotes" : "1",
-            "Rank" : 3
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
@@ -4164,7 +4191,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -4174,7 +4201,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -4184,10 +4211,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -4195,16 +4223,21 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
+          }, {
+            "@type" : "CVR.SelectionPosition",
+            "HasIndication" : "yes",
+            "IsAllocable" : "no",
+            "NumberVotes" : 1,
+            "Rank" : 3
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
@@ -4213,18 +4246,8 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-f",
-          "SelectionPosition" : [ {
-            "@type" : "CVR.SelectionPosition",
-            "HasIndication" : "yes",
-            "IsAllocable" : "yes",
-            "NumberVotes" : "1",
-            "Rank" : 3
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
@@ -4233,7 +4256,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -4243,7 +4266,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -4253,10 +4276,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -4264,16 +4288,21 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
+          }, {
+            "@type" : "CVR.SelectionPosition",
+            "HasIndication" : "yes",
+            "IsAllocable" : "no",
+            "NumberVotes" : 1,
+            "Rank" : 3
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
@@ -4282,18 +4311,8 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-f",
-          "SelectionPosition" : [ {
-            "@type" : "CVR.SelectionPosition",
-            "HasIndication" : "yes",
-            "IsAllocable" : "yes",
-            "NumberVotes" : "1",
-            "Rank" : 3
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
@@ -4302,7 +4321,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -4312,7 +4331,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -4322,10 +4341,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -4333,16 +4353,21 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
+          }, {
+            "@type" : "CVR.SelectionPosition",
+            "HasIndication" : "yes",
+            "IsAllocable" : "no",
+            "NumberVotes" : 1,
+            "Rank" : 3
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
@@ -4351,18 +4376,8 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-f",
-          "SelectionPosition" : [ {
-            "@type" : "CVR.SelectionPosition",
-            "HasIndication" : "yes",
-            "IsAllocable" : "no",
-            "NumberVotes" : "1",
-            "Rank" : 3
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
@@ -4371,7 +4386,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -4381,7 +4396,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -4391,10 +4406,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -4402,16 +4418,21 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
+          }, {
+            "@type" : "CVR.SelectionPosition",
+            "HasIndication" : "yes",
+            "IsAllocable" : "no",
+            "NumberVotes" : 1,
+            "Rank" : 3
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
@@ -4420,18 +4441,8 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-f",
-          "SelectionPosition" : [ {
-            "@type" : "CVR.SelectionPosition",
-            "HasIndication" : "yes",
-            "IsAllocable" : "no",
-            "NumberVotes" : "1",
-            "Rank" : 3
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
@@ -4440,7 +4451,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -4450,7 +4461,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -4460,10 +4471,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -4471,16 +4483,21 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
+          }, {
+            "@type" : "CVR.SelectionPosition",
+            "HasIndication" : "yes",
+            "IsAllocable" : "no",
+            "NumberVotes" : 1,
+            "Rank" : 3
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
@@ -4489,18 +4506,8 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-f",
-          "SelectionPosition" : [ {
-            "@type" : "CVR.SelectionPosition",
-            "HasIndication" : "yes",
-            "IsAllocable" : "no",
-            "NumberVotes" : "1",
-            "Rank" : 3
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
@@ -4509,7 +4516,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -4517,9 +4524,10 @@
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".7183",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.7183",
+            "NumberVotes" : 0,
             "Rank" : 5
           } ]
         }, {
@@ -4529,10 +4537,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -4546,15 +4555,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -4564,7 +4572,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -4574,7 +4582,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -4584,10 +4592,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -4595,15 +4604,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -4613,7 +4621,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -4623,7 +4631,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -4633,10 +4641,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -4644,15 +4653,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -4662,7 +4670,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -4672,7 +4680,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -4682,10 +4690,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -4693,15 +4702,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".9063",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.9063",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -4709,9 +4718,10 @@
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".0937",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.0937",
+            "NumberVotes" : 0,
             "Rank" : 2
           } ]
         }, {
@@ -4721,7 +4731,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -4731,10 +4741,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -4742,15 +4753,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".9063",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.9063",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -4758,9 +4769,10 @@
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".0937",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.0937",
+            "NumberVotes" : 0,
             "Rank" : 2
           } ]
         }, {
@@ -4770,7 +4782,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -4780,10 +4792,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -4791,15 +4804,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".9063",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.9063",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -4809,7 +4822,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -4819,7 +4832,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -4829,10 +4842,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -4840,15 +4854,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".9063",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.9063",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -4858,7 +4872,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -4868,7 +4882,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -4878,10 +4892,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -4895,15 +4910,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -4913,7 +4927,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -4923,7 +4937,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -4933,7 +4947,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -4943,10 +4957,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -4954,15 +4969,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -4972,7 +4986,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -4982,7 +4996,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -4992,7 +5006,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -5002,10 +5016,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -5013,15 +5028,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5031,7 +5045,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -5041,7 +5055,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -5051,7 +5065,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -5061,10 +5075,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -5072,15 +5087,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5090,7 +5104,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -5100,7 +5114,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -5110,7 +5124,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -5120,10 +5134,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -5131,15 +5146,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5149,7 +5163,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -5159,7 +5173,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -5169,7 +5183,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -5179,10 +5193,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -5190,15 +5205,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5208,7 +5222,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -5218,7 +5232,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -5228,7 +5242,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -5238,10 +5252,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -5249,15 +5264,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5267,7 +5281,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -5275,9 +5289,10 @@
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".7183",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.7183",
+            "NumberVotes" : 0,
             "Rank" : 3
           } ]
         }, {
@@ -5287,7 +5302,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -5297,10 +5312,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -5314,15 +5330,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5332,7 +5347,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -5342,7 +5357,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -5352,7 +5367,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -5362,7 +5377,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -5372,10 +5387,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -5383,15 +5399,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5401,7 +5416,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -5411,7 +5426,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -5421,7 +5436,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -5431,7 +5446,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -5441,10 +5456,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -5452,15 +5468,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5470,7 +5485,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -5480,7 +5495,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -5490,7 +5505,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -5500,7 +5515,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -5510,10 +5525,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -5521,15 +5537,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5539,7 +5554,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -5549,7 +5564,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -5559,7 +5574,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -5569,7 +5584,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -5579,10 +5594,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -5590,15 +5606,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5608,7 +5623,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -5618,7 +5633,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -5628,7 +5643,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -5638,7 +5653,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -5648,10 +5663,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -5659,15 +5675,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5677,7 +5692,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -5687,7 +5702,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -5697,7 +5712,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -5707,7 +5722,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -5717,10 +5732,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -5728,15 +5744,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".7052",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.7052",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -5746,7 +5762,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -5756,7 +5772,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -5766,7 +5782,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -5776,7 +5792,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -5786,10 +5802,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -5803,15 +5820,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5821,7 +5837,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -5831,7 +5847,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -5841,10 +5857,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -5852,15 +5869,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5870,7 +5886,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -5880,7 +5896,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -5890,10 +5906,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -5901,15 +5918,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5919,7 +5935,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -5929,7 +5945,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -5939,10 +5955,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -5950,15 +5967,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5968,7 +5984,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -5978,7 +5994,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -5988,10 +6004,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -5999,15 +6016,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6017,7 +6033,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -6027,7 +6043,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -6037,10 +6053,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -6048,15 +6065,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6066,7 +6082,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -6076,7 +6092,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -6086,10 +6102,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -6097,15 +6114,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6115,7 +6131,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -6125,7 +6141,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -6135,10 +6151,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -6152,15 +6169,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6170,7 +6186,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -6180,7 +6196,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -6190,7 +6206,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -6200,7 +6216,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -6210,10 +6226,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -6221,15 +6238,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6239,7 +6255,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -6249,7 +6265,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -6259,7 +6275,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -6269,7 +6285,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -6279,10 +6295,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -6290,15 +6307,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6308,7 +6324,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -6318,7 +6334,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -6328,7 +6344,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -6338,7 +6354,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -6348,10 +6364,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -6359,15 +6376,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6377,7 +6393,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -6387,7 +6403,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -6397,7 +6413,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -6407,7 +6423,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -6417,10 +6433,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -6428,15 +6445,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6446,7 +6462,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -6456,7 +6472,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -6466,7 +6482,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -6476,7 +6492,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -6486,10 +6502,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -6497,15 +6514,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6515,7 +6531,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -6525,7 +6541,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -6535,7 +6551,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -6545,7 +6561,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -6555,10 +6571,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -6566,15 +6583,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6584,7 +6600,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -6594,7 +6610,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -6602,9 +6618,10 @@
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".7052",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.7052",
+            "NumberVotes" : 0,
             "Rank" : 4
           } ]
         }, {
@@ -6614,7 +6631,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -6624,10 +6641,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -6641,15 +6659,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6659,7 +6676,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -6669,7 +6686,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -6679,7 +6696,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -6689,7 +6706,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -6699,10 +6716,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -6710,15 +6728,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6728,7 +6745,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -6738,7 +6755,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -6748,7 +6765,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -6758,7 +6775,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -6768,10 +6785,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -6779,15 +6797,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6797,7 +6814,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -6807,7 +6824,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -6817,7 +6834,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -6827,7 +6844,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -6837,10 +6854,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -6848,15 +6866,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".9063",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.9063",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -6864,9 +6882,10 @@
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".0937",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.0937",
+            "NumberVotes" : 0,
             "Rank" : 2
           } ]
         }, {
@@ -6876,7 +6895,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -6886,7 +6905,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -6896,7 +6915,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -6906,10 +6925,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -6917,15 +6937,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".9063",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.9063",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -6933,9 +6953,10 @@
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".0937",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.0937",
+            "NumberVotes" : 0,
             "Rank" : 2
           } ]
         }, {
@@ -6945,7 +6966,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -6955,7 +6976,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -6965,7 +6986,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -6975,10 +6996,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -6986,15 +7008,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".9063",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.9063",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -7004,7 +7026,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -7012,9 +7034,10 @@
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".0937",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.0937",
+            "NumberVotes" : 0,
             "Rank" : 3
           } ]
         }, {
@@ -7024,7 +7047,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -7034,7 +7057,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -7044,10 +7067,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -7055,15 +7079,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".9063",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.9063",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -7073,7 +7097,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -7081,9 +7105,10 @@
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".0661",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.0661",
+            "NumberVotes" : 0,
             "Rank" : 3
           } ]
         }, {
@@ -7093,7 +7118,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -7103,7 +7128,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -7113,10 +7138,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -7130,15 +7156,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7148,7 +7173,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -7158,7 +7183,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -7168,10 +7193,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -7179,15 +7205,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7197,7 +7222,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -7207,7 +7232,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -7217,10 +7242,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -7228,15 +7254,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7246,7 +7271,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -7256,7 +7281,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -7266,10 +7291,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -7277,15 +7303,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7295,7 +7320,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -7305,7 +7330,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -7315,10 +7340,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -7326,15 +7352,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7344,7 +7369,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -7354,7 +7379,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -7364,10 +7389,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -7375,15 +7401,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7393,7 +7418,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -7403,7 +7428,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -7413,10 +7438,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -7424,15 +7450,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".7052",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.7052",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -7442,7 +7468,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -7452,7 +7478,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -7462,10 +7488,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -7479,15 +7506,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7497,10 +7523,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -7508,15 +7535,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7526,10 +7552,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -7537,15 +7564,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7555,10 +7581,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -7566,15 +7593,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7584,10 +7610,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -7595,15 +7622,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7613,10 +7639,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -7624,15 +7651,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7642,10 +7668,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -7653,15 +7680,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".7183",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.7183",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -7671,10 +7698,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -7688,15 +7716,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7706,7 +7733,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -7716,7 +7743,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -7726,7 +7753,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -7736,7 +7763,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -7746,10 +7773,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -7757,15 +7785,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7775,7 +7802,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -7785,7 +7812,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -7795,7 +7822,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -7805,7 +7832,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -7815,10 +7842,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -7826,15 +7854,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7844,7 +7871,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -7854,7 +7881,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -7864,7 +7891,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -7874,7 +7901,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -7884,10 +7911,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -7895,15 +7923,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7913,7 +7940,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -7923,7 +7950,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -7933,7 +7960,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -7943,7 +7970,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -7953,10 +7980,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -7964,15 +7992,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7982,7 +8009,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -7992,7 +8019,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -8002,7 +8029,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -8012,7 +8039,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -8022,10 +8049,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -8033,15 +8061,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8051,7 +8078,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8061,7 +8088,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -8071,7 +8098,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -8081,7 +8108,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -8091,10 +8118,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -8102,15 +8130,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8118,9 +8145,10 @@
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".7052",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.7052",
+            "NumberVotes" : 0,
             "Rank" : 2
           } ]
         }, {
@@ -8130,7 +8158,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -8140,7 +8168,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -8150,7 +8178,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -8160,10 +8188,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -8177,15 +8206,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8195,7 +8223,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8205,7 +8233,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -8215,10 +8243,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -8226,15 +8255,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8244,7 +8272,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8254,7 +8282,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -8264,10 +8292,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -8275,15 +8304,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8293,7 +8321,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8303,7 +8331,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -8313,10 +8341,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -8324,15 +8353,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8342,7 +8370,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8352,7 +8380,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -8362,10 +8390,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -8373,15 +8402,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8391,7 +8419,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8401,7 +8429,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -8411,10 +8439,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -8422,15 +8451,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8440,7 +8468,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8450,7 +8478,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -8460,10 +8488,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -8471,15 +8500,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".7183",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.7183",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -8489,7 +8518,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8499,7 +8528,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -8509,10 +8538,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -8526,15 +8556,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8544,7 +8573,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8554,7 +8583,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -8564,7 +8593,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -8574,10 +8603,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -8585,15 +8615,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8603,7 +8632,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8613,7 +8642,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -8623,7 +8652,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -8633,10 +8662,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -8644,15 +8674,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8662,7 +8691,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8672,7 +8701,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -8682,7 +8711,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -8692,10 +8721,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -8703,15 +8733,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8721,7 +8750,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8731,7 +8760,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -8741,7 +8770,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -8751,10 +8780,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -8762,15 +8792,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8780,7 +8809,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8790,7 +8819,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -8800,7 +8829,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -8810,10 +8839,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -8821,15 +8851,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8839,7 +8868,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8849,7 +8878,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -8859,7 +8888,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -8869,10 +8898,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -8880,15 +8910,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".7052",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.7052",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -8898,7 +8928,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8908,7 +8938,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -8918,7 +8948,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -8928,10 +8958,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -8945,15 +8976,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8963,7 +8993,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8973,7 +9003,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -8983,7 +9013,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -8993,7 +9023,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -9003,10 +9033,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -9014,15 +9045,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9032,7 +9062,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -9042,7 +9072,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -9052,7 +9082,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -9062,7 +9092,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -9072,10 +9102,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -9083,15 +9114,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9101,7 +9131,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -9111,7 +9141,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -9121,7 +9151,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -9131,7 +9161,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -9141,10 +9171,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -9152,15 +9183,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9170,7 +9200,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -9180,7 +9210,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -9190,7 +9220,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -9200,7 +9230,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -9210,10 +9240,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -9221,15 +9252,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9239,7 +9269,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -9249,7 +9279,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -9259,7 +9289,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -9269,7 +9299,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -9279,10 +9309,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -9290,15 +9321,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9308,7 +9338,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -9318,7 +9348,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -9328,7 +9358,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -9338,7 +9368,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -9348,10 +9378,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -9359,15 +9390,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9377,7 +9407,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -9387,7 +9417,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -9397,7 +9427,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -9405,9 +9435,10 @@
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".7183",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.7183",
+            "NumberVotes" : 0,
             "Rank" : 5
           } ]
         }, {
@@ -9417,10 +9448,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -9434,15 +9466,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9452,10 +9483,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -9463,15 +9495,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9481,10 +9512,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -9492,15 +9524,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9510,10 +9541,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -9521,15 +9553,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9539,10 +9570,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -9550,15 +9582,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9568,10 +9599,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -9579,15 +9611,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9597,10 +9628,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -9608,15 +9640,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".7052",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.7052",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -9626,10 +9658,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -9643,15 +9676,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9661,7 +9693,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -9671,10 +9703,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -9682,15 +9715,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9700,7 +9732,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -9710,10 +9742,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -9721,15 +9754,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9739,7 +9771,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -9749,10 +9781,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -9760,15 +9793,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".9063",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.9063",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -9776,9 +9809,10 @@
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".0937",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.0937",
+            "NumberVotes" : 0,
             "Rank" : 2
           } ]
         }, {
@@ -9788,10 +9822,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -9799,15 +9834,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".9063",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.9063",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -9815,9 +9850,10 @@
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".0937",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.0937",
+            "NumberVotes" : 0,
             "Rank" : 2
           } ]
         }, {
@@ -9827,10 +9863,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -9838,15 +9875,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".9063",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.9063",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -9856,7 +9893,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -9866,10 +9903,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -9877,15 +9915,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".9063",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.9063",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -9895,7 +9933,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -9905,10 +9943,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -9922,15 +9961,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9940,7 +9978,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -9950,7 +9988,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -9960,7 +9998,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -9970,7 +10008,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -9980,10 +10018,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -9991,15 +10030,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -10009,7 +10047,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -10019,7 +10057,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -10029,7 +10067,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -10039,7 +10077,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -10049,10 +10087,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -10060,15 +10099,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -10078,7 +10116,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -10088,7 +10126,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -10098,7 +10136,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -10108,7 +10146,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -10118,10 +10156,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -10129,15 +10168,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -10147,7 +10185,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -10157,7 +10195,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -10167,7 +10205,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -10177,7 +10215,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -10187,10 +10225,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -10198,15 +10237,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -10216,7 +10254,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -10226,7 +10264,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -10236,7 +10274,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -10246,7 +10284,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -10256,10 +10294,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -10267,15 +10306,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -10285,7 +10323,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -10295,7 +10333,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -10305,7 +10343,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -10315,7 +10353,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -10325,10 +10363,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -10336,15 +10375,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -10354,7 +10392,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -10364,7 +10402,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -10374,7 +10412,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -10382,9 +10420,10 @@
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".7183",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.7183",
+            "NumberVotes" : 0,
             "Rank" : 5
           } ]
         }, {
@@ -10394,10 +10433,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -10411,15 +10451,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -10429,7 +10468,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -10439,7 +10478,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -10449,10 +10488,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -10460,15 +10500,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -10478,7 +10517,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -10488,7 +10527,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -10498,10 +10537,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -10509,15 +10549,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -10527,7 +10566,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -10537,7 +10576,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -10547,10 +10586,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -10558,15 +10598,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".9063",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.9063",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -10574,9 +10614,10 @@
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".0937",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.0937",
+            "NumberVotes" : 0,
             "Rank" : 2
           } ]
         }, {
@@ -10586,7 +10627,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -10596,10 +10637,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -10607,15 +10649,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".9063",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.9063",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -10623,9 +10665,10 @@
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".0937",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.0937",
+            "NumberVotes" : 0,
             "Rank" : 2
           } ]
         }, {
@@ -10635,7 +10678,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -10645,10 +10688,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -10656,15 +10700,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".9063",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.9063",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -10674,7 +10718,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -10684,7 +10728,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -10694,10 +10738,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -10705,15 +10750,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".9063",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.9063",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -10723,7 +10768,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -10733,7 +10778,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -10743,10 +10788,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -10760,15 +10806,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -10778,7 +10823,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -10788,7 +10833,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -10798,7 +10843,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -10808,10 +10853,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -10819,15 +10865,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -10837,7 +10882,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -10847,7 +10892,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -10857,7 +10902,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -10867,10 +10912,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -10878,15 +10924,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -10896,7 +10941,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -10906,7 +10951,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -10916,7 +10961,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -10926,10 +10971,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -10937,15 +10983,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -10955,7 +11000,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -10965,7 +11010,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -10975,7 +11020,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -10985,10 +11030,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -10996,15 +11042,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -11014,7 +11059,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -11024,7 +11069,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -11034,7 +11079,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -11044,10 +11089,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -11055,15 +11101,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -11073,7 +11118,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -11083,7 +11128,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -11093,7 +11138,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -11103,10 +11148,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -11114,15 +11160,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".7183",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.7183",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -11132,7 +11178,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -11142,7 +11188,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -11152,7 +11198,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -11162,10 +11208,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -11179,15 +11226,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -11197,7 +11243,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -11207,7 +11253,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -11217,7 +11263,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -11227,7 +11273,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -11237,10 +11283,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -11248,15 +11295,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -11266,7 +11312,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -11276,7 +11322,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -11286,7 +11332,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -11296,7 +11342,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -11306,10 +11352,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -11317,15 +11364,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -11335,7 +11381,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -11345,7 +11391,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -11355,7 +11401,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -11365,7 +11411,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -11375,10 +11421,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -11386,15 +11433,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -11404,7 +11450,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -11414,7 +11460,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -11424,7 +11470,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -11434,7 +11480,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -11444,10 +11490,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -11455,15 +11502,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -11473,7 +11519,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -11483,7 +11529,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -11493,7 +11539,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -11503,7 +11549,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -11513,10 +11559,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -11524,15 +11571,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -11542,7 +11588,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -11552,7 +11598,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -11562,7 +11608,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -11572,7 +11618,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -11582,10 +11628,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -11593,15 +11640,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".7052",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.7052",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -11611,7 +11658,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -11621,7 +11668,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -11631,7 +11678,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -11641,7 +11688,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -11651,10 +11698,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -11668,22 +11716,22 @@
       "@id" : "contest-001",
       "@type" : "CVR.CandidateContest",
       "ContestSelection" : [ {
-        "@id" : "cs-e",
+        "@id" : "cs-a",
         "@type" : "CVR.ContestSelection",
         "Code" : [ {
           "@type" : "CVR.Code",
           "OtherType" : "vendor-label",
           "Type" : "other",
-          "Value" : "E"
+          "Value" : "A"
         } ]
       }, {
-        "@id" : "cs-f",
+        "@id" : "cs-b",
         "@type" : "CVR.ContestSelection",
         "Code" : [ {
           "@type" : "CVR.Code",
           "OtherType" : "vendor-label",
           "Type" : "other",
-          "Value" : "F"
+          "Value" : "B"
         } ]
       }, {
         "@id" : "cs-c",
@@ -11704,28 +11752,28 @@
           "Value" : "D"
         } ]
       }, {
-        "@id" : "cs-a",
+        "@id" : "cs-e",
         "@type" : "CVR.ContestSelection",
         "Code" : [ {
           "@type" : "CVR.Code",
           "OtherType" : "vendor-label",
           "Type" : "other",
-          "Value" : "A"
+          "Value" : "E"
         } ]
       }, {
-        "@id" : "cs-b",
+        "@id" : "cs-f",
         "@type" : "CVR.ContestSelection",
         "Code" : [ {
           "@type" : "CVR.Code",
           "OtherType" : "vendor-label",
           "Type" : "other",
-          "Value" : "B"
+          "Value" : "F"
         } ]
       } ]
     } ],
     "ElectionScopeId" : "gpu-election"
   } ],
-  "GeneratedDate" : "2019-04-26T23:31:44-07:00",
+  "GeneratedDate" : "2019-05-01T17:39:11-07:00",
   "GpUnit" : [ {
     "@id" : "gpu-election",
     "@type" : "CVR.GpUnit",
@@ -11737,7 +11785,7 @@
   "ReportingDevice" : [ {
     "@id" : "rd-001",
     "@type" : "CVR.ReportingDevice",
-    "Application" : "RCV Universal Tabulator",
+    "Application" : "RCVRC Tabulator",
     "Manufacturer" : "Bright Spots"
   } ],
   "Version" : "1.0.0"

--- a/src/test/resources/test_data/test_set_multi_winner_whole_threshold/test_set_multi_winner_whole_threshold_cvr.json
+++ b/src/test/resources/test_data/test_set_multi_winner_whole_threshold/test_set_multi_winner_whole_threshold_cvr.json
@@ -8,15 +8,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -26,7 +25,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -36,7 +35,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -46,7 +45,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -56,10 +55,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -73,15 +73,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -91,7 +90,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -101,7 +100,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -111,7 +110,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -121,7 +120,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -131,10 +130,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -148,15 +148,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -166,7 +165,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -176,7 +175,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -186,7 +185,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -196,7 +195,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -206,10 +205,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -223,15 +223,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -241,7 +240,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -251,7 +250,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -261,10 +260,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -278,15 +278,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -296,10 +295,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -313,15 +313,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -331,7 +330,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -341,7 +340,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -351,7 +350,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -361,7 +360,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -371,10 +370,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -388,15 +388,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -406,7 +405,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -416,7 +415,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -426,10 +425,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -443,15 +443,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -461,7 +460,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -471,7 +470,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -481,7 +480,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -491,10 +490,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -508,15 +508,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -526,7 +525,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -536,7 +535,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -546,7 +545,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -556,10 +555,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -573,18 +573,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -598,15 +598,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -616,7 +615,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -626,10 +625,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -643,16 +643,21 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
+          }, {
+            "@type" : "CVR.SelectionPosition",
+            "HasIndication" : "yes",
+            "IsAllocable" : "unknown",
+            "NumberVotes" : 1,
+            "Rank" : 3
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
@@ -661,18 +666,8 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-f",
-          "SelectionPosition" : [ {
-            "@type" : "CVR.SelectionPosition",
-            "HasIndication" : "yes",
-            "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
-            "Rank" : 3
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
@@ -681,7 +676,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -691,7 +686,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -701,10 +696,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -718,15 +714,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -736,7 +731,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -746,7 +741,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -756,10 +751,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -773,15 +769,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -791,7 +786,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -801,7 +796,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -811,7 +806,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -821,10 +816,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -838,15 +834,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -856,7 +851,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -866,7 +861,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -876,7 +871,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -886,7 +881,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -896,10 +891,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -913,15 +909,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -931,7 +926,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -941,7 +936,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -951,10 +946,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -968,15 +964,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -986,7 +981,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -996,7 +991,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1006,7 +1001,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -1016,7 +1011,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -1026,10 +1021,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -1043,15 +1039,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1061,7 +1056,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1071,7 +1066,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1081,7 +1076,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -1091,7 +1086,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -1101,10 +1096,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -1118,15 +1114,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1136,7 +1131,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1146,7 +1141,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1156,10 +1151,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -1173,15 +1169,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1191,10 +1186,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -1208,15 +1204,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1226,7 +1221,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1236,7 +1231,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1246,7 +1241,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -1256,7 +1251,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -1266,10 +1261,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -1283,15 +1279,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1301,7 +1296,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1311,7 +1306,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1321,10 +1316,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -1338,15 +1334,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1356,7 +1351,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1366,7 +1361,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1376,7 +1371,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -1386,10 +1381,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -1403,15 +1399,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1421,7 +1416,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1431,7 +1426,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1441,7 +1436,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -1451,7 +1446,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -1461,10 +1456,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -1478,15 +1474,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1496,10 +1491,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -1513,15 +1509,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1531,7 +1526,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1541,10 +1536,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -1558,15 +1554,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1576,7 +1571,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1586,7 +1581,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1596,7 +1591,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -1606,7 +1601,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -1616,10 +1611,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -1633,15 +1629,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1651,7 +1646,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1661,7 +1656,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -1671,10 +1666,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -1688,15 +1684,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1706,7 +1701,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1716,7 +1711,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1726,7 +1721,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -1736,10 +1731,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -1753,15 +1749,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1771,7 +1766,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1781,7 +1776,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1791,7 +1786,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -1801,7 +1796,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -1811,10 +1806,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     } ],
@@ -1885,7 +1881,7 @@
     } ],
     "ElectionScopeId" : "gpu-election"
   } ],
-  "GeneratedDate" : "2019-04-26T23:10:51-07:00",
+  "GeneratedDate" : "2019-05-01T16:33:35-07:00",
   "GpUnit" : [ {
     "@id" : "gpu-election",
     "@type" : "CVR.GpUnit",
@@ -1897,7 +1893,7 @@
   "ReportingDevice" : [ {
     "@id" : "rd-001",
     "@type" : "CVR.ReportingDevice",
-    "Application" : "RCV Universal Tabulator",
+    "Application" : "RCVRC Tabulator",
     "Manufacturer" : "Bright Spots"
   } ],
   "Version" : "1.0.0"

--- a/src/test/resources/test_data/test_set_multi_winner_whole_threshold/test_set_multi_winner_whole_threshold_expected_cvr_cdf.json
+++ b/src/test/resources/test_data/test_set_multi_winner_whole_threshold/test_set_multi_winner_whole_threshold_expected_cvr_cdf.json
@@ -8,15 +8,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -26,7 +25,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -36,7 +35,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -46,7 +45,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -56,10 +55,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -67,15 +67,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -85,7 +84,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -95,7 +94,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -105,7 +104,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -115,10 +114,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -126,15 +126,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -144,7 +143,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -154,7 +153,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -164,7 +163,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -174,10 +173,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -185,15 +185,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -203,7 +202,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -213,7 +212,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -223,7 +222,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -233,10 +232,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -244,15 +244,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -262,7 +261,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -272,7 +271,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -282,7 +281,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -292,10 +291,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -303,15 +303,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -321,7 +320,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -331,7 +330,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -341,7 +340,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -351,10 +350,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -362,15 +362,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -380,7 +379,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -390,7 +389,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -400,7 +399,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -408,12 +407,14 @@
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".7742",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.7742",
+            "NumberVotes" : 0,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -427,15 +428,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -445,7 +445,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -455,7 +455,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -465,7 +465,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -475,7 +475,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -485,10 +485,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -496,15 +497,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -514,7 +514,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -524,7 +524,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -534,7 +534,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -544,7 +544,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -554,10 +554,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -565,15 +566,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8889",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8889",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -581,9 +582,10 @@
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".1111",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.1111",
+            "NumberVotes" : 0,
             "Rank" : 2
           } ]
         }, {
@@ -593,7 +595,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -603,7 +605,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -613,7 +615,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -623,10 +625,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -634,15 +637,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8889",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8889",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -652,7 +655,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -660,9 +663,10 @@
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".1111",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.1111",
+            "NumberVotes" : 0,
             "Rank" : 3
           } ]
         }, {
@@ -672,7 +676,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -682,7 +686,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -692,10 +696,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -703,15 +708,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8889",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8889",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -721,7 +726,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -731,7 +736,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -739,9 +744,10 @@
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".1111",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.1111",
+            "NumberVotes" : 0,
             "Rank" : 4
           } ]
         }, {
@@ -751,7 +757,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -761,10 +767,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -772,15 +779,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8889",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8889",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -790,7 +797,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -800,7 +807,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -808,9 +815,10 @@
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".1111",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.1111",
+            "NumberVotes" : 0,
             "Rank" : 4
           } ]
         }, {
@@ -820,7 +828,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -830,10 +838,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -841,15 +850,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8889",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8889",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -859,7 +868,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -869,7 +878,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -877,9 +886,10 @@
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".0861",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.0861",
+            "NumberVotes" : 0,
             "Rank" : 4
           } ]
         }, {
@@ -889,7 +899,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -899,10 +909,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -916,15 +927,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -934,7 +944,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -944,7 +954,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -954,7 +964,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -964,7 +974,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -974,10 +984,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -985,15 +996,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1003,7 +1013,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1013,7 +1023,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1023,7 +1033,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -1033,7 +1043,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -1043,10 +1053,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1054,15 +1065,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8889",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8889",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -1070,9 +1081,10 @@
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".1111",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.1111",
+            "NumberVotes" : 0,
             "Rank" : 2
           } ]
         }, {
@@ -1082,7 +1094,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1092,7 +1104,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -1102,7 +1114,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -1112,10 +1124,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1123,15 +1136,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8889",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8889",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -1139,9 +1152,10 @@
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".1111",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.1111",
+            "NumberVotes" : 0,
             "Rank" : 2
           } ]
         }, {
@@ -1151,7 +1165,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1161,7 +1175,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -1171,7 +1185,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -1181,10 +1195,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1192,15 +1207,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8889",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8889",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -1208,9 +1223,10 @@
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".1111",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.1111",
+            "NumberVotes" : 0,
             "Rank" : 2
           } ]
         }, {
@@ -1220,7 +1236,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1230,7 +1246,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -1240,7 +1256,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -1250,10 +1266,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1261,15 +1278,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8889",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8889",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -1279,7 +1296,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1287,9 +1304,10 @@
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".1111",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.1111",
+            "NumberVotes" : 0,
             "Rank" : 3
           } ]
         }, {
@@ -1299,7 +1317,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -1309,7 +1327,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -1319,10 +1337,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1330,15 +1349,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8889",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8889",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -1348,7 +1367,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1356,9 +1375,10 @@
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".0861",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.0861",
+            "NumberVotes" : 0,
             "Rank" : 3
           } ]
         }, {
@@ -1368,7 +1388,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -1378,7 +1398,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -1388,10 +1408,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1405,15 +1426,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1423,7 +1443,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1433,7 +1453,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1443,10 +1463,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1454,15 +1475,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1472,7 +1492,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1482,7 +1502,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1492,10 +1512,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1503,15 +1524,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1521,7 +1541,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1531,7 +1551,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1541,10 +1561,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1552,15 +1573,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1570,7 +1590,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1580,7 +1600,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1590,10 +1610,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1601,15 +1622,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1619,7 +1639,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1629,7 +1649,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1639,10 +1659,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1650,15 +1671,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1668,7 +1688,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1678,7 +1698,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -1688,10 +1708,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1699,15 +1720,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1717,7 +1737,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1725,9 +1745,10 @@
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8675",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8675",
+            "NumberVotes" : 0,
             "Rank" : 3
           } ]
         }, {
@@ -1737,10 +1758,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1754,15 +1776,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1772,10 +1793,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -1783,15 +1805,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1801,10 +1822,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1812,15 +1834,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1830,10 +1851,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1841,15 +1863,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1859,10 +1880,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1870,15 +1892,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1888,10 +1909,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1899,15 +1921,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1917,10 +1938,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -1928,15 +1950,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8675",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8675",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -1946,10 +1968,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -1963,15 +1986,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -1981,7 +2003,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -1991,7 +2013,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2001,7 +2023,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -2011,7 +2033,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -2021,10 +2043,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -2032,15 +2055,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2050,7 +2072,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2060,7 +2082,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2070,7 +2092,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -2080,7 +2102,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -2090,10 +2112,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2101,15 +2124,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2119,7 +2141,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2129,7 +2151,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2139,7 +2161,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -2149,7 +2171,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -2159,10 +2181,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2170,15 +2193,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2188,7 +2210,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2198,7 +2220,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2208,7 +2230,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -2218,7 +2240,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -2228,10 +2250,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2239,15 +2262,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2257,7 +2279,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2267,7 +2289,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2277,7 +2299,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -2287,7 +2309,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -2297,10 +2319,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2308,15 +2331,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2326,7 +2348,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2336,7 +2358,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2346,7 +2368,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -2356,7 +2378,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -2366,10 +2388,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2377,15 +2400,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2393,9 +2415,10 @@
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".7742",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.7742",
+            "NumberVotes" : 0,
             "Rank" : 2
           } ]
         }, {
@@ -2405,7 +2428,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2415,7 +2438,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -2425,7 +2448,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -2435,10 +2458,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -2452,15 +2476,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2470,7 +2493,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2480,7 +2503,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2490,10 +2513,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -2501,15 +2525,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2519,7 +2542,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2529,7 +2552,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2539,10 +2562,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2550,15 +2574,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2568,7 +2591,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2578,7 +2601,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2588,10 +2611,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2599,15 +2623,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2617,7 +2640,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2627,7 +2650,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2637,10 +2660,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2648,15 +2672,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2666,7 +2689,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2676,7 +2699,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2686,10 +2709,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2697,15 +2721,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2715,7 +2738,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2725,7 +2748,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2735,10 +2758,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2746,15 +2770,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8675",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8675",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -2764,7 +2788,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2774,7 +2798,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2784,10 +2808,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -2801,15 +2826,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2819,7 +2843,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2829,7 +2853,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2839,7 +2863,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -2849,10 +2873,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -2860,15 +2885,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2878,7 +2902,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2888,7 +2912,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2898,7 +2922,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -2908,10 +2932,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2919,15 +2944,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2937,7 +2961,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -2947,7 +2971,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -2957,7 +2981,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -2967,10 +2991,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -2978,15 +3003,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -2996,7 +3020,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -3006,7 +3030,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -3016,7 +3040,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -3026,10 +3050,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3037,15 +3062,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -3055,7 +3079,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -3065,7 +3089,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -3075,7 +3099,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -3085,10 +3109,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3096,15 +3121,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -3114,7 +3138,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -3124,7 +3148,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -3134,7 +3158,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -3144,10 +3168,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3155,15 +3180,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".7742",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.7742",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -3173,7 +3198,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -3183,7 +3208,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -3193,7 +3218,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -3203,10 +3228,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -3220,15 +3246,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -3238,7 +3263,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -3248,7 +3273,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -3258,7 +3283,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -3268,10 +3293,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -3279,15 +3305,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -3297,7 +3322,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -3307,7 +3332,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -3317,7 +3342,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -3327,10 +3352,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3338,15 +3364,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8889",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8889",
+            "NumberVotes" : 0,
             "Rank" : 2
           } ]
         }, {
@@ -3354,9 +3380,10 @@
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".1111",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.1111",
+            "NumberVotes" : 0,
             "Rank" : 3
           } ]
         }, {
@@ -3366,7 +3393,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -3376,7 +3403,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -3386,10 +3413,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3397,15 +3425,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8889",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8889",
+            "NumberVotes" : 0,
             "Rank" : 2
           } ]
         }, {
@@ -3413,9 +3441,10 @@
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".1111",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.1111",
+            "NumberVotes" : 0,
             "Rank" : 3
           } ]
         }, {
@@ -3425,7 +3454,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -3435,7 +3464,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -3445,10 +3474,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3456,15 +3486,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8889",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8889",
+            "NumberVotes" : 0,
             "Rank" : 2
           } ]
         }, {
@@ -3474,7 +3504,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -3484,7 +3514,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -3492,9 +3522,10 @@
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".1111",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.1111",
+            "NumberVotes" : 0,
             "Rank" : 5
           } ]
         }, {
@@ -3504,10 +3535,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3515,15 +3547,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8889",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8889",
+            "NumberVotes" : 0,
             "Rank" : 2
           } ]
         }, {
@@ -3533,7 +3565,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -3543,7 +3575,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -3551,9 +3583,10 @@
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".1111",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.1111",
+            "NumberVotes" : 0,
             "Rank" : 5
           } ]
         }, {
@@ -3563,10 +3596,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3574,15 +3608,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8889",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8889",
+            "NumberVotes" : 0,
             "Rank" : 2
           } ]
         }, {
@@ -3592,7 +3626,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -3602,7 +3636,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -3610,9 +3644,10 @@
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".0964",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.0964",
+            "NumberVotes" : 0,
             "Rank" : 5
           } ]
         }, {
@@ -3622,10 +3657,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -3639,18 +3675,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -3658,18 +3694,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3677,18 +3713,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3696,18 +3732,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3715,18 +3751,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3734,18 +3770,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3753,18 +3789,18 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -3778,15 +3814,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -3796,7 +3831,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -3806,10 +3841,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -3817,15 +3853,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -3835,7 +3870,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -3845,10 +3880,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3856,15 +3892,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8889",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8889",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -3872,9 +3908,10 @@
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".1111",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.1111",
+            "NumberVotes" : 0,
             "Rank" : 2
           } ]
         }, {
@@ -3884,10 +3921,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3895,15 +3933,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8889",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8889",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -3911,9 +3949,10 @@
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".1111",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.1111",
+            "NumberVotes" : 0,
             "Rank" : 2
           } ]
         }, {
@@ -3923,10 +3962,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3934,15 +3974,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8889",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8889",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -3950,9 +3990,10 @@
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".1111",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.1111",
+            "NumberVotes" : 0,
             "Rank" : 2
           } ]
         }, {
@@ -3962,10 +4003,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -3973,15 +4015,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8889",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8889",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -3991,7 +4033,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -4001,10 +4043,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -4012,15 +4055,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8889",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8889",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -4030,7 +4073,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -4040,10 +4083,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -4057,16 +4101,21 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
+          }, {
+            "@type" : "CVR.SelectionPosition",
+            "HasIndication" : "yes",
+            "IsAllocable" : "unknown",
+            "NumberVotes" : 1,
+            "Rank" : 3
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
@@ -4075,18 +4124,8 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-f",
-          "SelectionPosition" : [ {
-            "@type" : "CVR.SelectionPosition",
-            "HasIndication" : "yes",
-            "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
-            "Rank" : 3
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
@@ -4095,7 +4134,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -4105,7 +4144,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -4115,10 +4154,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -4126,16 +4166,21 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
+          }, {
+            "@type" : "CVR.SelectionPosition",
+            "HasIndication" : "yes",
+            "IsAllocable" : "no",
+            "NumberVotes" : 1,
+            "Rank" : 3
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
@@ -4144,18 +4189,8 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-f",
-          "SelectionPosition" : [ {
-            "@type" : "CVR.SelectionPosition",
-            "HasIndication" : "yes",
-            "IsAllocable" : "yes",
-            "NumberVotes" : "1",
-            "Rank" : 3
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
@@ -4164,7 +4199,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -4174,7 +4209,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -4184,10 +4219,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -4195,16 +4231,21 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
+          }, {
+            "@type" : "CVR.SelectionPosition",
+            "HasIndication" : "yes",
+            "IsAllocable" : "no",
+            "NumberVotes" : 1,
+            "Rank" : 3
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
@@ -4213,18 +4254,8 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-f",
-          "SelectionPosition" : [ {
-            "@type" : "CVR.SelectionPosition",
-            "HasIndication" : "yes",
-            "IsAllocable" : "yes",
-            "NumberVotes" : "1",
-            "Rank" : 3
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
@@ -4233,7 +4264,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -4243,7 +4274,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -4253,10 +4284,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -4264,16 +4296,21 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
+          }, {
+            "@type" : "CVR.SelectionPosition",
+            "HasIndication" : "yes",
+            "IsAllocable" : "no",
+            "NumberVotes" : 1,
+            "Rank" : 3
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
@@ -4282,18 +4319,8 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-f",
-          "SelectionPosition" : [ {
-            "@type" : "CVR.SelectionPosition",
-            "HasIndication" : "yes",
-            "IsAllocable" : "yes",
-            "NumberVotes" : "1",
-            "Rank" : 3
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
@@ -4302,7 +4329,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -4312,7 +4339,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -4322,10 +4349,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -4333,16 +4361,21 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
+          }, {
+            "@type" : "CVR.SelectionPosition",
+            "HasIndication" : "yes",
+            "IsAllocable" : "no",
+            "NumberVotes" : 1,
+            "Rank" : 3
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
@@ -4351,18 +4384,8 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-f",
-          "SelectionPosition" : [ {
-            "@type" : "CVR.SelectionPosition",
-            "HasIndication" : "yes",
-            "IsAllocable" : "no",
-            "NumberVotes" : "1",
-            "Rank" : 3
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
@@ -4371,7 +4394,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -4381,7 +4404,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -4391,10 +4414,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -4402,16 +4426,21 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
+          }, {
+            "@type" : "CVR.SelectionPosition",
+            "HasIndication" : "yes",
+            "IsAllocable" : "no",
+            "NumberVotes" : 1,
+            "Rank" : 3
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
@@ -4420,18 +4449,8 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-f",
-          "SelectionPosition" : [ {
-            "@type" : "CVR.SelectionPosition",
-            "HasIndication" : "yes",
-            "IsAllocable" : "no",
-            "NumberVotes" : "1",
-            "Rank" : 3
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
@@ -4440,7 +4459,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -4450,7 +4469,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -4460,10 +4479,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -4471,16 +4491,21 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-f",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
+          }, {
+            "@type" : "CVR.SelectionPosition",
+            "HasIndication" : "yes",
+            "IsAllocable" : "no",
+            "NumberVotes" : 1,
+            "Rank" : 3
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
@@ -4489,18 +4514,8 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
-          } ]
-        }, {
-          "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-f",
-          "SelectionPosition" : [ {
-            "@type" : "CVR.SelectionPosition",
-            "HasIndication" : "yes",
-            "IsAllocable" : "no",
-            "NumberVotes" : "1",
-            "Rank" : 3
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
@@ -4509,7 +4524,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -4517,9 +4532,10 @@
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8675",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8675",
+            "NumberVotes" : 0,
             "Rank" : 5
           } ]
         }, {
@@ -4529,10 +4545,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -4546,15 +4563,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -4564,7 +4580,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -4574,7 +4590,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -4584,10 +4600,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -4595,15 +4612,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -4613,7 +4629,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -4623,7 +4639,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -4633,10 +4649,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -4644,15 +4661,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8889",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8889",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -4660,9 +4677,10 @@
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".1111",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.1111",
+            "NumberVotes" : 0,
             "Rank" : 2
           } ]
         }, {
@@ -4672,7 +4690,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -4682,10 +4700,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -4693,15 +4712,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8889",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8889",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -4709,9 +4728,10 @@
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".1111",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.1111",
+            "NumberVotes" : 0,
             "Rank" : 2
           } ]
         }, {
@@ -4721,7 +4741,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -4731,10 +4751,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -4742,15 +4763,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8889",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8889",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -4758,9 +4779,10 @@
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".1111",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.1111",
+            "NumberVotes" : 0,
             "Rank" : 2
           } ]
         }, {
@@ -4770,7 +4792,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -4780,10 +4802,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -4791,15 +4814,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8889",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8889",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -4809,7 +4832,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -4819,7 +4842,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -4829,10 +4852,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -4840,15 +4864,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8889",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8889",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -4858,7 +4882,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -4868,7 +4892,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -4878,10 +4902,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -4895,15 +4920,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -4913,7 +4937,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -4923,7 +4947,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -4933,7 +4957,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -4943,10 +4967,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -4954,15 +4979,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -4972,7 +4996,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -4982,7 +5006,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -4992,7 +5016,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -5002,10 +5026,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -5013,15 +5038,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8889",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8889",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -5029,9 +5054,10 @@
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".1111",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.1111",
+            "NumberVotes" : 0,
             "Rank" : 2
           } ]
         }, {
@@ -5041,7 +5067,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -5051,7 +5077,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -5061,10 +5087,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -5072,15 +5099,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8889",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8889",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -5088,9 +5115,10 @@
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".1111",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.1111",
+            "NumberVotes" : 0,
             "Rank" : 2
           } ]
         }, {
@@ -5100,7 +5128,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -5110,7 +5138,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -5120,10 +5148,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -5131,15 +5160,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8889",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8889",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -5147,9 +5176,10 @@
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".1111",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.1111",
+            "NumberVotes" : 0,
             "Rank" : 2
           } ]
         }, {
@@ -5159,7 +5189,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -5169,7 +5199,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -5179,10 +5209,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -5190,15 +5221,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8889",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8889",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -5208,7 +5239,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -5216,9 +5247,10 @@
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".1111",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.1111",
+            "NumberVotes" : 0,
             "Rank" : 3
           } ]
         }, {
@@ -5228,7 +5260,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -5238,10 +5270,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -5249,15 +5282,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8889",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8889",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -5267,7 +5300,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -5275,9 +5308,10 @@
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".0964",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.0964",
+            "NumberVotes" : 0,
             "Rank" : 3
           } ]
         }, {
@@ -5287,7 +5321,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -5297,10 +5331,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -5314,15 +5349,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5332,7 +5366,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -5342,7 +5376,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -5352,7 +5386,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -5362,7 +5396,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -5372,10 +5406,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -5383,15 +5418,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5401,7 +5435,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -5411,7 +5445,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -5421,7 +5455,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -5431,7 +5465,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -5441,10 +5475,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -5452,15 +5487,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5470,7 +5504,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -5480,7 +5514,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -5490,7 +5524,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -5500,7 +5534,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -5510,10 +5544,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -5521,15 +5556,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5539,7 +5573,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -5549,7 +5583,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -5559,7 +5593,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -5569,7 +5603,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -5579,10 +5613,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -5590,15 +5625,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5608,7 +5642,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -5618,7 +5652,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -5628,7 +5662,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -5638,7 +5672,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -5648,10 +5682,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -5659,15 +5694,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5677,7 +5711,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -5687,7 +5721,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -5697,7 +5731,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -5707,7 +5741,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -5717,10 +5751,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -5728,15 +5763,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".7742",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.7742",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -5746,7 +5781,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -5756,7 +5791,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -5766,7 +5801,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -5776,7 +5811,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -5786,10 +5821,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -5803,15 +5839,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5821,7 +5856,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -5831,7 +5866,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -5841,10 +5876,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -5852,15 +5888,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5870,7 +5905,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -5880,7 +5915,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -5890,10 +5925,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -5901,15 +5937,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5919,7 +5954,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -5929,7 +5964,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -5939,10 +5974,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -5950,15 +5986,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -5968,7 +6003,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -5978,7 +6013,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -5988,10 +6023,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -5999,15 +6035,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6017,7 +6052,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -6027,7 +6062,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -6037,10 +6072,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -6048,15 +6084,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6066,7 +6101,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -6076,7 +6111,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -6086,10 +6121,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -6097,15 +6133,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-d",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6115,7 +6150,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -6125,7 +6160,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -6135,10 +6170,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -6152,15 +6188,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6170,7 +6205,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -6180,7 +6215,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -6190,7 +6225,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -6200,7 +6235,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -6210,10 +6245,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -6221,15 +6257,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6239,7 +6274,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -6249,7 +6284,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -6259,7 +6294,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -6269,7 +6304,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -6279,10 +6314,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -6290,15 +6326,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6308,7 +6343,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -6318,7 +6353,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -6328,7 +6363,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -6338,7 +6373,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -6348,10 +6383,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -6359,15 +6395,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6377,7 +6412,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -6387,7 +6422,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -6397,7 +6432,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -6407,7 +6442,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -6417,10 +6452,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -6428,15 +6464,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6446,7 +6481,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -6456,7 +6491,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -6466,7 +6501,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -6476,7 +6511,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -6486,10 +6521,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -6497,15 +6533,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6515,7 +6550,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -6525,7 +6560,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -6535,7 +6570,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -6545,7 +6580,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -6555,10 +6590,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -6566,15 +6602,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6584,7 +6619,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -6594,7 +6629,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -6602,9 +6637,10 @@
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".7742",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.7742",
+            "NumberVotes" : 0,
             "Rank" : 4
           } ]
         }, {
@@ -6614,7 +6650,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -6624,10 +6660,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -6641,15 +6678,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6659,7 +6695,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -6669,7 +6705,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -6679,7 +6715,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -6689,7 +6725,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -6699,10 +6735,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -6710,15 +6747,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -6728,7 +6764,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -6738,7 +6774,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -6748,7 +6784,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -6758,7 +6794,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -6768,10 +6804,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -6779,15 +6816,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8889",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8889",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -6795,9 +6832,10 @@
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".1111",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.1111",
+            "NumberVotes" : 0,
             "Rank" : 2
           } ]
         }, {
@@ -6807,7 +6845,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -6817,7 +6855,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -6827,7 +6865,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -6837,10 +6875,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -6848,15 +6887,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8889",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8889",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -6864,9 +6903,10 @@
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".1111",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.1111",
+            "NumberVotes" : 0,
             "Rank" : 2
           } ]
         }, {
@@ -6876,7 +6916,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -6886,7 +6926,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -6896,7 +6936,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -6906,10 +6946,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -6917,15 +6958,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8889",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8889",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -6933,9 +6974,10 @@
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".1111",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.1111",
+            "NumberVotes" : 0,
             "Rank" : 2
           } ]
         }, {
@@ -6945,7 +6987,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -6955,7 +6997,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -6965,7 +7007,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -6975,10 +7017,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -6986,15 +7029,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8889",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8889",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -7004,7 +7047,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -7012,9 +7055,10 @@
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".1111",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.1111",
+            "NumberVotes" : 0,
             "Rank" : 3
           } ]
         }, {
@@ -7024,7 +7068,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -7034,7 +7078,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -7044,10 +7088,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -7055,15 +7100,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8889",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8889",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -7073,7 +7118,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -7081,9 +7126,10 @@
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".0861",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.0861",
+            "NumberVotes" : 0,
             "Rank" : 3
           } ]
         }, {
@@ -7093,7 +7139,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -7103,7 +7149,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -7113,10 +7159,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -7130,15 +7177,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7148,7 +7194,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -7158,7 +7204,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -7168,10 +7214,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -7179,15 +7226,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7197,7 +7243,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -7207,7 +7253,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -7217,10 +7263,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -7228,15 +7275,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7246,7 +7292,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -7256,7 +7302,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -7266,10 +7312,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -7277,15 +7324,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7295,7 +7341,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -7305,7 +7351,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -7315,10 +7361,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -7326,15 +7373,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7344,7 +7390,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -7354,7 +7400,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -7364,10 +7410,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -7375,15 +7422,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7393,7 +7439,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -7403,7 +7449,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -7413,10 +7459,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -7424,15 +7471,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".7742",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.7742",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -7442,7 +7489,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -7452,7 +7499,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -7462,10 +7509,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -7479,15 +7527,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7497,10 +7544,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -7508,15 +7556,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7526,10 +7573,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -7537,15 +7585,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7555,10 +7602,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -7566,15 +7614,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7584,10 +7631,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -7595,15 +7643,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7613,10 +7660,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -7624,15 +7672,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7642,10 +7689,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -7653,15 +7701,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8675",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8675",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -7671,10 +7719,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -7688,15 +7737,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7706,7 +7754,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -7716,7 +7764,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -7726,7 +7774,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -7736,7 +7784,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -7746,10 +7794,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -7757,15 +7806,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7775,7 +7823,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -7785,7 +7833,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -7795,7 +7843,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -7805,7 +7853,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -7815,10 +7863,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -7826,15 +7875,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7844,7 +7892,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -7854,7 +7902,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -7864,7 +7912,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -7874,7 +7922,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -7884,10 +7932,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -7895,15 +7944,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7913,7 +7961,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -7923,7 +7971,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -7933,7 +7981,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -7943,7 +7991,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -7953,10 +8001,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -7964,15 +8013,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -7982,7 +8030,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -7992,7 +8040,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -8002,7 +8050,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -8012,7 +8060,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -8022,10 +8070,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -8033,15 +8082,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8051,7 +8099,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8061,7 +8109,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -8071,7 +8119,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -8081,7 +8129,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -8091,10 +8139,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -8102,15 +8151,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8118,9 +8166,10 @@
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".7742",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.7742",
+            "NumberVotes" : 0,
             "Rank" : 2
           } ]
         }, {
@@ -8130,7 +8179,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -8140,7 +8189,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -8150,7 +8199,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -8160,10 +8209,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -8177,15 +8227,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8195,7 +8244,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8205,7 +8254,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -8215,10 +8264,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -8226,15 +8276,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8244,7 +8293,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8254,7 +8303,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -8264,10 +8313,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -8275,15 +8325,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8293,7 +8342,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8303,7 +8352,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -8313,10 +8362,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -8324,15 +8374,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8342,7 +8391,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8352,7 +8401,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -8362,10 +8411,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -8373,15 +8423,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8391,7 +8440,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8401,7 +8450,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -8411,10 +8460,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -8422,15 +8472,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8440,7 +8489,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8450,7 +8499,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -8460,10 +8509,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -8471,15 +8521,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8675",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8675",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -8489,7 +8539,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8499,7 +8549,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -8509,10 +8559,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -8526,15 +8577,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8544,7 +8594,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8554,7 +8604,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -8564,7 +8614,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -8574,10 +8624,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -8585,15 +8636,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8603,7 +8653,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8613,7 +8663,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -8623,7 +8673,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -8633,10 +8683,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -8644,15 +8695,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8662,7 +8712,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8672,7 +8722,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -8682,7 +8732,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -8692,10 +8742,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -8703,15 +8754,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8721,7 +8771,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8731,7 +8781,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -8741,7 +8791,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -8751,10 +8801,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -8762,15 +8813,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8780,7 +8830,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8790,7 +8840,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -8800,7 +8850,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -8810,10 +8860,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -8821,15 +8872,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8839,7 +8889,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8849,7 +8899,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -8859,7 +8909,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -8869,10 +8919,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -8880,15 +8931,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".7742",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.7742",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -8898,7 +8949,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8908,7 +8959,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -8918,7 +8969,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -8928,10 +8979,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -8945,15 +8997,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -8963,7 +9014,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -8973,7 +9024,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -8983,7 +9034,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -8993,7 +9044,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -9003,10 +9054,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -9014,15 +9066,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9032,7 +9083,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -9042,7 +9093,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -9052,7 +9103,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -9062,7 +9113,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -9072,10 +9123,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -9083,15 +9135,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9101,7 +9152,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -9111,7 +9162,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -9121,7 +9172,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -9131,7 +9182,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -9141,10 +9192,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -9152,15 +9204,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9170,7 +9221,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -9180,7 +9231,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -9190,7 +9241,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -9200,7 +9251,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -9210,10 +9261,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -9221,15 +9273,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9239,7 +9290,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -9249,7 +9300,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -9259,7 +9310,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -9269,7 +9320,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -9279,10 +9330,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -9290,15 +9342,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9308,7 +9359,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -9318,7 +9369,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -9328,7 +9379,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -9338,7 +9389,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -9348,10 +9399,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -9359,15 +9411,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9377,7 +9428,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -9387,7 +9438,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -9397,7 +9448,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -9405,9 +9456,10 @@
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8675",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8675",
+            "NumberVotes" : 0,
             "Rank" : 5
           } ]
         }, {
@@ -9417,10 +9469,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -9434,15 +9487,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9452,10 +9504,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -9463,15 +9516,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9481,10 +9533,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -9492,15 +9545,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9510,10 +9562,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -9521,15 +9574,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9539,10 +9591,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -9550,15 +9603,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9568,10 +9620,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -9579,15 +9632,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9597,10 +9649,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -9608,15 +9661,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".7742",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.7742",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -9626,10 +9679,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -9643,15 +9697,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9661,7 +9714,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -9671,10 +9724,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -9682,15 +9736,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9700,7 +9753,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -9710,10 +9763,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -9721,15 +9775,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8889",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8889",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -9737,9 +9791,10 @@
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".1111",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.1111",
+            "NumberVotes" : 0,
             "Rank" : 2
           } ]
         }, {
@@ -9749,10 +9804,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -9760,15 +9816,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8889",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8889",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -9776,9 +9832,10 @@
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".1111",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.1111",
+            "NumberVotes" : 0,
             "Rank" : 2
           } ]
         }, {
@@ -9788,10 +9845,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -9799,15 +9857,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8889",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8889",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -9815,9 +9873,10 @@
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".1111",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.1111",
+            "NumberVotes" : 0,
             "Rank" : 2
           } ]
         }, {
@@ -9827,10 +9886,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -9838,15 +9898,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8889",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8889",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -9856,7 +9916,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -9866,10 +9926,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -9877,15 +9938,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8889",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8889",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -9895,7 +9956,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -9905,10 +9966,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -9922,15 +9984,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -9940,7 +10001,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -9950,7 +10011,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -9960,7 +10021,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -9970,7 +10031,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -9980,10 +10041,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -9991,15 +10053,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -10009,7 +10070,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -10019,7 +10080,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -10029,7 +10090,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -10039,7 +10100,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -10049,10 +10110,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -10060,15 +10122,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -10078,7 +10139,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -10088,7 +10149,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -10098,7 +10159,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -10108,7 +10169,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -10118,10 +10179,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -10129,15 +10191,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -10147,7 +10208,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -10157,7 +10218,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -10167,7 +10228,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -10177,7 +10238,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -10187,10 +10248,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -10198,15 +10260,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -10216,7 +10277,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -10226,7 +10287,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -10236,7 +10297,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -10246,7 +10307,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -10256,10 +10317,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -10267,15 +10329,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -10285,7 +10346,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -10295,7 +10356,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -10305,7 +10366,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -10315,7 +10376,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -10325,10 +10386,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -10336,15 +10398,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -10354,7 +10415,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -10364,7 +10425,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -10374,7 +10435,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -10382,9 +10443,10 @@
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8675",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8675",
+            "NumberVotes" : 0,
             "Rank" : 5
           } ]
         }, {
@@ -10394,10 +10456,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -10411,15 +10474,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -10429,7 +10491,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -10439,7 +10501,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -10449,10 +10511,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -10460,15 +10523,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -10478,7 +10540,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -10488,7 +10550,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -10498,10 +10560,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -10509,15 +10572,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8889",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8889",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -10525,9 +10588,10 @@
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".1111",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.1111",
+            "NumberVotes" : 0,
             "Rank" : 2
           } ]
         }, {
@@ -10537,7 +10601,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -10547,10 +10611,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -10558,15 +10623,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8889",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8889",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -10574,9 +10639,10 @@
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".1111",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.1111",
+            "NumberVotes" : 0,
             "Rank" : 2
           } ]
         }, {
@@ -10586,7 +10652,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -10596,10 +10662,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -10607,15 +10674,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8889",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8889",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -10623,9 +10690,10 @@
           "ContestSelectionId" : "cs-e",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".1111",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.1111",
+            "NumberVotes" : 0,
             "Rank" : 2
           } ]
         }, {
@@ -10635,7 +10703,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -10645,10 +10713,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -10656,15 +10725,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8889",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8889",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -10674,7 +10743,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -10684,7 +10753,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -10694,10 +10763,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -10705,15 +10775,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-c",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8889",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8889",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -10723,7 +10793,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -10733,7 +10803,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -10743,10 +10813,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -10760,15 +10831,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -10778,7 +10848,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -10788,7 +10858,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -10798,7 +10868,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -10808,10 +10878,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -10819,15 +10890,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -10837,7 +10907,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -10847,7 +10917,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -10857,7 +10927,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -10867,10 +10937,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -10878,15 +10949,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -10896,7 +10966,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -10906,7 +10976,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -10916,7 +10986,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -10926,10 +10996,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -10937,15 +11008,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -10955,7 +11025,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -10965,7 +11035,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -10975,7 +11045,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -10985,10 +11055,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -10996,15 +11067,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -11014,7 +11084,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -11024,7 +11094,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -11034,7 +11104,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -11044,10 +11114,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -11055,15 +11126,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -11073,7 +11143,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -11083,7 +11153,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -11093,7 +11163,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -11103,10 +11173,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -11114,15 +11185,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-b",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".8675",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.8675",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -11132,7 +11203,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -11142,7 +11213,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -11152,7 +11223,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -11162,10 +11233,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -11179,15 +11251,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -11197,7 +11268,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -11207,7 +11278,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -11217,7 +11288,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -11227,7 +11298,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -11237,10 +11308,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "unknown",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "original"
     }, {
@@ -11248,15 +11320,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -11266,7 +11337,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -11276,7 +11347,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -11286,7 +11357,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -11296,7 +11367,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -11306,10 +11377,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -11317,15 +11389,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -11335,7 +11406,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -11345,7 +11416,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -11355,7 +11426,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -11365,7 +11436,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -11375,10 +11446,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -11386,15 +11458,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -11404,7 +11475,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -11414,7 +11485,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -11424,7 +11495,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -11434,7 +11505,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -11444,10 +11515,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -11455,15 +11527,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -11473,7 +11544,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -11483,7 +11554,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -11493,7 +11564,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -11503,7 +11574,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -11513,10 +11584,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -11524,15 +11596,14 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 1
           } ]
         }, {
@@ -11542,7 +11613,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -11552,7 +11623,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -11562,7 +11633,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -11572,7 +11643,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -11582,10 +11653,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     }, {
@@ -11593,15 +11665,15 @@
       "@type" : "CVR.CVRSnapshot",
       "CVRContest" : [ {
         "@type" : "CVR.CVRContest",
-        "ContestId" : "contest-001",
-        "ContestSelection" : [ {
+        "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
           "ContestSelectionId" : "cs-a",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
+            "FractionalVotes" : ".7742",
             "HasIndication" : "yes",
             "IsAllocable" : "yes",
-            "NumberVotes" : "0.7742",
+            "NumberVotes" : 0,
             "Rank" : 1
           } ]
         }, {
@@ -11611,7 +11683,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 2
           } ]
         }, {
@@ -11621,7 +11693,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 3
           } ]
         }, {
@@ -11631,7 +11703,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 4
           } ]
         }, {
@@ -11641,7 +11713,7 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 5
           } ]
         }, {
@@ -11651,10 +11723,11 @@
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
             "IsAllocable" : "no",
-            "NumberVotes" : "1",
+            "NumberVotes" : 1,
             "Rank" : 6
           } ]
-        } ]
+        } ],
+        "ContestId" : "contest-001"
       } ],
       "Type" : "interpreted"
     } ],
@@ -11668,22 +11741,22 @@
       "@id" : "contest-001",
       "@type" : "CVR.CandidateContest",
       "ContestSelection" : [ {
-        "@id" : "cs-e",
+        "@id" : "cs-a",
         "@type" : "CVR.ContestSelection",
         "Code" : [ {
           "@type" : "CVR.Code",
           "OtherType" : "vendor-label",
           "Type" : "other",
-          "Value" : "E"
+          "Value" : "A"
         } ]
       }, {
-        "@id" : "cs-f",
+        "@id" : "cs-b",
         "@type" : "CVR.ContestSelection",
         "Code" : [ {
           "@type" : "CVR.Code",
           "OtherType" : "vendor-label",
           "Type" : "other",
-          "Value" : "F"
+          "Value" : "B"
         } ]
       }, {
         "@id" : "cs-c",
@@ -11704,28 +11777,28 @@
           "Value" : "D"
         } ]
       }, {
-        "@id" : "cs-a",
+        "@id" : "cs-e",
         "@type" : "CVR.ContestSelection",
         "Code" : [ {
           "@type" : "CVR.Code",
           "OtherType" : "vendor-label",
           "Type" : "other",
-          "Value" : "A"
+          "Value" : "E"
         } ]
       }, {
-        "@id" : "cs-b",
+        "@id" : "cs-f",
         "@type" : "CVR.ContestSelection",
         "Code" : [ {
           "@type" : "CVR.Code",
           "OtherType" : "vendor-label",
           "Type" : "other",
-          "Value" : "B"
+          "Value" : "F"
         } ]
       } ]
     } ],
     "ElectionScopeId" : "gpu-election"
   } ],
-  "GeneratedDate" : "2019-04-26T23:27:46-07:00",
+  "GeneratedDate" : "2019-05-01T18:22:48-07:00",
   "GpUnit" : [ {
     "@id" : "gpu-election",
     "@type" : "CVR.GpUnit",
@@ -11737,7 +11810,7 @@
   "ReportingDevice" : [ {
     "@id" : "rd-001",
     "@type" : "CVR.ReportingDevice",
-    "Application" : "RCV Universal Tabulator",
+    "Application" : "RCVRC Tabulator",
     "Manufacturer" : "Bright Spots"
   } ],
   "Version" : "1.0.0"


### PR DESCRIPTION
OK, this is pretty gnarly, but I think I got it right.

Previously, if a given ballot had the same candidate ranked in multiple spots, we were generating a separate ContestSelection for each of those ranks. This worked fine -- or, at least, our tabulator was able to understand it fine -- but I realized last night that what the spec intends is for us to handle this case by having a single ContestSelection with multiple SelectionPositions (one for each rank). Transforming our CVR data so that we can export in that format was surprisingly tricky. I also added sorting logic so that the ordering of ContestSelections and SelectionPositions will be deterministic (which is also relevant for overvote situations).

And then I updated a bunch of tests accordingly.