### PR TITLE
fix for #332

### DIFF
--- a/src/main/java/network/brightspots/rcv/GuiConfigController.java
+++ b/src/main/java/network/brightspots/rcv/GuiConfigController.java
@@ -794,7 +794,7 @@ public class GuiConfigController implements Initializable {
         datePickerContestDate.setValue(
             LocalDate.parse(outputSettings.contestDate, DATE_TIME_FORMATTER));
       } catch (DateTimeParseException exception) {
-        Logger.log(Level.SEVERE, "invalid contestDate: %s", outputSettings.contestDate);
+        Logger.log(Level.SEVERE, "Invalid contestDate: %s!", outputSettings.contestDate);
         datePickerContestDate.setValue(null);
       }
     }

--- a/src/main/java/network/brightspots/rcv/GuiConfigController.java
+++ b/src/main/java/network/brightspots/rcv/GuiConfigController.java
@@ -26,6 +26,7 @@ import java.io.InputStreamReader;
 import java.net.URL;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Optional;
 import java.util.ResourceBundle;
@@ -789,8 +790,13 @@ public class GuiConfigController implements Initializable {
     textFieldContestName.setText(outputSettings.contestName);
     textFieldOutputDirectory.setText(config.getOutputDirectoryRaw());
     if (!isNullOrBlank(outputSettings.contestDate)) {
-      datePickerContestDate.setValue(
-          LocalDate.parse(outputSettings.contestDate, DATE_TIME_FORMATTER));
+      try {
+        datePickerContestDate.setValue(
+            LocalDate.parse(outputSettings.contestDate, DATE_TIME_FORMATTER));
+      } catch (DateTimeParseException exception) {
+        Logger.log(Level.SEVERE, "invalid contestDate: %s", outputSettings.contestDate);
+        datePickerContestDate.setValue(null);
+      }
     }
     textFieldContestJurisdiction.setText(outputSettings.contestJurisdiction);
     textFieldContestOffice.setText(outputSettings.contestOffice);

--- a/src/main/java/network/brightspots/rcv/StreamingCVRReader.java
+++ b/src/main/java/network/brightspots/rcv/StreamingCVRReader.java
@@ -358,8 +358,8 @@ class StreamingCVRReader {
     xmlReader.setContentHandler(handler);
     // trigger parsing
     xmlReader.parse(new InputSource(xssfReader.getSheetsData().next()));
-    // close zip file
-    pkg.close();
+    // close zip file without saving
+    pkg.revert();
 
     // throw if there were any unrecognized candidates -- this is considered bad
     if (unrecognizedCandidateCounts.size() > 0) {


### PR DESCRIPTION
This fix handles bad date strings.  

The second idea in the ticket to more broadly handle all "silent" exceptions is tricky.  The only way I can see to do that is add generic exception handling on all ui callback code.  I don't think it's worth doing, certainly not for this release.