### PR TITLE
Outputs wildcard * instead of %g in messages displaying path to logs …

### DIFF
--- a/src/main/java/network/brightspots/rcv/Logger.java
+++ b/src/main/java/network/brightspots/rcv/Logger.java
@@ -97,7 +97,8 @@ class Logger {
     }
 
     // log results
-    log(Level.INFO, "RCV Tabulator logging execution to: %s", logPath.toString());
+    log(Level.INFO, "RCV Tabulator logging execution to: %s",
+        logPath.toString().replace("%g", "*"));
   }
 
   // function: addTabulationFileLogging

--- a/src/main/java/network/brightspots/rcv/TabulatorSession.java
+++ b/src/main/java/network/brightspots/rcv/TabulatorSession.java
@@ -51,7 +51,7 @@ class TabulatorSession {
   private final String configPath;
   // precinct IDs discovered during CVR parsing to support testing
   private final Set<String> precinctIDs = new HashSet<>();
-  // cache output path location
+  // Visible for testing: cache output path location
   String outputPath;
   private String tabulationLogPath;
   private final String timestampString;
@@ -126,7 +126,8 @@ class TabulatorSession {
       }
 
       Logger.removeTabulationFileLogging();
-      Logger.log(Level.INFO, "Done logging tabulation to: %s", tabulationLogPath);
+      Logger
+          .log(Level.INFO, "Done logging tabulation to: %s", tabulationLogPath.replace("%g", "*"));
     } else {
       Logger.log(Level.SEVERE, "Aborting because contest config is invalid!");
     }


### PR DESCRIPTION
…(%g is log rotation number, and it's difficult to get in realtime). Fixes #158.