### PR TITLE
Better label and reserved string validation

### DIFF
--- a/src/main/java/network/brightspots/rcv/ContestConfig.java
+++ b/src/main/java/network/brightspots/rcv/ContestConfig.java
@@ -179,19 +179,6 @@ class ContestConfig {
     return match;
   }
 
-  private static boolean candidateStringIsReservedForTallyTransfers(String candidateString) {
-    boolean found = false;
-    if (!isNullOrBlank(candidateString)) {
-      for (String s : TallyTransfers.RESERVED_STRINGS) {
-        if (s.equalsIgnoreCase(candidateString)) {
-          found = true;
-          break;
-        }
-      }
-    }
-    return found;
-  }
-
   // function: resolveConfigPath
   // purpose: given a path returns absolute path for use in File IO
   // param: path from this config file (cvr or output folder)
@@ -375,18 +362,19 @@ class ContestConfig {
       foundError = true;
       Logger.log(
           Level.SEVERE, "Duplicate candidate %ss are not allowed: %s", field, candidateString);
-    } else if (candidateStringIsReservedForTallyTransfers(candidateString)) {
+    } else if (TallyTransfers.RESERVED_STRINGS.contains(candidateString)) {
       foundError = true;
       Logger.log(
           Level.SEVERE,
           "\"%s\" is a reserved term and can't be used as a candidate %s!",
           candidateString,
           field);
-    } else if (candidateStringMatchesLabel(
-        candidateString, field, getUndeclaredWriteInLabel(), "undeclaredWriteInLabel")
-        || candidateStringMatchesLabel(candidateString, field, getOvervoteLabel(), "overvoteLabel")
-        || candidateStringMatchesLabel(
-        candidateString, field, getUndervoteLabel(), "undervoteLabel")) {
+    } else if (
+        candidateStringMatchesLabel(candidateString, field, getOvervoteLabel(), "overvoteLabel")
+            || candidateStringMatchesLabel(candidateString, field, getUndervoteLabel(),
+            "undervoteLabel")
+            || candidateStringMatchesLabel(candidateString, field, getUndeclaredWriteInLabel(),
+            "undeclaredWriteInLabel")) {
       foundError = true;
     }
 

--- a/src/main/java/network/brightspots/rcv/TallyTransfers.java
+++ b/src/main/java/network/brightspots/rcv/TallyTransfers.java
@@ -27,6 +27,7 @@ package network.brightspots.rcv;
 import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 // TallyTransfers class stores summary info on vote transfers
 // used primarily as visualizer input to help build Sankey plots
@@ -35,7 +36,7 @@ class TallyTransfers {
   static final String RESIDUAL_TARGET = "residual surplus";
   private static final String EXHAUSTED = "exhausted";
   private static final String UNCOUNTED = "uncounted";
-  static final String[] RESERVED_STRINGS = {EXHAUSTED, RESIDUAL_TARGET, UNCOUNTED};
+  static final Set<String> RESERVED_STRINGS = Set.of(RESIDUAL_TARGET, EXHAUSTED, UNCOUNTED);
 
   // Map of round number to vote transfers which occurred in that round
   // transfers for a round are a map of SOURCE candidate(s) to one or more TARGET candidates.


### PR DESCRIPTION
Simplifies `TallyTransfers.RESERVED_STRINGS` check. Checks label fields against each other and `RESERVED_STRINGS`. Needs a bit more work (hence the TODOs), but please review and/or finish off if you can.