### PR TITLE
Stringify config

### DIFF
--- a/src/main/java/network/brightspots/rcv/ContestConfig.java
+++ b/src/main/java/network/brightspots/rcv/ContestConfig.java
@@ -462,7 +462,7 @@ class ContestConfig {
     }
   }
 
-  private boolean checkIfInt(String s) {
+  private boolean isInt(String s) {
     boolean isInt = true;
     try {
       Integer.parseInt(s);
@@ -545,7 +545,7 @@ class ContestConfig {
         MIN_MINIMUM_VOTE_THRESHOLD, MAX_MINIMUM_VOTE_THRESHOLD, true);
 
     // If this is a multi-seat contest, we validate a couple extra parameters.
-    if (!isNullOrBlank(getNumberOfWinnersRaw()) && checkIfInt(getNumberOfWinnersRaw())
+    if (!isNullOrBlank(getNumberOfWinnersRaw()) && isInt(getNumberOfWinnersRaw())
         && getNumberOfWinners() > 1) {
       if (isSingleSeatContinueUntilTwoCandidatesRemainEnabled()) {
         isValid = false;
@@ -960,7 +960,7 @@ class ContestConfig {
       // It's not valid to have a null random seed with this tie-break mode; the validation will
       // catch that and report a helpful error. Validation also hits this code path, though, so we
       // need to prevent a NullPointerException here.
-      if (!isNullOrBlank(getRandomSeedRaw()) && checkIfInt(getRandomSeedRaw())) {
+      if (!isNullOrBlank(getRandomSeedRaw()) && isInt(getRandomSeedRaw())) {
         Collections.shuffle(candidatePermutation, new Random(getRandomSeed()));
       }
     }

--- a/src/main/java/network/brightspots/rcv/ContestConfig.java
+++ b/src/main/java/network/brightspots/rcv/ContestConfig.java
@@ -226,24 +226,58 @@ class ContestConfig {
     return isValid;
   }
 
+  private void invalidateAndLog(String message, String inputLocation) {
+    isValid = false;
+    message += inputLocation == null ? "!" : ": " + inputLocation;
+    Logger.log(Level.SEVERE, message);
+  }
+
+  // Makes sure String input can be converted to an int, and checks that int against boundaries
+  private void checkStringToIntWithBoundaries(String input, String inputName, Integer lowerBoundary,
+      Integer upperBoundary, boolean isRequired) {
+    checkStringToIntWithBoundaries(input, inputName, lowerBoundary, upperBoundary, isRequired,
+        null);
+  }
+
   // Makes sure String input can be converted to an int, and checks that int against boundaries
   private void checkStringToIntWithBoundaries(
-      String input, String inputName, int lowerBoundary, int upperBoundary, String inputLocation) {
-    try {
-      int stringInt = Integer.parseInt(input);
-      if (stringInt < lowerBoundary || stringInt > upperBoundary) {
-        isValid = false;
-        Logger.log(
-            Level.SEVERE,
-            "%s must be from %d to %d if supplied: %s",
-            inputName,
-            lowerBoundary,
-            upperBoundary,
-            inputLocation);
+      String input, String inputName, Integer lowerBoundary, Integer upperBoundary,
+      boolean isRequired, String inputLocation) {
+    String message = String.format("%s must be", inputName);
+    if (lowerBoundary != null && upperBoundary != null) {
+      if (lowerBoundary.equals(upperBoundary)) {
+        message += String.format(" equal to %d", lowerBoundary);
+      } else {
+        message += String.format(" from %d to %d", lowerBoundary, upperBoundary);
       }
-    } catch (NumberFormatException e) {
-      isValid = false;
-      Logger.log(Level.SEVERE, "%s must be an integer if supplied: %s", inputName, inputLocation);
+    } else if (lowerBoundary != null) {
+      message += String.format(" at least %d", lowerBoundary);
+    } else if (upperBoundary != null) {
+      message += String.format(" no greater than %d", upperBoundary);
+    } else {
+      message += " provided";
+    }
+    if (isNullOrBlank(input)) {
+      if (isRequired) {
+        invalidateAndLog(message, inputLocation);
+      }
+    } else {
+      try {
+        int stringInt = Integer.parseInt(input);
+        if ((lowerBoundary != null && stringInt < lowerBoundary)
+            || (upperBoundary != null && stringInt > upperBoundary)) {
+          if (!isRequired) {
+            message += " if supplied";
+          }
+          invalidateAndLog(message, inputLocation);
+        }
+      } catch (NumberFormatException e) {
+        message = String.format("%s must be an integer", inputName);
+        if (!isRequired) {
+          message += " if supplied";
+        }
+        invalidateAndLog(message, inputLocation);
+      }
     }
   }
 
@@ -275,7 +309,7 @@ class ContestConfig {
   private void validateCvrFileSources() {
     if (rawConfig.cvrFileSources == null || rawConfig.cvrFileSources.isEmpty()) {
       isValid = false;
-      Logger.log(Level.SEVERE, "Contest config must contain at least one cast vote record file!");
+      Logger.log(Level.SEVERE, "Contest config must contain at least 1 cast vote record file!");
     } else {
       HashSet<String> cvrFilePathSet = new HashSet<>();
       for (CVRSource source : rawConfig.cvrFileSources) {
@@ -318,35 +352,23 @@ class ContestConfig {
           // perform ES&S checks
 
           // ensure valid first vote column value
-          if (isNullOrBlank(source.getFirstVoteColumnIndex())) {
-            isValid = false;
-            Logger.log(Level.SEVERE, "firstVoteColumnIndex is required: %s", cvrPath);
-          } else {
-            checkStringToIntWithBoundaries(source.getFirstVoteColumnIndex(), "firstVoteColumnIndex",
-                MIN_COLUMN_INDEX, MAX_COLUMN_INDEX, cvrPath);
-          }
+          checkStringToIntWithBoundaries(source.getFirstVoteColumnIndex(), "firstVoteColumnIndex",
+              MIN_COLUMN_INDEX, MAX_COLUMN_INDEX, true, cvrPath);
 
           // ensure valid first vote row value
-          if (isNullOrBlank(source.getFirstVoteRowIndex())) {
-            isValid = false;
-            Logger.log(Level.SEVERE, "firstVoteRowIndex is required: %s", cvrPath);
-          } else {
-            checkStringToIntWithBoundaries(source.getFirstVoteRowIndex(), "firstVoteRowIndex",
-                MIN_ROW_INDEX, MAX_ROW_INDEX, cvrPath);
-          }
+          checkStringToIntWithBoundaries(source.getFirstVoteRowIndex(), "firstVoteRowIndex",
+              MIN_ROW_INDEX, MAX_ROW_INDEX, true, cvrPath);
 
           // ensure valid id column value
-          if (!isNullOrBlank(source.getIdColumnIndex())) {
-            checkStringToIntWithBoundaries(source.getIdColumnIndex(), "idColumnIndex",
-                MIN_COLUMN_INDEX, MAX_COLUMN_INDEX, cvrPath);
-          }
+          checkStringToIntWithBoundaries(source.getIdColumnIndex(), "idColumnIndex",
+              MIN_COLUMN_INDEX, MAX_COLUMN_INDEX, false, cvrPath);
 
           // ensure valid precinct column value
-          if (!isNullOrBlank(source.getPrecinctColumnIndex())) {
-            checkStringToIntWithBoundaries(
-                source.getPrecinctColumnIndex(), "precinctColumnIndex", MIN_COLUMN_INDEX,
-                MAX_COLUMN_INDEX, cvrPath);
-          } else if (isTabulateByPrecinctEnabled()) {
+          checkStringToIntWithBoundaries(
+              source.getPrecinctColumnIndex(), "precinctColumnIndex", MIN_COLUMN_INDEX,
+              MAX_COLUMN_INDEX, false, cvrPath);
+
+          if (isNullOrBlank(source.getPrecinctColumnIndex()) && isTabulateByPrecinctEnabled()) {
             isValid = false;
             Logger.log(
                 Level.SEVERE,
@@ -440,6 +462,16 @@ class ContestConfig {
     }
   }
 
+  private boolean checkIfInt(String s) {
+    boolean isInt = true;
+    try {
+      Integer.parseInt(s);
+    } catch (NumberFormatException e) {
+      isInt = false;
+    }
+    return isInt;
+  }
+
   private void validateRules() {
     if (getTiebreakMode() == TieBreakMode.MODE_UNKNOWN) {
       isValid = false;
@@ -449,7 +481,7 @@ class ContestConfig {
     if ((getTiebreakMode() == TieBreakMode.RANDOM
         || getTiebreakMode() == TieBreakMode.PREVIOUS_ROUND_COUNTS_THEN_RANDOM
         || getTiebreakMode() == TieBreakMode.GENERATE_PERMUTATION)
-        && getRandomSeed() == null) {
+        && isNullOrBlank(getRandomSeedRaw())) {
       isValid = false;
       Logger.log(
           Level.SEVERE,
@@ -501,41 +533,20 @@ class ContestConfig {
           MIN_MAX_SKIPPED_RANKS_ALLOWED);
     }
 
-    if (getNumberOfWinners() == null
-        || getNumberOfWinners() < MIN_NUMBER_OF_WINNERS
-        || getNumberOfWinners() > getNumDeclaredCandidates()) {
-      isValid = false;
-      Logger.log(
-          Level.SEVERE,
-          "numberOfWinners must be at least %d and no more than the number "
-              + "of declared candidates!",
-          MIN_NUMBER_OF_WINNERS);
-    }
+    checkStringToIntWithBoundaries(getNumberOfWinnersRaw(), "numberOfWinners",
+        MIN_NUMBER_OF_WINNERS, getNumDeclaredCandidates() < 1 ? null : getNumDeclaredCandidates(),
+        true);
 
-    if (getDecimalPlacesForVoteArithmetic() == null
-        || getDecimalPlacesForVoteArithmetic() < MIN_DECIMAL_PLACES_FOR_VOTE_ARITHMETIC
-        || getDecimalPlacesForVoteArithmetic() > MAX_DECIMAL_PLACES_FOR_VOTE_ARITHMETIC) {
-      isValid = false;
-      Logger.log(
-          Level.SEVERE,
-          "decimalPlacesForVoteArithmetic must be from %d to %d!",
-          MIN_DECIMAL_PLACES_FOR_VOTE_ARITHMETIC,
-          MAX_DECIMAL_PLACES_FOR_VOTE_ARITHMETIC);
-    }
+    checkStringToIntWithBoundaries(getDecimalPlacesForVoteArithmeticRaw(),
+        "decimalPlacesForVoteArithmetic",
+        MIN_DECIMAL_PLACES_FOR_VOTE_ARITHMETIC, MAX_DECIMAL_PLACES_FOR_VOTE_ARITHMETIC, true);
 
-    if (getMinimumVoteThreshold() == null
-        || getMinimumVoteThreshold().intValue() < MIN_MINIMUM_VOTE_THRESHOLD
-        || getMinimumVoteThreshold().intValue() > MAX_MINIMUM_VOTE_THRESHOLD) {
-      isValid = false;
-      Logger.log(
-          Level.SEVERE,
-          "minimumVoteThreshold must be from %d to %d!",
-          MIN_MINIMUM_VOTE_THRESHOLD,
-          MAX_MINIMUM_VOTE_THRESHOLD);
-    }
+    checkStringToIntWithBoundaries(getMinimumVoteThresholdRaw(), "minimumVoteThreshold",
+        MIN_MINIMUM_VOTE_THRESHOLD, MAX_MINIMUM_VOTE_THRESHOLD, true);
 
     // If this is a multi-seat contest, we validate a couple extra parameters.
-    if (getNumberOfWinners() != null && getNumberOfWinners() > 1) {
+    if (!isNullOrBlank(getNumberOfWinnersRaw()) && checkIfInt(getNumberOfWinnersRaw())
+        && getNumberOfWinners() > 1) {
       if (isSingleSeatContinueUntilTwoCandidatesRemainEnabled()) {
         isValid = false;
         Logger.log(
@@ -581,10 +592,7 @@ class ContestConfig {
           "batchElimination can't be true when winnerElectionMode is multiSeatBottomsUp!");
     }
 
-    if (getRandomSeed() != null && getRandomSeed() < MIN_RANDOM_SEED) {
-      isValid = false;
-      Logger.log(Level.SEVERE, "randomSeed can't be less than %d!", MIN_RANDOM_SEED);
-    }
+    checkStringToIntWithBoundaries(getRandomSeedRaw(), "randomSeed", MIN_RANDOM_SEED, null, false);
 
     if (!isNullOrBlank(getOvervoteLabel()) && stringAlreadyInUseElsewhere(getOvervoteLabel(),
         "overvoteLabel")) {
@@ -607,15 +615,19 @@ class ContestConfig {
     }
   }
 
+  private String getNumberOfWinnersRaw() {
+    return rawConfig.rules.numberOfWinners;
+  }
+
   // function: getNumberWinners
   // purpose: how many winners for this contest
   // returns: number of winners
   Integer getNumberOfWinners() {
-    return rawConfig.rules.numberOfWinners;
+    return Integer.parseInt(rawConfig.rules.numberOfWinners);
   }
 
   void setNumberOfWinners(int numberOfWinners) {
-    rawConfig.rules.numberOfWinners = numberOfWinners;
+    rawConfig.rules.numberOfWinners = Integer.toString(numberOfWinners);
   }
 
   List<String> getSequentialWinners() {
@@ -626,11 +638,15 @@ class ContestConfig {
     sequentialWinners.add(winner);
   }
 
+  private String getDecimalPlacesForVoteArithmeticRaw() {
+    return rawConfig.rules.decimalPlacesForVoteArithmetic;
+  }
+
   // function: getDecimalPlacesForVoteArithmetic
   // purpose: how many places to round votes to after performing fractional vote transfers
   // returns: number of places to round to
   Integer getDecimalPlacesForVoteArithmetic() {
-    return rawConfig.rules.decimalPlacesForVoteArithmetic;
+    return Integer.parseInt(rawConfig.rules.decimalPlacesForVoteArithmetic);
   }
 
   WinnerElectionMode getWinnerElectionMode() {
@@ -802,13 +818,15 @@ class ContestConfig {
     return rule == null ? OvervoteRule.RULE_UNKNOWN : rule;
   }
 
+  private String getMinimumVoteThresholdRaw() {
+    return rawConfig.rules.minimumVoteThreshold;
+  }
+
   // function: getMinimumVoteThreshold
   // purpose: getter for minimumVoteThreshold rule
   // returns: minimum vote threshold to use or default value if it's not specified
   BigDecimal getMinimumVoteThreshold() {
-    return rawConfig.rules.minimumVoteThreshold != null
-        ? new BigDecimal(rawConfig.rules.minimumVoteThreshold)
-        : null;
+    return new BigDecimal(rawConfig.rules.minimumVoteThreshold);
   }
 
   // function: getMaxSkippedRanksAllowed
@@ -850,8 +868,12 @@ class ContestConfig {
     return mode == null ? TieBreakMode.MODE_UNKNOWN : mode;
   }
 
-  Integer getRandomSeed() {
+  private String getRandomSeedRaw() {
     return rawConfig.rules.randomSeed;
+  }
+
+  Integer getRandomSeed() {
+    return Integer.parseInt(rawConfig.rules.randomSeed);
   }
 
   // function: isTreatBlankAsUndeclaredWriteInEnabled
@@ -938,7 +960,7 @@ class ContestConfig {
       // It's not valid to have a null random seed with this tie-break mode; the validation will
       // catch that and report a helpful error. Validation also hits this code path, though, so we
       // need to prevent a NullPointerException here.
-      if (getRandomSeed() != null) {
+      if (!isNullOrBlank(getRandomSeedRaw()) && checkIfInt(getRandomSeedRaw())) {
         Collections.shuffle(candidatePermutation, new Random(getRandomSeed()));
       }
     }

--- a/src/main/java/network/brightspots/rcv/ContestConfig.java
+++ b/src/main/java/network/brightspots/rcv/ContestConfig.java
@@ -46,6 +46,7 @@ import network.brightspots.rcv.Tabulator.WinnerElectionMode;
 
 class ContestConfig {
   // If any booleans are unspecified in config file, they should default to false no matter what
+  static final String SUGGESTED_OUTPUT_DIRECTORY = "output";
   static final boolean SUGGESTED_TABULATE_BY_PRECINCT = false;
   static final boolean SUGGESTED_GENERATE_CDF_JSON = false;
   static final boolean SUGGESTED_CANDIDATE_EXCLUDED = false;
@@ -689,8 +690,7 @@ class ContestConfig {
   // returns: raw string from config or falls back to user folder if none is set
   String getOutputDirectoryRaw() {
     // outputDirectory is where output files should be written
-    return isNullOrBlank(rawConfig.outputSettings.outputDirectory) ? FileUtils.getUserDirectory()
-        : rawConfig.outputSettings.outputDirectory;
+    return rawConfig.outputSettings.outputDirectory;
   }
 
   // function: getOutputDirectory

--- a/src/main/java/network/brightspots/rcv/ContestConfig.java
+++ b/src/main/java/network/brightspots/rcv/ContestConfig.java
@@ -253,15 +253,11 @@ class ContestConfig {
     } else {
       if (!getTabulatorVersion().equals(Main.APP_VERSION)) {
         isValid = false;
-        Logger.log(
-            Level.SEVERE,
-            "tabulatorVersion %s not supported!",
-            getTabulatorVersion(),
-            Main.APP_VERSION);
+        Logger.log(Level.SEVERE, "tabulatorVersion %s not supported!", getTabulatorVersion());
       }
     }
     if (!isValid) {
-      Logger.log(Level.SEVERE, "tabulatorVersion must be set to %s.", Main.APP_VERSION);
+      Logger.log(Level.SEVERE, "tabulatorVersion must be set to %s!", Main.APP_VERSION);
     }
   }
 

--- a/src/main/java/network/brightspots/rcv/ContestConfig.java
+++ b/src/main/java/network/brightspots/rcv/ContestConfig.java
@@ -623,7 +623,7 @@ class ContestConfig {
   // purpose: how many winners for this contest
   // returns: number of winners
   Integer getNumberOfWinners() {
-    return Integer.parseInt(rawConfig.rules.numberOfWinners);
+    return Integer.parseInt(getNumberOfWinnersRaw());
   }
 
   void setNumberOfWinners(int numberOfWinners) {
@@ -646,7 +646,7 @@ class ContestConfig {
   // purpose: how many places to round votes to after performing fractional vote transfers
   // returns: number of places to round to
   Integer getDecimalPlacesForVoteArithmetic() {
-    return Integer.parseInt(rawConfig.rules.decimalPlacesForVoteArithmetic);
+    return Integer.parseInt(getDecimalPlacesForVoteArithmeticRaw());
   }
 
   WinnerElectionMode getWinnerElectionMode() {
@@ -826,7 +826,7 @@ class ContestConfig {
   // purpose: getter for minimumVoteThreshold rule
   // returns: minimum vote threshold to use or default value if it's not specified
   BigDecimal getMinimumVoteThreshold() {
-    return new BigDecimal(rawConfig.rules.minimumVoteThreshold);
+    return new BigDecimal(getMinimumVoteThresholdRaw());
   }
 
   // function: getMaxSkippedRanksAllowed
@@ -873,7 +873,7 @@ class ContestConfig {
   }
 
   Integer getRandomSeed() {
-    return Integer.parseInt(rawConfig.rules.randomSeed);
+    return Integer.parseInt(getRandomSeedRaw());
   }
 
   // function: isTreatBlankAsUndeclaredWriteInEnabled

--- a/src/main/java/network/brightspots/rcv/GuiConfigController.java
+++ b/src/main/java/network/brightspots/rcv/GuiConfigController.java
@@ -771,13 +771,14 @@ public class GuiConfigController implements Initializable {
     }
   }
 
-  // version migration logic goes here
   private void migrateConfigVersion(ContestConfig config) {
     if (config.rawConfig.tabulatorVersion == null || !config.rawConfig.tabulatorVersion
         .equals(Main.APP_VERSION)) {
+      // Any necessary future version migration logic goes here
+      Logger.log(Level.INFO, "Migrated tabulator config version from %s to %s.",
+          config.rawConfig.tabulatorVersion != null ? config.rawConfig.tabulatorVersion : "unknown",
+          Main.APP_VERSION);
       config.rawConfig.tabulatorVersion = Main.APP_VERSION;
-      Logger.log(Level.INFO, "Migrated tabulator version from %s to %s.",
-          config.rawConfig.tabulatorVersion, Main.APP_VERSION);
     }
   }
 
@@ -806,11 +807,14 @@ public class GuiConfigController implements Initializable {
     }
 
     ContestRules rules = rawConfig.rules;
-    choiceTiebreakMode.setValue(config.getTiebreakMode());
-    choiceOvervoteRule.setValue(config.getOvervoteRule());
-    if (config.getWinnerElectionMode() != WinnerElectionMode.MODE_UNKNOWN) {
-      choiceWinnerElectionMode.setValue(config.getWinnerElectionMode());
-    }
+    choiceTiebreakMode.setValue(
+        config.getTiebreakMode() == TieBreakMode.MODE_UNKNOWN ? null : config.getTiebreakMode());
+    choiceOvervoteRule.setValue(
+        config.getOvervoteRule() == OvervoteRule.RULE_UNKNOWN ? null : config.getOvervoteRule());
+    choiceWinnerElectionMode.setValue(
+        config.getWinnerElectionMode() == WinnerElectionMode.MODE_UNKNOWN ? null
+            : config.getWinnerElectionMode());
+
     setTextFieldToInteger(textFieldRandomSeed, rules.randomSeed);
     setTextFieldToInteger(textFieldNumberOfWinners, rules.numberOfWinners);
     setTextFieldToInteger(

--- a/src/main/java/network/brightspots/rcv/GuiConfigController.java
+++ b/src/main/java/network/brightspots/rcv/GuiConfigController.java
@@ -502,6 +502,7 @@ public class GuiConfigController implements Initializable {
     checkBoxTreatBlankAsUndeclaredWriteIn.setSelected(
         ContestConfig.SUGGESTED_TREAT_BLANK_AS_UNDECLARED_WRITE_IN);
 
+    textFieldOutputDirectory.setText(ContestConfig.SUGGESTED_OUTPUT_DIRECTORY);
     textFieldNumberOfWinners.setText(String.valueOf(ContestConfig.SUGGESTED_NUMBER_OF_WINNERS));
     textFieldDecimalPlacesForVoteArithmetic.setText(
         String.valueOf(ContestConfig.SUGGESTED_DECIMAL_PLACES_FOR_VOTE_ARITHMETIC));

--- a/src/main/java/network/brightspots/rcv/GuiConfigController.java
+++ b/src/main/java/network/brightspots/rcv/GuiConfigController.java
@@ -388,6 +388,7 @@ public class GuiConfigController implements Initializable {
 
   public void changeCvrFilePath(CellEditEvent cellEditEvent) {
     CVRSource cvrSelected = tableViewCvrFiles.getSelectionModel().getSelectedItem();
+    // Cache the original value to revert back to in case the change fails
     String oldFilePath = cvrSelected.getFilePath();
     cvrSelected.setFilePath(cellEditEvent.getNewValue().toString().trim());
     if (!cvrSourceHasRequiredFields(cvrSelected)) {
@@ -398,6 +399,7 @@ public class GuiConfigController implements Initializable {
 
   public void changeCvrFirstVoteCol(CellEditEvent cellEditEvent) {
     CVRSource cvrSelected = tableViewCvrFiles.getSelectionModel().getSelectedItem();
+    // Cache the original value to revert back to in case the change fails
     String oldFirstVoteCol = cvrSelected.getFirstVoteColumnIndex();
     cvrSelected.setFirstVoteColumnIndex(cellEditEvent.getNewValue().toString().trim());
     if (!cvrSourceHasRequiredFields(cvrSelected)) {
@@ -408,6 +410,7 @@ public class GuiConfigController implements Initializable {
 
   public void changeCvrFirstVoteRow(CellEditEvent cellEditEvent) {
     CVRSource cvrSelected = tableViewCvrFiles.getSelectionModel().getSelectedItem();
+    // Cache the original value to revert back to in case the change fails
     String oldFirstVoteRow = cvrSelected.getFirstVoteRowIndex();
     cvrSelected.setFirstVoteRowIndex(cellEditEvent.getNewValue().toString().trim());
     if (!cvrSourceHasRequiredFields(cvrSelected)) {
@@ -418,6 +421,7 @@ public class GuiConfigController implements Initializable {
 
   public void changeCvrIdColIndex(CellEditEvent cellEditEvent) {
     CVRSource cvrSelected = tableViewCvrFiles.getSelectionModel().getSelectedItem();
+    // Cache the original value to revert back to in case the change fails
     String oldIdColIndex = cvrSelected.getIdColumnIndex();
     cvrSelected.setIdColumnIndex(cellEditEvent.getNewValue().toString().trim());
     if (!cvrSourceHasRequiredFields(cvrSelected)) {
@@ -428,6 +432,7 @@ public class GuiConfigController implements Initializable {
 
   public void changeCvrPrecinctColIndex(CellEditEvent cellEditEvent) {
     CVRSource cvrSelected = tableViewCvrFiles.getSelectionModel().getSelectedItem();
+    // Cache the original value to revert back to in case the change fails
     String oldPrecinctColIndex = cvrSelected.getPrecinctColumnIndex();
     cvrSelected.setPrecinctColumnIndex(cellEditEvent.getNewValue().toString().trim());
     if (!cvrSourceHasRequiredFields(cvrSelected)) {
@@ -438,6 +443,7 @@ public class GuiConfigController implements Initializable {
 
   public void changeCvrProvider(CellEditEvent cellEditEvent) {
     CVRSource cvrSelected = tableViewCvrFiles.getSelectionModel().getSelectedItem();
+    // Cache the original value to revert back to in case the change fails
     String oldProvider = cvrSelected.getProvider();
     cvrSelected.setProvider(cellEditEvent.getNewValue().toString().trim());
     if (!cvrSourceHasRequiredFields(cvrSelected)) {

--- a/src/main/java/network/brightspots/rcv/RawContestConfig.java
+++ b/src/main/java/network/brightspots/rcv/RawContestConfig.java
@@ -75,15 +75,28 @@ public class RawContestConfig {
     // path to the file on disk
     private String filePath;
     // 1-indexed column where rankings data begins
-    private Integer firstVoteColumnIndex;
+    private String firstVoteColumnIndex;
     // 1-indexed row where first CVR appears
-    private Integer firstVoteRowIndex;
+    private String firstVoteRowIndex;
     // 1-indexed column containing CVR ID (if any)
     private String idColumnIndex;
     // 1-indexed column containing precinct (if any)
     private String precinctColumnIndex;
     // provider for this source e.g. "ES&S"
     private String provider;
+
+    public CVRSource() {
+    }
+
+    public CVRSource(String filePath, String firstVoteColumnIndex, String firstVoteRowIndex,
+        String idColumnIndex, String precinctColumnIndex, String provider) {
+      this.filePath = filePath;
+      this.firstVoteColumnIndex = firstVoteColumnIndex;
+      this.firstVoteRowIndex = firstVoteRowIndex;
+      this.idColumnIndex = idColumnIndex;
+      this.precinctColumnIndex = precinctColumnIndex;
+      this.provider = provider;
+    }
 
     // get underlying file path string
     public String getFilePath() {
@@ -95,19 +108,19 @@ public class RawContestConfig {
       this.filePath = filePath;
     }
 
-    public Integer getFirstVoteColumnIndex() {
+    public String getFirstVoteColumnIndex() {
       return firstVoteColumnIndex;
     }
 
-    public void setFirstVoteColumnIndex(Integer firstVoteColumnIndex) {
+    public void setFirstVoteColumnIndex(String firstVoteColumnIndex) {
       this.firstVoteColumnIndex = firstVoteColumnIndex;
     }
 
-    public Integer getFirstVoteRowIndex() {
+    public String getFirstVoteRowIndex() {
       return firstVoteRowIndex;
     }
 
-    public void setFirstVoteRowIndex(Integer firstVoteRowIndex) {
+    public void setFirstVoteRowIndex(String firstVoteRowIndex) {
       this.firstVoteRowIndex = firstVoteRowIndex;
     }
 

--- a/src/main/java/network/brightspots/rcv/RawContestConfig.java
+++ b/src/main/java/network/brightspots/rcv/RawContestConfig.java
@@ -193,13 +193,13 @@ public class RawContestConfig {
     // which overvote rule to use
     public String overvoteRule;
     public String winnerElectionMode;
-    public Integer randomSeed;
+    public String randomSeed;
     // setting for number of winners
-    public Integer numberOfWinners;
+    public String numberOfWinners;
     // how far to round vote values when performing arithmetic
-    public Integer decimalPlacesForVoteArithmetic;
+    public String decimalPlacesForVoteArithmetic;
     // minimum votes needed to continue
-    public Integer minimumVoteThreshold;
+    public String minimumVoteThreshold;
     // max number of skipped rankings allowed
     public String maxSkippedRanksAllowed;
     // max rankings allowed

--- a/src/main/java/network/brightspots/rcv/StreamingCVRReader.java
+++ b/src/main/java/network/brightspots/rcv/StreamingCVRReader.java
@@ -100,8 +100,8 @@ class StreamingCVRReader {
     this.excelFileName = new File(excelFilePath).getName();
 
     // to keep our code simple, we convert 1-indexed user-supplied values to 0-indexed here
-    this.firstVoteColumnIndex = source.getFirstVoteColumnIndex() - 1;
-    this.firstVoteRowIndex = source.getFirstVoteRowIndex() - 1;
+    this.firstVoteColumnIndex = Integer.parseInt(source.getFirstVoteColumnIndex()) - 1;
+    this.firstVoteRowIndex = Integer.parseInt(source.getFirstVoteRowIndex()) - 1;
     this.idColumnIndex =
         isNullOrBlank(source.getIdColumnIndex()) ? null
             : Integer.parseInt(source.getIdColumnIndex()) - 1;

--- a/src/main/resources/network/brightspots/rcv/config_file_documentation.txt
+++ b/src/main/resources/network/brightspots/rcv/config_file_documentation.txt
@@ -134,7 +134,6 @@ Config file must be valid JSON format. Examples can be found in the test_data fo
       "randomSeed" required when tiebreakMode is random, previousRoundCountsThenRandom, or generatePermutation
         the integer seed for the application's pseudorandom number generator
         value: [0..2147483647]
-        if not supplied: null
 
       "numberOfWinners" required
         the number of seats to be won in this contest

--- a/src/main/resources/network/brightspots/rcv/config_file_documentation.txt
+++ b/src/main/resources/network/brightspots/rcv/config_file_documentation.txt
@@ -55,20 +55,21 @@ Config file must be valid JSON format. Examples can be found in the test_data fo
         if not supplied: false
 
   "cvrFileSources" required
-    list of input CVR file paths and their associated parameters
+    list of input cast vote record (CVR) file paths and their associated parameters
     each "cvrFileSources" list item contains the following parameters:
 
       "filePath" required
         location of the CVR file
+        if this is a ".json" file (and the provider is "CDF") the CVR file will be read as NIST Common Data Format (CDF)
         example: /Users/test_data/2015-portland-mayor-cvr.xlsx
         value: string of length [1..1000]
 
-      "firstVoteColumnIndex" required unless source is JSON
+      "firstVoteColumnIndex" required unless source is CDF
         index of the column (starting from 1) that contains the top-ranked candidate for each CVR
         example: 3
         value: [1..1000]
 
-      "firstVoteRowIndex" required unless source is JSON
+      "firstVoteRowIndex" required unless source is CDF
         index of the row (starting from 1) that contains the rankings for the first CVR
         example: 2
         value: [1..100000]
@@ -85,10 +86,10 @@ Config file must be valid JSON format. Examples can be found in the test_data fo
 
       "provider" optional
         text description of the vendor / machine which generated this file
+        if set to "CDF" (and the filePath is ".json") the CVR file will be read as NIST Common Data Format (CDF)
         example: "ES&S"
-        if set to "CDF" the CVR file will be read as NIST Common Data Format
-        if not supplied: file will be read as ES&S format
         value: text string of length [1..1000]
+        if not supplied: file will be read as ES&S format
 
   "candidates" required
     list of registered candidate names and associated candidate code (note: leave empty when CVR is in Common Data Format)


### PR DESCRIPTION
Fixes #211. Cleaned up migrateConfigVersion() (fixes #345); enum choiceBox elements in GUI now load as blank when bad values are present in the config.

Set up suggested outputDirectory of "output".

Changes RawConfig firstVoteColumnIndex and firstVoteRowIndex fields to Strings; tightens up editing of CVR sources in GUI (fixes #325); ContestConfig.isCdf also checks file extension now.

Converted RawContestConfig fields randomSeed, numberOfWinners, decimalPlacesForVoteArithmetic, minimumVoteThreshold to Strings; refactored and cleaned up validation logic; got rid of TextFieldListenerNonNegInt (fixes #139).