### PR TITLE
fix minor issue with transfer tallies

### DIFF
--- a/src/main/java/network/brightspots/rcv/Tabulator.java
+++ b/src/main/java/network/brightspots/rcv/Tabulator.java
@@ -202,7 +202,7 @@ class Tabulator {
         }
       } else if (winnerToRound.size() < config.getNumberOfWinners()
           || (config.isSingleSeatContinueUntilTwoCandidatesRemainEnabled()
-          && candidateToRoundEliminated.size() < config.getNumCandidates() - 2)) {
+              && candidateToRoundEliminated.size() < config.getNumCandidates() - 2)) {
         // We need to make more eliminations if
         // a) we haven't found all the winners yet, or
         // b) we've found our winner, but we're continuing until we have only two candidates
@@ -416,8 +416,8 @@ class Tabulator {
       // bottoms-up is enabled, in which case we can stop as soon as we've declared the winners.
       return numWinnersDeclared < config.getNumberOfWinners()
           || (config.getNumberOfWinners() > 1
-          && winnerToRound.values().contains(currentRound)
-          && !config.isMultiSeatBottomsUpEnabled());
+              && winnerToRound.values().contains(currentRound)
+              && !config.isMultiSeatBottomsUpEnabled());
     }
   }
 
@@ -430,7 +430,7 @@ class Tabulator {
     CandidateStatus status = getCandidateStatus(candidate);
     return status == CandidateStatus.CONTINUING
         || (status == CandidateStatus.WINNER
-        && config.isSingleSeatContinueUntilTwoCandidatesRemainEnabled());
+            && config.isSingleSeatContinueUntilTwoCandidatesRemainEnabled());
   }
 
   // function: getCandidateStatus
@@ -691,7 +691,8 @@ class Tabulator {
           numBallotsByPrecinct.put(precinct, currentTally + 1);
         }
       }
-      writer.generatePrecinctSummaryFiles(precinctRoundTallies, precinctTallyTransfers, numBallotsByPrecinct);
+      writer.generatePrecinctSummaryFiles(
+          precinctRoundTallies, precinctTallyTransfers, numBallotsByPrecinct);
     }
 
     if (config.isGenerateCdfJsonEnabled()) {
@@ -819,18 +820,23 @@ class Tabulator {
   //  update tallyTransfers counts
   private void recordSelectionForCastVoteRecord(
       CastVoteRecord cvr, int currentRound, String selectedCandidate, String outcomeDescription) {
-    // update transfer counts
-    tallyTransfers.addTransfer(
-        currentRound,
-        cvr.getCurrentRecipientOfVote(),
-        selectedCandidate,
-        cvr.getFractionalTransferValue());
-    if (config.isTabulateByPrecinctEnabled()) {
-      precinctTallyTransfers.get(cvr.getPrecinct()).addTransfer(
+    // update transfer counts (unless there's no value to transfer, which can happen if someone
+    // wins with a tally that exactly matches the winning threshold)
+    if (cvr.getFractionalTransferValue().signum() == 1) {
+      tallyTransfers.addTransfer(
           currentRound,
           cvr.getCurrentRecipientOfVote(),
           selectedCandidate,
           cvr.getFractionalTransferValue());
+      if (config.isTabulateByPrecinctEnabled()) {
+        precinctTallyTransfers
+            .get(cvr.getPrecinct())
+            .addTransfer(
+                currentRound,
+                cvr.getCurrentRecipientOfVote(),
+                selectedCandidate,
+                cvr.getFractionalTransferValue());
+      }
     }
 
     // update cvr recipient
@@ -1205,7 +1211,5 @@ class Tabulator {
     }
   }
 
-  static class TabulationCancelledException extends Exception {
-
-  }
+  static class TabulationCancelledException extends Exception {}
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/2013_minneapolis_park/2013_minneapolis_park_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/2013_minneapolis_park/2013_minneapolis_park_config.json
@@ -1,64 +1,78 @@
 {
+  "tabulatorVersion" : "0.1.0",
   "outputSettings" : {
     "contestName" : "2013 Minneapolis Park Board",
     "outputDirectory" : "output",
     "contestDate" : "",
     "contestJurisdiction" : "Minneapolis",
     "contestOffice" : "Park and Recreation Commissioner",
-    "tabulateByPrecinct" : false
+    "tabulateByPrecinct" : false,
+    "generateCdfJson" : false
   },
   "cvrFileSources" : [ {
     "filePath" : "2013_minneapolis_park_cvr.xlsx",
     "firstVoteColumnIndex" : 2,
-    "firstVoteRowIndex": 2,
-    "precinctColumnIndex" : 1,
+    "firstVoteRowIndex" : 2,
+    "idColumnIndex" : "",
+    "precinctColumnIndex" : "1",
     "provider" : "ES&S"
   } ],
   "candidates" : [ {
     "name" : "ANNIE YOUNG",
+    "code" : "",
     "excluded" : false
   }, {
     "name" : "CASPER HILL",
+    "code" : "",
     "excluded" : false
   }, {
     "name" : "HASHIM YONIS",
+    "code" : "",
     "excluded" : false
   }, {
     "name" : "ISHMAEL ISRAEL",
+    "code" : "",
     "excluded" : false
   }, {
     "name" : "JASON STONE",
+    "code" : "",
     "excluded" : false
   }, {
     "name" : "JOHN ERWIN",
+    "code" : "",
     "excluded" : false
   }, {
     "name" : "MARY LYNN MCPHERSON",
+    "code" : "",
     "excluded" : false
   }, {
     "name" : "MEG FORNEY",
+    "code" : "",
     "excluded" : false
   }, {
     "name" : "STEVE BARLAND",
+    "code" : "",
     "excluded" : false
   }, {
     "name" : "TOM NORDYKE",
+    "code" : "",
     "excluded" : false
   } ],
   "rules" : {
     "tiebreakMode" : "random",
-    "randomSeed" : 0,
     "overvoteRule" : "alwaysSkipToNextRank",
-    "maxRankingsAllowed" : 3,
-    "maxSkippedRanksAllowed" : 2,
+    "winnerElectionMode" : "standard",
+    "randomSeed" : 0,
     "numberOfWinners" : 3,
     "decimalPlacesForVoteArithmetic" : 4,
     "minimumVoteThreshold" : 0,
+    "maxSkippedRanksAllowed" : "2",
+    "maxRankingsAllowed" : "3",
+    "nonIntegerWinningThreshold" : false,
+    "hareQuota" : false,
     "batchElimination" : false,
-    "continueUntilTwoCandidatesRemain" : false,
     "exhaustOnDuplicateCandidate" : false,
     "treatBlankAsUndeclaredWriteIn" : false,
-    "nonIntegerWinningThreshold": false,
     "overvoteLabel" : "overvote",
     "undervoteLabel" : "undervote",
     "undeclaredWriteInLabel" : "UWI",


### PR DESCRIPTION
We were sometimes showing transfers of 0.0000 (literally zero) in the summary JSON, which is dumb. The issue is that when someone wins in a multi-seat contest, their ballot can get transferred to another candidate... but if there's no surplus for the victory, the transfer value is zero. I suppose we could just exhaust the ballot instead, but for now this is at least a step in the right direction. None of this affects the actual outcome; it's just a subtlety in how we're reporting it.