### PR TITLE
Consolidates validation logic

### DIFF
--- a/src/main/java/network/brightspots/rcv/ContestConfig.java
+++ b/src/main/java/network/brightspots/rcv/ContestConfig.java
@@ -58,10 +58,10 @@ class ContestConfig {
   static final BigDecimal SUGGESTED_MINIMUM_VOTE_THRESHOLD = BigDecimal.ZERO;
   static final int SUGGESTED_MAX_SKIPPED_RANKS_ALLOWED = 1;
   static final WinnerElectionMode SUGGESTED_WINNER_ELECTION_MODE = WinnerElectionMode.STANDARD;
-  static final int MIN_COLUMN_INDEX = 1;
-  static final int MAX_COLUMN_INDEX = 1000;
-  static final int MIN_ROW_INDEX = 1;
-  static final int MAX_ROW_INDEX = 100000;
+  private static final int MIN_COLUMN_INDEX = 1;
+  private static final int MAX_COLUMN_INDEX = 1000;
+  private static final int MIN_ROW_INDEX = 1;
+  private static final int MAX_ROW_INDEX = 100000;
   private static final int MIN_MAX_RANKINGS_ALLOWED = 1;
   private static final int MIN_MAX_SKIPPED_RANKS_ALLOWED = 0;
   private static final int MIN_NUMBER_OF_WINNERS = 1;
@@ -224,21 +224,22 @@ class ContestConfig {
     return isValid;
   }
 
-  private void invalidateAndLog(String message, String inputLocation) {
-    isValid = false;
+  private static void logWithLocation(String message, String inputLocation) {
     message += inputLocation == null ? "!" : ": " + inputLocation;
     Logger.log(Level.SEVERE, message);
   }
 
-  // Makes sure String input can be converted to an int, and checks that int against boundaries
-  private void checkStringToIntWithBoundaries(String input, String inputName, Integer lowerBoundary,
+  // Returns true if String input can be converted to an int and is within supplied boundaries
+  private static boolean checkStringToIntWithBoundaries(String input, String inputName,
+      Integer lowerBoundary,
       Integer upperBoundary, boolean isRequired) {
-    checkStringToIntWithBoundaries(input, inputName, lowerBoundary, upperBoundary, isRequired,
+    return checkStringToIntWithBoundaries(input, inputName, lowerBoundary, upperBoundary,
+        isRequired,
         null);
   }
 
-  // Makes sure String input can be converted to an int, and checks that int against boundaries
-  private void checkStringToIntWithBoundaries(
+  // Returns true if String input can be converted to an int and is within supplied boundaries
+  private static boolean checkStringToIntWithBoundaries(
       String input, String inputName, Integer lowerBoundary, Integer upperBoundary,
       boolean isRequired, String inputLocation) {
     lowerBoundary = lowerBoundary != null ? lowerBoundary : Integer.MIN_VALUE;
@@ -249,9 +250,11 @@ class ContestConfig {
     } else {
       message += String.format(" from %d to %d", lowerBoundary, upperBoundary);
     }
+    boolean stringValid = true;
     if (isNullOrBlank(input)) {
       if (isRequired) {
-        invalidateAndLog(message, inputLocation);
+        stringValid = false;
+        logWithLocation(message, inputLocation);
       }
     } else {
       try {
@@ -260,15 +263,18 @@ class ContestConfig {
           if (!isRequired) {
             message += " if supplied";
           }
-          invalidateAndLog(message, inputLocation);
+          stringValid = false;
+          logWithLocation(message, inputLocation);
         }
       } catch (NumberFormatException e) {
         if (!isRequired) {
           message += " if supplied";
         }
-        invalidateAndLog(message, inputLocation);
+        stringValid = false;
+        logWithLocation(message, inputLocation);
       }
     }
+    return stringValid;
   }
 
   // version validation and migration logic goes here
@@ -296,78 +302,48 @@ class ContestConfig {
     }
   }
 
-  private void validateCvrFileSources() {
-    if (rawConfig.cvrFileSources == null || rawConfig.cvrFileSources.isEmpty()) {
-      isValid = false;
-      Logger.log(Level.SEVERE, "Contest config must contain at least 1 cast vote record file!");
+  static boolean isCvrSourceValid(CVRSource source) {
+    boolean sourceValid = true;
+    // perform checks on source input path
+    if (isNullOrBlank(source.getFilePath())) {
+      sourceValid = false;
+      Logger.log(Level.SEVERE, "filePath is required for each cast vote record file!");
     } else {
-      HashSet<String> cvrFilePathSet = new HashSet<>();
-      for (CVRSource source : rawConfig.cvrFileSources) {
-        // perform checks on source input path
-        if (isNullOrBlank(source.getFilePath())) {
-          isValid = false;
-          Logger.log(Level.SEVERE, "filePath is required for each cast vote record file!");
-          break;
-        }
+      // ensure valid first vote column value
+      if (!checkStringToIntWithBoundaries(source.getFirstVoteColumnIndex(), "firstVoteColumnIndex",
+          MIN_COLUMN_INDEX, MAX_COLUMN_INDEX, !isCdf(source), source.getFilePath())) {
+        sourceValid = false;
+      }
 
-        // full path to CVR
-        String cvrPath = resolveConfigPath(source.getFilePath());
+      // ensure valid first vote row value
+      if (!checkStringToIntWithBoundaries(source.getFirstVoteRowIndex(), "firstVoteRowIndex",
+          MIN_ROW_INDEX, MAX_ROW_INDEX, !isCdf(source), source.getFilePath())) {
+        sourceValid = false;
+      }
 
-        // look for duplicate paths
-        if (cvrFilePathSet.contains(cvrPath)) {
-          isValid = false;
-          Logger.log(
-              Level.SEVERE, "Duplicate cast vote record filePaths are not allowed: %s", cvrPath);
-        } else {
-          cvrFilePathSet.add(cvrPath);
-        }
+      // ensure valid id column value
+      if (!checkStringToIntWithBoundaries(source.getIdColumnIndex(), "idColumnIndex",
+          MIN_COLUMN_INDEX, MAX_COLUMN_INDEX, false, source.getFilePath())) {
+        sourceValid = false;
+      }
 
-        // ensure file exists
-        if (!new File(cvrPath).exists()) {
-          isValid = false;
-          Logger.log(Level.SEVERE, "Cast vote record file not found: %s", cvrPath);
-        }
-
-        // perform CDF checks
-        if (isCdf(source)) {
-          if (rawConfig.cvrFileSources.size() != 1) {
-            isValid = false;
-            Logger.log(Level.SEVERE, "CDF files must be tabulated individually.");
-          }
-          if (isTabulateByPrecinctEnabled()) {
-            isValid = false;
-            Logger.log(Level.SEVERE, "tabulateByPrecinct may not be used with CDF files.");
-          }
-        } else {
-          // perform ES&S checks
-
-          // ensure valid first vote column value
-          checkStringToIntWithBoundaries(source.getFirstVoteColumnIndex(), "firstVoteColumnIndex",
-              MIN_COLUMN_INDEX, MAX_COLUMN_INDEX, true, cvrPath);
-
-          // ensure valid first vote row value
-          checkStringToIntWithBoundaries(source.getFirstVoteRowIndex(), "firstVoteRowIndex",
-              MIN_ROW_INDEX, MAX_ROW_INDEX, true, cvrPath);
-
-          // ensure valid id column value
-          checkStringToIntWithBoundaries(source.getIdColumnIndex(), "idColumnIndex",
-              MIN_COLUMN_INDEX, MAX_COLUMN_INDEX, false, cvrPath);
-
-          // ensure valid precinct column value
-          checkStringToIntWithBoundaries(
-              source.getPrecinctColumnIndex(), "precinctColumnIndex", MIN_COLUMN_INDEX,
-              MAX_COLUMN_INDEX, false, cvrPath);
-
-          if (isNullOrBlank(source.getPrecinctColumnIndex()) && isTabulateByPrecinctEnabled()) {
-            isValid = false;
-            Logger.log(
-                Level.SEVERE,
-                "precinctColumnIndex is required when tabulateByPrecinct is enabled: %s",
-                cvrPath);
-          }
-        }
+      // ensure valid precinct column value
+      if (!checkStringToIntWithBoundaries(
+          source.getPrecinctColumnIndex(), "precinctColumnIndex", MIN_COLUMN_INDEX,
+          MAX_COLUMN_INDEX, false, source.getFilePath())) {
+        sourceValid = false;
       }
     }
+    return sourceValid;
+  }
+
+  static boolean isCandidateValid(Candidate candidate) {
+    boolean candidateValid = true;
+    if (isNullOrBlank(candidate.getName())) {
+      candidateValid = false;
+      Logger.log(Level.SEVERE, "A name is required for each candidate!");
+    }
+    return candidateValid;
   }
 
   // function: stringAlreadyInUseElsewhere
@@ -412,19 +388,76 @@ class ContestConfig {
     return inUse;
   }
 
+  private void validateCvrFileSources() {
+    if (rawConfig.cvrFileSources == null || rawConfig.cvrFileSources.isEmpty()) {
+      isValid = false;
+      Logger.log(Level.SEVERE, "Contest config must contain at least 1 cast vote record file!");
+    } else {
+      HashSet<String> cvrFilePathSet = new HashSet<>();
+      for (CVRSource source : rawConfig.cvrFileSources) {
+        if (!isCvrSourceValid(source)) {
+          isValid = false;
+        }
+
+        // full path to CVR
+        String cvrPath =
+            isNullOrBlank(source.getFilePath()) ? null : resolveConfigPath(source.getFilePath());
+
+        // look for duplicate paths
+        if (cvrFilePathSet.contains(cvrPath)) {
+          isValid = false;
+          Logger.log(
+              Level.SEVERE, "Duplicate cast vote record filePaths are not allowed: %s", cvrPath);
+        } else {
+          cvrFilePathSet.add(cvrPath);
+        }
+
+        // ensure file exists
+        if (cvrPath != null && !new File(cvrPath).exists()) {
+          isValid = false;
+          Logger.log(Level.SEVERE, "Cast vote record file not found: %s", cvrPath);
+        }
+
+        if (isCdf(source)) {
+          // perform CDF checks
+          if (rawConfig.cvrFileSources.size() != 1) {
+            isValid = false;
+            Logger.log(Level.SEVERE, "CDF files must be tabulated individually.");
+          }
+          if (isTabulateByPrecinctEnabled()) {
+            isValid = false;
+            Logger.log(Level.SEVERE, "tabulateByPrecinct may not be used with CDF files.");
+          }
+        } else {
+          // perform ES&S checks
+          if (isNullOrBlank(source.getPrecinctColumnIndex()) && isTabulateByPrecinctEnabled()) {
+            isValid = false;
+            Logger.log(
+                Level.SEVERE,
+                "precinctColumnIndex is required when tabulateByPrecinct is enabled: %s",
+                cvrPath);
+          }
+        }
+      }
+    }
+  }
+
   private void validateCandidates() {
     Set<String> candidateNameSet = new HashSet<>();
     Set<String> candidateCodeSet = new HashSet<>();
 
     for (Candidate candidate : rawConfig.candidates) {
-      if (isNullOrBlank(candidate.getName())) {
+      if (!isCandidateValid(candidate)) {
         isValid = false;
-        Logger.log(Level.SEVERE, "Name is required for each candidate!");
-      } else if (candidateStringAlreadyInUseElsewhere(
-          candidate.getName(), "name", candidateNameSet)) {
-        isValid = false;
-      } else {
-        candidateNameSet.add(candidate.getName());
+      }
+
+      if (!isNullOrBlank(candidate.getName())) {
+        if (candidateStringAlreadyInUseElsewhere(
+            candidate.getName(), "name", candidateNameSet)) {
+          isValid = false;
+        } else {
+          candidateNameSet.add(candidate.getName());
+        }
       }
 
       if (!isNullOrBlank(candidate.getCode())) {
@@ -502,16 +535,22 @@ class ContestConfig {
           Integer.MAX_VALUE);
     }
 
-    checkStringToIntWithBoundaries(getNumberOfWinnersRaw(), "numberOfWinners",
+    if (!checkStringToIntWithBoundaries(getNumberOfWinnersRaw(), "numberOfWinners",
         MIN_NUMBER_OF_WINNERS, getNumDeclaredCandidates() < 1 ? null : getNumDeclaredCandidates(),
-        true);
+        true)) {
+      isValid = false;
+    }
 
-    checkStringToIntWithBoundaries(getDecimalPlacesForVoteArithmeticRaw(),
+    if (!checkStringToIntWithBoundaries(getDecimalPlacesForVoteArithmeticRaw(),
         "decimalPlacesForVoteArithmetic",
-        MIN_DECIMAL_PLACES_FOR_VOTE_ARITHMETIC, MAX_DECIMAL_PLACES_FOR_VOTE_ARITHMETIC, true);
+        MIN_DECIMAL_PLACES_FOR_VOTE_ARITHMETIC, MAX_DECIMAL_PLACES_FOR_VOTE_ARITHMETIC, true)) {
+      isValid = false;
+    }
 
-    checkStringToIntWithBoundaries(getMinimumVoteThresholdRaw(), "minimumVoteThreshold",
-        MIN_MINIMUM_VOTE_THRESHOLD, MAX_MINIMUM_VOTE_THRESHOLD, true);
+    if (!checkStringToIntWithBoundaries(getMinimumVoteThresholdRaw(), "minimumVoteThreshold",
+        MIN_MINIMUM_VOTE_THRESHOLD, MAX_MINIMUM_VOTE_THRESHOLD, true)) {
+      isValid = false;
+    }
 
     // If this is a multi-seat contest, we validate a couple extra parameters.
     if (Utils.isInt(getNumberOfWinnersRaw()) && getNumberOfWinners() > 1) {
@@ -560,7 +599,10 @@ class ContestConfig {
           "batchElimination can't be true when winnerElectionMode is multiSeatBottomsUp!");
     }
 
-    checkStringToIntWithBoundaries(getRandomSeedRaw(), "randomSeed", MIN_RANDOM_SEED, null, false);
+    if (!checkStringToIntWithBoundaries(getRandomSeedRaw(), "randomSeed", MIN_RANDOM_SEED, null,
+        false)) {
+      isValid = false;
+    }
 
     if (!isNullOrBlank(getOvervoteLabel()) && stringAlreadyInUseElsewhere(getOvervoteLabel(),
         "overvoteLabel")) {

--- a/src/main/java/network/brightspots/rcv/ContestConfig.java
+++ b/src/main/java/network/brightspots/rcv/ContestConfig.java
@@ -229,36 +229,34 @@ class ContestConfig {
     Logger.log(Level.SEVERE, message);
   }
 
-  // Returns true if String input can be converted to an int and is within supplied boundaries
-  private static boolean checkStringToIntWithBoundaries(String input, String inputName,
-      Integer lowerBoundary,
-      Integer upperBoundary, boolean isRequired) {
-    return checkStringToIntWithBoundaries(input, inputName, lowerBoundary, upperBoundary,
+  // Returns true if field value can't be converted to an int or isn't within supplied boundaries
+  private static boolean fieldOutOfRangeOrNotInt(String value, String fieldName,
+      Integer lowerBoundary, Integer upperBoundary, boolean isRequired) {
+    return fieldOutOfRangeOrNotInt(value, fieldName, lowerBoundary, upperBoundary,
         isRequired,
         null);
   }
 
-  // Returns true if String input can be converted to an int and is within supplied boundaries
-  private static boolean checkStringToIntWithBoundaries(
-      String input, String inputName, Integer lowerBoundary, Integer upperBoundary,
-      boolean isRequired, String inputLocation) {
+  // Returns true if field value can't be converted to an int or isn't within supplied boundaries
+  private static boolean fieldOutOfRangeOrNotInt(String value, String fieldName,
+      Integer lowerBoundary, Integer upperBoundary, boolean isRequired, String inputLocation) {
     lowerBoundary = lowerBoundary != null ? lowerBoundary : Integer.MIN_VALUE;
     upperBoundary = upperBoundary != null ? upperBoundary : Integer.MAX_VALUE;
-    String message = String.format("%s must be an integer", inputName);
+    String message = String.format("%s must be an integer", fieldName);
     if (lowerBoundary.equals(upperBoundary)) {
       message += String.format(" equal to %d", lowerBoundary);
     } else {
       message += String.format(" from %d to %d", lowerBoundary, upperBoundary);
     }
     boolean stringValid = true;
-    if (isNullOrBlank(input)) {
+    if (isNullOrBlank(value)) {
       if (isRequired) {
         stringValid = false;
         logWithLocation(message, inputLocation);
       }
     } else {
       try {
-        int stringInt = Integer.parseInt(input);
+        int stringInt = Integer.parseInt(value);
         if (stringInt < lowerBoundary || stringInt > upperBoundary) {
           if (!isRequired) {
             message += " if supplied";
@@ -274,7 +272,7 @@ class ContestConfig {
         logWithLocation(message, inputLocation);
       }
     }
-    return stringValid;
+    return !stringValid;
   }
 
   // version validation and migration logic goes here
@@ -310,25 +308,25 @@ class ContestConfig {
       Logger.log(Level.SEVERE, "filePath is required for each cast vote record file!");
     } else {
       // ensure valid first vote column value
-      if (!checkStringToIntWithBoundaries(source.getFirstVoteColumnIndex(), "firstVoteColumnIndex",
+      if (fieldOutOfRangeOrNotInt(source.getFirstVoteColumnIndex(), "firstVoteColumnIndex",
           MIN_COLUMN_INDEX, MAX_COLUMN_INDEX, !isCdf(source), source.getFilePath())) {
         sourceValid = false;
       }
 
       // ensure valid first vote row value
-      if (!checkStringToIntWithBoundaries(source.getFirstVoteRowIndex(), "firstVoteRowIndex",
+      if (fieldOutOfRangeOrNotInt(source.getFirstVoteRowIndex(), "firstVoteRowIndex",
           MIN_ROW_INDEX, MAX_ROW_INDEX, !isCdf(source), source.getFilePath())) {
         sourceValid = false;
       }
 
       // ensure valid id column value
-      if (!checkStringToIntWithBoundaries(source.getIdColumnIndex(), "idColumnIndex",
+      if (fieldOutOfRangeOrNotInt(source.getIdColumnIndex(), "idColumnIndex",
           MIN_COLUMN_INDEX, MAX_COLUMN_INDEX, false, source.getFilePath())) {
         sourceValid = false;
       }
 
       // ensure valid precinct column value
-      if (!checkStringToIntWithBoundaries(
+      if (fieldOutOfRangeOrNotInt(
           source.getPrecinctColumnIndex(), "precinctColumnIndex", MIN_COLUMN_INDEX,
           MAX_COLUMN_INDEX, false, source.getFilePath())) {
         sourceValid = false;
@@ -535,19 +533,19 @@ class ContestConfig {
           Integer.MAX_VALUE);
     }
 
-    if (!checkStringToIntWithBoundaries(getNumberOfWinnersRaw(), "numberOfWinners",
+    if (fieldOutOfRangeOrNotInt(getNumberOfWinnersRaw(), "numberOfWinners",
         MIN_NUMBER_OF_WINNERS, getNumDeclaredCandidates() < 1 ? null : getNumDeclaredCandidates(),
         true)) {
       isValid = false;
     }
 
-    if (!checkStringToIntWithBoundaries(getDecimalPlacesForVoteArithmeticRaw(),
+    if (fieldOutOfRangeOrNotInt(getDecimalPlacesForVoteArithmeticRaw(),
         "decimalPlacesForVoteArithmetic",
         MIN_DECIMAL_PLACES_FOR_VOTE_ARITHMETIC, MAX_DECIMAL_PLACES_FOR_VOTE_ARITHMETIC, true)) {
       isValid = false;
     }
 
-    if (!checkStringToIntWithBoundaries(getMinimumVoteThresholdRaw(), "minimumVoteThreshold",
+    if (fieldOutOfRangeOrNotInt(getMinimumVoteThresholdRaw(), "minimumVoteThreshold",
         MIN_MINIMUM_VOTE_THRESHOLD, MAX_MINIMUM_VOTE_THRESHOLD, true)) {
       isValid = false;
     }
@@ -599,7 +597,7 @@ class ContestConfig {
           "batchElimination can't be true when winnerElectionMode is multiSeatBottomsUp!");
     }
 
-    if (!checkStringToIntWithBoundaries(getRandomSeedRaw(), "randomSeed", MIN_RANDOM_SEED, null,
+    if (fieldOutOfRangeOrNotInt(getRandomSeedRaw(), "randomSeed", MIN_RANDOM_SEED, null,
         false)) {
       isValid = false;
     }

--- a/src/main/java/network/brightspots/rcv/ContestConfig.java
+++ b/src/main/java/network/brightspots/rcv/ContestConfig.java
@@ -224,7 +224,7 @@ class ContestConfig {
     return isValid;
   }
 
-  private static void logWithLocation(String message, String inputLocation) {
+  private static void logErrorWithLocation(String message, String inputLocation) {
     message += inputLocation == null ? "!" : ": " + inputLocation;
     Logger.log(Level.SEVERE, message);
   }
@@ -252,7 +252,7 @@ class ContestConfig {
     if (isNullOrBlank(value)) {
       if (isRequired) {
         stringValid = false;
-        logWithLocation(message, inputLocation);
+        logErrorWithLocation(message, inputLocation);
       }
     } else {
       try {
@@ -262,14 +262,14 @@ class ContestConfig {
             message += " if supplied";
           }
           stringValid = false;
-          logWithLocation(message, inputLocation);
+          logErrorWithLocation(message, inputLocation);
         }
       } catch (NumberFormatException e) {
         if (!isRequired) {
           message += " if supplied";
         }
         stringValid = false;
-        logWithLocation(message, inputLocation);
+        logErrorWithLocation(message, inputLocation);
       }
     }
     return !stringValid;
@@ -300,7 +300,7 @@ class ContestConfig {
     }
   }
 
-  static boolean isCvrSourceValid(CVRSource source) {
+  static boolean passesBasicCvrSourceValidation(CVRSource source) {
     boolean sourceValid = true;
     // perform checks on source input path
     if (isNullOrBlank(source.getFilePath())) {
@@ -335,7 +335,7 @@ class ContestConfig {
     return sourceValid;
   }
 
-  static boolean isCandidateValid(Candidate candidate) {
+  static boolean passesBasicCandidateValidation(Candidate candidate) {
     boolean candidateValid = true;
     if (isNullOrBlank(candidate.getName())) {
       candidateValid = false;
@@ -393,7 +393,7 @@ class ContestConfig {
     } else {
       HashSet<String> cvrFilePathSet = new HashSet<>();
       for (CVRSource source : rawConfig.cvrFileSources) {
-        if (!isCvrSourceValid(source)) {
+        if (!passesBasicCvrSourceValidation(source)) {
           isValid = false;
         }
 
@@ -445,7 +445,7 @@ class ContestConfig {
     Set<String> candidateCodeSet = new HashSet<>();
 
     for (Candidate candidate : rawConfig.candidates) {
-      if (!isCandidateValid(candidate)) {
+      if (!passesBasicCandidateValidation(candidate)) {
         isValid = false;
       }
 

--- a/src/main/java/network/brightspots/rcv/GuiConfigController.java
+++ b/src/main/java/network/brightspots/rcv/GuiConfigController.java
@@ -352,7 +352,7 @@ public class GuiConfigController implements Initializable {
         getTextOrEmptyString(textFieldCvrFirstVoteCol),
         getTextOrEmptyString(textFieldCvrFirstVoteRow), getTextOrEmptyString(textFieldCvrIdCol),
         getTextOrEmptyString(textFieldCvrPrecinctCol), getTextOrEmptyString(textFieldCvrProvider));
-    if (ContestConfig.isCvrSourceValid(cvrSource)) {
+    if (ContestConfig.passesBasicCvrSourceValidation(cvrSource)) {
       tableViewCvrFiles.getItems().add(cvrSource);
       textFieldCvrFilePath.clear();
       textFieldCvrFirstVoteCol.clear();
@@ -408,7 +408,7 @@ public class GuiConfigController implements Initializable {
   public void buttonAddCandidateClicked() {
     Candidate candidate = new Candidate(getTextOrEmptyString(textFieldCandidateName),
         getTextOrEmptyString(textFieldCandidateCode), ContestConfig.SUGGESTED_CANDIDATE_EXCLUDED);
-    if (ContestConfig.isCandidateValid(candidate)) {
+    if (ContestConfig.passesBasicCandidateValidation(candidate)) {
       tableViewCandidates.getItems().add(candidate);
       textFieldCandidateName.clear();
       textFieldCandidateCode.clear();

--- a/src/main/java/network/brightspots/rcv/GuiConfigController.java
+++ b/src/main/java/network/brightspots/rcv/GuiConfigController.java
@@ -347,42 +347,12 @@ public class GuiConfigController implements Initializable {
     }
   }
 
-  private boolean cvrSourceHasRequiredFields(CVRSource source) {
-    boolean hasRequiredFields = true;
-    if (source.getFilePath().isBlank()) {
-      hasRequiredFields = false;
-      Logger.log(Level.WARNING, "filePath is required!");
-    }
-    if (!ContestConfig.isCdf(source)) {
-      String colIndex = source.getFirstVoteColumnIndex();
-      if (!Utils.isInt(colIndex) || Integer.parseInt(colIndex) < ContestConfig.MIN_COLUMN_INDEX
-          || Integer.parseInt(colIndex) > ContestConfig.MAX_COLUMN_INDEX) {
-        hasRequiredFields = false;
-        Logger.log(Level.WARNING,
-            "firstVoteColumnIndex must be an integer from %d to %d for non-CDF files!",
-            ContestConfig.MIN_COLUMN_INDEX, ContestConfig.MAX_COLUMN_INDEX);
-      }
-      String rowIndex = source.getFirstVoteRowIndex();
-      if (!Utils.isInt(rowIndex)
-          || Integer.parseInt(rowIndex) < ContestConfig.MIN_ROW_INDEX
-          || Integer.parseInt(rowIndex) > ContestConfig.MAX_ROW_INDEX) {
-        hasRequiredFields = false;
-        Logger.log(
-            Level.WARNING,
-            "firstVoteRowIndex must be an integer from %d to %d for non-CDF files!",
-            ContestConfig.MIN_ROW_INDEX,
-            ContestConfig.MAX_ROW_INDEX);
-      }
-    }
-    return hasRequiredFields;
-  }
-
   public void buttonAddCvrFileClicked() {
     CVRSource cvrSource = new CVRSource(getTextOrEmptyString(textFieldCvrFilePath),
         getTextOrEmptyString(textFieldCvrFirstVoteCol),
         getTextOrEmptyString(textFieldCvrFirstVoteRow), getTextOrEmptyString(textFieldCvrIdCol),
         getTextOrEmptyString(textFieldCvrPrecinctCol), getTextOrEmptyString(textFieldCvrProvider));
-    if (cvrSourceHasRequiredFields(cvrSource)) {
+    if (ContestConfig.isCvrSourceValid(cvrSource)) {
       tableViewCvrFiles.getItems().add(cvrSource);
       textFieldCvrFilePath.clear();
       textFieldCvrFirstVoteCol.clear();
@@ -400,80 +370,45 @@ public class GuiConfigController implements Initializable {
   }
 
   public void changeCvrFilePath(CellEditEvent cellEditEvent) {
-    CVRSource cvrSelected = tableViewCvrFiles.getSelectionModel().getSelectedItem();
-    // Cache the original value to revert back to in case the change fails
-    String oldFilePath = cvrSelected.getFilePath();
-    cvrSelected.setFilePath(cellEditEvent.getNewValue().toString().trim());
-    if (!cvrSourceHasRequiredFields(cvrSelected)) {
-      cvrSelected.setFilePath(oldFilePath);
-    }
+    tableViewCvrFiles.getSelectionModel().getSelectedItem()
+        .setFilePath(cellEditEvent.getNewValue().toString().trim());
     tableViewCvrFiles.refresh();
   }
 
   public void changeCvrFirstVoteCol(CellEditEvent cellEditEvent) {
-    CVRSource cvrSelected = tableViewCvrFiles.getSelectionModel().getSelectedItem();
-    // Cache the original value to revert back to in case the change fails
-    String oldFirstVoteCol = cvrSelected.getFirstVoteColumnIndex();
-    cvrSelected.setFirstVoteColumnIndex(cellEditEvent.getNewValue().toString().trim());
-    if (!cvrSourceHasRequiredFields(cvrSelected)) {
-      cvrSelected.setFirstVoteColumnIndex(oldFirstVoteCol);
-    }
+    tableViewCvrFiles.getSelectionModel().getSelectedItem()
+        .setFirstVoteColumnIndex(cellEditEvent.getNewValue().toString().trim());
     tableViewCvrFiles.refresh();
   }
 
   public void changeCvrFirstVoteRow(CellEditEvent cellEditEvent) {
-    CVRSource cvrSelected = tableViewCvrFiles.getSelectionModel().getSelectedItem();
-    // Cache the original value to revert back to in case the change fails
-    String oldFirstVoteRow = cvrSelected.getFirstVoteRowIndex();
-    cvrSelected.setFirstVoteRowIndex(cellEditEvent.getNewValue().toString().trim());
-    if (!cvrSourceHasRequiredFields(cvrSelected)) {
-      cvrSelected.setFirstVoteRowIndex(oldFirstVoteRow);
-    }
+    tableViewCvrFiles.getSelectionModel().getSelectedItem()
+        .setFirstVoteRowIndex(cellEditEvent.getNewValue().toString().trim());
     tableViewCvrFiles.refresh();
   }
 
   public void changeCvrIdColIndex(CellEditEvent cellEditEvent) {
-    CVRSource cvrSelected = tableViewCvrFiles.getSelectionModel().getSelectedItem();
-    // Cache the original value to revert back to in case the change fails
-    String oldIdColIndex = cvrSelected.getIdColumnIndex();
-    cvrSelected.setIdColumnIndex(cellEditEvent.getNewValue().toString().trim());
-    if (!cvrSourceHasRequiredFields(cvrSelected)) {
-      cvrSelected.setIdColumnIndex(oldIdColIndex);
-    }
+    tableViewCvrFiles.getSelectionModel().getSelectedItem()
+        .setIdColumnIndex(cellEditEvent.getNewValue().toString().trim());
     tableViewCvrFiles.refresh();
   }
 
   public void changeCvrPrecinctColIndex(CellEditEvent cellEditEvent) {
-    CVRSource cvrSelected = tableViewCvrFiles.getSelectionModel().getSelectedItem();
-    // Cache the original value to revert back to in case the change fails
-    String oldPrecinctColIndex = cvrSelected.getPrecinctColumnIndex();
-    cvrSelected.setPrecinctColumnIndex(cellEditEvent.getNewValue().toString().trim());
-    if (!cvrSourceHasRequiredFields(cvrSelected)) {
-      cvrSelected.setPrecinctColumnIndex(oldPrecinctColIndex);
-    }
+    tableViewCvrFiles.getSelectionModel().getSelectedItem()
+        .setPrecinctColumnIndex(cellEditEvent.getNewValue().toString().trim());
     tableViewCvrFiles.refresh();
   }
 
   public void changeCvrProvider(CellEditEvent cellEditEvent) {
-    CVRSource cvrSelected = tableViewCvrFiles.getSelectionModel().getSelectedItem();
-    // Cache the original value to revert back to in case the change fails
-    String oldProvider = cvrSelected.getProvider();
-    cvrSelected.setProvider(cellEditEvent.getNewValue().toString().trim());
-    if (!cvrSourceHasRequiredFields(cvrSelected)) {
-      cvrSelected.setProvider(oldProvider);
-    }
+    tableViewCvrFiles.getSelectionModel().getSelectedItem()
+        .setProvider(cellEditEvent.getNewValue().toString().trim());
     tableViewCvrFiles.refresh();
   }
 
   public void buttonAddCandidateClicked() {
-    Candidate candidate = new Candidate();
-    String candidateName = getTextOrEmptyString(textFieldCandidateName);
-    if (candidateName.isBlank()) {
-      Logger.log(Level.WARNING, "Candidate name is required!");
-    } else {
-      candidate.setName(candidateName);
-      candidate.setCode(getTextOrEmptyString(textFieldCandidateCode));
-      candidate.setExcluded(ContestConfig.SUGGESTED_CANDIDATE_EXCLUDED);
+    Candidate candidate = new Candidate(getTextOrEmptyString(textFieldCandidateName),
+        getTextOrEmptyString(textFieldCandidateCode), ContestConfig.SUGGESTED_CANDIDATE_EXCLUDED);
+    if (ContestConfig.isCandidateValid(candidate)) {
       tableViewCandidates.getItems().add(candidate);
       textFieldCandidateName.clear();
       textFieldCandidateCode.clear();
@@ -487,12 +422,8 @@ public class GuiConfigController implements Initializable {
   }
 
   public void changeCandidateName(CellEditEvent cellEditEvent) {
-    String candidateName = cellEditEvent.getNewValue().toString().trim();
-    if (candidateName.isBlank()) {
-      Logger.log(Level.WARNING, "Candidate name is required!");
-    } else {
-      tableViewCandidates.getSelectionModel().getSelectedItem().setName(candidateName);
-    }
+    tableViewCandidates.getSelectionModel().getSelectedItem()
+        .setName(cellEditEvent.getNewValue().toString().trim());
     tableViewCandidates.refresh();
   }
 

--- a/src/main/java/network/brightspots/rcv/RawContestConfig.java
+++ b/src/main/java/network/brightspots/rcv/RawContestConfig.java
@@ -153,6 +153,16 @@ public class RawContestConfig {
   @JsonIgnoreProperties(ignoreUnknown = true)
   @JsonInclude(JsonInclude.Include.NON_NULL)
   public static class Candidate {
+
+    public Candidate() {
+    }
+
+    public Candidate(String name, String code, boolean excluded) {
+      this.name = name;
+      this.code = code;
+      this.excluded = excluded;
+    }
+
     // full candidate name
     private String name;
     // candidate ID

--- a/src/main/java/network/brightspots/rcv/RawContestConfig.java
+++ b/src/main/java/network/brightspots/rcv/RawContestConfig.java
@@ -88,8 +88,13 @@ public class RawContestConfig {
     public CVRSource() {
     }
 
-    public CVRSource(String filePath, String firstVoteColumnIndex, String firstVoteRowIndex,
-        String idColumnIndex, String precinctColumnIndex, String provider) {
+    public CVRSource(
+        String filePath,
+        String firstVoteColumnIndex,
+        String firstVoteRowIndex,
+        String idColumnIndex,
+        String precinctColumnIndex,
+        String provider) {
       this.filePath = filePath;
       this.firstVoteColumnIndex = firstVoteColumnIndex;
       this.firstVoteRowIndex = firstVoteRowIndex;
@@ -153,6 +158,11 @@ public class RawContestConfig {
   @JsonIgnoreProperties(ignoreUnknown = true)
   @JsonInclude(JsonInclude.Include.NON_NULL)
   public static class Candidate {
+    // full candidate name
+    private String name;
+    // candidate ID
+    private String code;
+    private boolean excluded;
 
     public Candidate() {
     }
@@ -162,12 +172,6 @@ public class RawContestConfig {
       this.code = code;
       this.excluded = excluded;
     }
-
-    // full candidate name
-    private String name;
-    // candidate ID
-    private String code;
-    private boolean excluded;
 
     public String getName() {
       return name;


### PR DESCRIPTION
Consolidates validation logic for sources and candidates (progress on #371); disables validation check when changing cells to avoid situation where config with bad sources is loaded in the GUI and can't get corrected. Renames and inverts `checkStringToIntWithBoundaries` to `fieldOutOfRangeOrNotInt`.