### PR TITLE
fix two bugs related to undeclared write-ins

### DIFF
--- a/src/main/java/network/brightspots/rcv/Tabulator.java
+++ b/src/main/java/network/brightspots/rcv/Tabulator.java
@@ -442,7 +442,12 @@ class Tabulator {
           if (tally.compareTo(winningThreshold) >= 0) {
             // we have winner(s)
             List<String> winningCandidates = currentRoundTallyToCandidates.get(tally);
-            selectedWinners.addAll(winningCandidates);
+            for (String candidate : winningCandidates) {
+              // The undeclared write-in placeholder can't win!
+              if (!candidate.equals(config.getUndeclaredWriteInLabel())) {
+                selectedWinners.add(candidate);
+              }
+            }
           }
         }
       }

--- a/src/main/java/network/brightspots/rcv/Tabulator.java
+++ b/src/main/java/network/brightspots/rcv/Tabulator.java
@@ -503,9 +503,8 @@ class Tabulator {
     List<String> eliminated = new LinkedList<>();
     // undeclared label
     String label = config.getUndeclaredWriteInLabel();
-    if (currentRound == 1
-        && !isNullOrBlank(label)
-        && candidateIds.contains(label)
+    if (!isNullOrBlank(label)
+        && currentRoundCandidateToTally.get(label) != null
         && currentRoundCandidateToTally.get(label).signum() == 1) {
       eliminated.add(label);
       Logger.log(


### PR DESCRIPTION
Bug 1: in a multi-seat contest, if someone wins in the first round, we don't automatically eliminate undeclared write-ins before we eliminate any other candidates. Instead, we treat UWI like a normal candidate, which means we potentially eliminate other candidates with lower tallies first.

Bug 2: if UWI exceeds the winning threshold in the initial count, we mistakenly elect this candidate.