### PR TITLE
CastVoteRecord extensions

### DIFF
--- a/src/main/java/network/brightspots/rcv/CastVoteRecord.java
+++ b/src/main/java/network/brightspots/rcv/CastVoteRecord.java
@@ -46,7 +46,7 @@ class CastVoteRecord {
   private final String precinct;
   // contest associated with this CVR
   private String contestId = null;
-  //tabulatorId parsed from Dominion CVR data
+  // tabulatorId parsed from Dominion CVR data
   private String tabulatorId = null;
   // batchId parsed from Dominion CVR data
   private String batchId = null;

--- a/src/main/java/network/brightspots/rcv/CastVoteRecord.java
+++ b/src/main/java/network/brightspots/rcv/CastVoteRecord.java
@@ -45,11 +45,11 @@ class CastVoteRecord {
   // which precinct this ballot came from
   private final String precinct;
   // contest associated with this CVR
-  private Integer contestId = null;
+  private Integer contestId;
   // tabulatorId parsed from Dominion CVR data
-  private String tabulatorId = null;
+  private Integer tabulatorId;
   // batchId parsed from Dominion CVR data
-  private String batchId = null;
+  private Integer batchId;
   // container for ALL CVR data parsed from the source CVR file
   private final List<String> fullCvrData;
   // records winners to whom some fraction of this vote has been allocated

--- a/src/main/java/network/brightspots/rcv/CastVoteRecord.java
+++ b/src/main/java/network/brightspots/rcv/CastVoteRecord.java
@@ -45,7 +45,7 @@ class CastVoteRecord {
   // which precinct this ballot came from
   private final String precinct;
   // contest associated with this CVR
-  private String contestId = null;
+  private Integer contestId = null;
   // tabulatorId parsed from Dominion CVR data
   private String tabulatorId = null;
   // batchId parsed from Dominion CVR data

--- a/src/main/java/network/brightspots/rcv/CastVoteRecord.java
+++ b/src/main/java/network/brightspots/rcv/CastVoteRecord.java
@@ -44,6 +44,12 @@ class CastVoteRecord {
   private final String suppliedId;
   // which precinct this ballot came from
   private final String precinct;
+  // contest associated with this CVR
+  private String contestId = null;
+  //tabulatorId parsed from Dominion CVR data
+  private String tabulatorId = null;
+  // batchId parsed from Dominion CVR data
+  private String batchId = null;
   // container for ALL CVR data parsed from the source CVR file
   private final List<String> fullCvrData;
   // records winners to whom some fraction of this vote has been allocated

--- a/src/main/java/network/brightspots/rcv/RawContestConfig.java
+++ b/src/main/java/network/brightspots/rcv/RawContestConfig.java
@@ -143,6 +143,7 @@ public class RawContestConfig {
     private String name;
     private String code;
     private boolean excluded;
+    private Integer contestId;
 
     Candidate() {
     }
@@ -151,6 +152,13 @@ public class RawContestConfig {
       this.name = name;
       this.code = code;
       this.excluded = excluded;
+    }
+
+    Candidate(String name, String code, boolean excluded, Integer contestId) {
+      this.name = name;
+      this.code = code;
+      this.excluded = excluded;
+      this.contestId = contestId;
     }
 
     public String getName() {


### PR DESCRIPTION
Additional CastVoteRecord fields to support #407 and #404.

When #407 is complete these fields will be populated with data from imported CVR json data.  A user input contestId can then be used to filter exported output by contestId.  In the interim some hard-coded or programmatic values can be faked here to move forward with #404 in parallel.  
