### PR TITLE
fix fallback logic for previous round counts tie-breaking modes

### DIFF
--- a/src/main/java/network/brightspots/rcv/Utils.java
+++ b/src/main/java/network/brightspots/rcv/Utils.java
@@ -16,9 +16,31 @@
 
 package network.brightspots.rcv;
 
+import java.util.List;
+
 class Utils {
 
   static boolean isNullOrBlank(String s) {
     return s == null || s.isBlank();
+  }
+
+  static String listToSentenceWithQuotes(List<String> list) {
+    String sentence;
+
+    if (list.size() == 1) {
+      sentence = String.format("\"%s\"", list.get(0));
+    } else if (list.size() == 2) {
+      // if there are only 2 candidates, don't use a comma
+      sentence = String.format("\"%s\" and \"%s\"", list.get(0), list.get(1));
+    } else {
+      StringBuilder stringBuilder = new StringBuilder();
+      for (int i = 0; i < list.size() - 1; i++) {
+        stringBuilder.append("\"").append(list.get(i)).append("\", ");
+      }
+      stringBuilder.append("and \"").append(list.get(list.size() - 1)).append("\"");
+      sentence = stringBuilder.toString();
+    }
+
+    return sentence;
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/tiebreak_generate_permutation_test/tiebreak_generate_permutation_test_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/tiebreak_generate_permutation_test/tiebreak_generate_permutation_test_config.json
@@ -1,4 +1,5 @@
 {
+  "tabulatorVersion" : "0.1.0",
   "outputSettings" : {
     "contestName" : "Tiebreak test",
     "outputDirectory" : "output",
@@ -36,18 +37,16 @@
   "rules" : {
     "tiebreakMode" : "generatePermutation",
     "overvoteRule" : "alwaysSkipToNextRank",
+    "winnerElectionMode" : "standard",
     "randomSeed" : 12345,
     "numberOfWinners" : 1,
     "decimalPlacesForVoteArithmetic" : 4,
     "minimumVoteThreshold" : 0,
     "maxSkippedRanksAllowed" : "0",
     "maxRankingsAllowed" : "1",
-    "sequentialMultiSeat" : false,
-    "bottomsUpMultiSeat" : false,
     "nonIntegerWinningThreshold" : false,
     "hareQuota" : false,
     "batchElimination" : true,
-    "continueUntilTwoCandidatesRemain" : false,
     "exhaustOnDuplicateCandidate" : false,
     "treatBlankAsUndeclaredWriteIn" : false,
     "overvoteLabel" : "overvote",

--- a/src/test/resources/network/brightspots/rcv/test_data/tiebreak_use_permutation_in_config_test/tiebreak_use_permutation_in_config_test_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/tiebreak_use_permutation_in_config_test/tiebreak_use_permutation_in_config_test_config.json
@@ -1,57 +1,56 @@
 {
-  "outputSettings": {
-    "contestName": "Tiebreak test",
-    "outputDirectory": "output",
-    "contestDate": "2017-12-03",
-    "contestJurisdiction": "Funkytown, USA",
-    "contestOffice": "Sergeant-at-Arms",
-    "tabulateByPrecinct": false,
-    "generateCdfJson": false
+  "tabulatorVersion" : "0.1.0",
+  "outputSettings" : {
+    "contestName" : "Tiebreak test",
+    "outputDirectory" : "output",
+    "contestDate" : "2017-12-03",
+    "contestJurisdiction" : "Funkytown, USA",
+    "contestOffice" : "Sergeant-at-Arms",
+    "tabulateByPrecinct" : false,
+    "generateCdfJson" : false
   },
-  "cvrFileSources": [
-    {
-      "filePath": "tiebreak_use_permutation_in_config_test_cvr.xlsx",
-      "firstVoteColumnIndex": 2,
-      "firstVoteRowIndex": 2,
-      "provider": "ES&S"
-    }
-  ],
-  "candidates": [
-    {
-      "name": "Mookie Blaylock",
-      "excluded": false
-    },
-    {
-      "name": "Yinka Dare",
-      "excluded": false
-    },
-    {
-      "name": "George Gervin",
-      "excluded": false
-    },
-    {
-      "name": "Sedale Threatt",
-      "excluded": false
-    }
-  ],
-  "rules": {
-    "tiebreakMode": "usePermutationInConfig",
-    "overvoteRule": "alwaysSkipToNextRank",
-    "numberOfWinners": 1,
-    "decimalPlacesForVoteArithmetic": 4,
-    "minimumVoteThreshold": 0,
-    "maxSkippedRanksAllowed": 0,
-    "maxRankingsAllowed": 3,
-    "sequentialMultiSeat": false,
-    "bottomsUpMultiSeat": false,
-    "nonIntegerWinningThreshold": false,
-    "hareQuota": false,
-    "batchElimination": true,
-    "continueUntilTwoCandidatesRemain": false,
-    "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "overvote",
-    "undervoteLabel": "undervote",
-    "rulesDescription": "Doyle Rules"
+  "cvrFileSources" : [ {
+    "filePath" : "tiebreak_use_permutation_in_config_test_cvr.xlsx",
+    "firstVoteColumnIndex" : 2,
+    "firstVoteRowIndex" : 2,
+    "idColumnIndex" : "",
+    "precinctColumnIndex" : "",
+    "provider" : "ES&S"
+  } ],
+  "candidates" : [ {
+    "name" : "Mookie Blaylock",
+    "code" : "",
+    "excluded" : false
+  }, {
+    "name" : "Yinka Dare",
+    "code" : "",
+    "excluded" : false
+  }, {
+    "name" : "George Gervin",
+    "code" : "",
+    "excluded" : false
+  }, {
+    "name" : "Sedale Threatt",
+    "code" : "",
+    "excluded" : false
+  } ],
+  "rules" : {
+    "tiebreakMode" : "usePermutationInConfig",
+    "overvoteRule" : "alwaysSkipToNextRank",
+    "winnerElectionMode" : "standard",
+    "numberOfWinners" : 1,
+    "decimalPlacesForVoteArithmetic" : 4,
+    "minimumVoteThreshold" : 0,
+    "maxSkippedRanksAllowed" : "0",
+    "maxRankingsAllowed" : "3",
+    "nonIntegerWinningThreshold" : false,
+    "hareQuota" : false,
+    "batchElimination" : true,
+    "exhaustOnDuplicateCandidate" : false,
+    "treatBlankAsUndeclaredWriteIn" : false,
+    "overvoteLabel" : "overvote",
+    "undervoteLabel" : "undervote",
+    "undeclaredWriteInLabel" : "",
+    "rulesDescription" : "Doyle Rules"
   }
 }


### PR DESCRIPTION
I only noticed this yesterday! Oops. Before this PR, the code has been handling the fallback part of previousRoundCountsThen[Random|Interactive] incorrectly: instead of only considering the candidates who were still tied at the end of the round counts comparison, it was reverting back to the full set of tied candidates.