### PR TITLE
Providers dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The Tabulator produces the following as output:
 
 #### Method 2 (Less Easy): Compile and Run Using Gradle
 
-1. Install [JDK 11 or higher](https://jdk.java.net/), and make sure your Java path is picking it up properly by verifying that the following command returns the expected version:
+1. Install [JDK 14 or higher](https://jdk.java.net/), and make sure your Java path is picking it up properly by verifying that the following command returns the expected version:
     
     `$ java -version`
     

--- a/src/main/java/network/brightspots/rcv/ContestConfig.java
+++ b/src/main/java/network/brightspots/rcv/ContestConfig.java
@@ -835,7 +835,6 @@ class ContestConfig {
   enum Provider {
     CDF("CDF"),
     ESS("ES&S"),
-    GENERIC("Generic format"),
     HART("Hart"),
     PROVIDER_UNKNOWN("Provider unknown");
 

--- a/src/main/java/network/brightspots/rcv/ContestConfig.java
+++ b/src/main/java/network/brightspots/rcv/ContestConfig.java
@@ -208,6 +208,11 @@ class ContestConfig {
           source.getFilePath())) {
         sourceValid = false;
       }
+
+      if (!sourceValid) {
+        Logger.log(Level.SEVERE, "The above error(s) pertain(s) to cast vote record source: %s",
+            source.getFilePath());
+      }
     }
     return sourceValid;
   }

--- a/src/main/java/network/brightspots/rcv/ContestConfig.java
+++ b/src/main/java/network/brightspots/rcv/ContestConfig.java
@@ -858,6 +858,10 @@ class ContestConfig {
     }
   }
 
+  static class UnrecognizedProviderException extends Exception {
+
+  }
+
   private String getMaxRankingsAllowedRaw() {
     return rawConfig.rules.maxRankingsAllowed;
   }

--- a/src/main/java/network/brightspots/rcv/ContestConfig.java
+++ b/src/main/java/network/brightspots/rcv/ContestConfig.java
@@ -457,12 +457,12 @@ class ContestConfig {
           }
         }
 
-        if (isNullOrBlank(getContestId()) && isHart(source)) {
+        if (isNullOrBlank(getContestId()) && getProvider(source) == Provider.HART) {
           isValid = false;
           Logger.log(
               Level.SEVERE,
               "contestId is required for Hart files.");
-        } else if (!isNullOrBlank(getContestId()) && !isHart(source)) {
+        } else if (!isNullOrBlank(getContestId()) && getProvider(source) != Provider.HART) {
           isValid = false;
           Logger.log(
               Level.SEVERE,

--- a/src/main/java/network/brightspots/rcv/ContestConfig.java
+++ b/src/main/java/network/brightspots/rcv/ContestConfig.java
@@ -82,8 +82,7 @@ class ContestConfig {
   static final String SUGGESTED_MAX_RANKINGS_ALLOWED = MAX_RANKINGS_ALLOWED_NUM_CANDIDATES_OPTION;
 
   static boolean isCdf(CvrSource source) {
-    return source.getProvider() != null
-        && Provider.getByLabel(source.getProvider()) == Provider.CDF
+    return getProvider(source) == Provider.CDF
         && source.getFilePath() != null
         && source.getFilePath().toLowerCase().endsWith(JSON_EXTENSION);
   }
@@ -146,11 +145,6 @@ class ContestConfig {
 
   static ContestConfig loadContestConfig(String configPath) {
     return loadContestConfig(configPath, false);
-  }
-
-  static boolean isHart(CvrSource source) {
-    return source.getProvider() != null
-        && Provider.getByLabel(source.getProvider()) == Provider.HART;
   }
 
   static boolean passesBasicCvrSourceValidation(CvrSource source) {
@@ -839,11 +833,11 @@ class ContestConfig {
   }
 
   enum Provider {
-    ESS("ES&S"),
-    DOMINION("Dominion"),
-    HART("Hart"),
     CDF("CDF"),
-    PROVIDER_UNKNOWN("Provider Unknown");
+    ESS("ES&S"),
+    GENERIC("Generic format"),
+    HART("Hart"),
+    PROVIDER_UNKNOWN("Provider unknown");
 
     private final String label;
 

--- a/src/main/java/network/brightspots/rcv/GuiConfigController.java
+++ b/src/main/java/network/brightspots/rcv/GuiConfigController.java
@@ -61,6 +61,7 @@ import javafx.stage.DirectoryChooser;
 import javafx.stage.FileChooser;
 import javafx.stage.FileChooser.ExtensionFilter;
 import javafx.util.StringConverter;
+import network.brightspots.rcv.ContestConfig.Provider;
 import network.brightspots.rcv.RawContestConfig.Candidate;
 import network.brightspots.rcv.RawContestConfig.ContestRules;
 import network.brightspots.rcv.RawContestConfig.CvrSource;
@@ -129,7 +130,7 @@ public class GuiConfigController implements Initializable {
   @FXML
   private TextField textFieldCvrPrecinctCol;
   @FXML
-  private TextField textFieldCvrProvider;
+  private ChoiceBox<Provider> choiceCvrProvider;
   @FXML
   private TableView<Candidate> tableViewCandidates;
   @FXML
@@ -427,15 +428,15 @@ public class GuiConfigController implements Initializable {
             getTextOrEmptyString(textFieldCvrFirstVoteRow),
             getTextOrEmptyString(textFieldCvrIdCol),
             getTextOrEmptyString(textFieldCvrPrecinctCol),
-            getTextOrEmptyString(textFieldCvrProvider));
+            getChoiceElse(choiceCvrProvider, Provider.PROVIDER_UNKNOWN));
     if (ContestConfig.passesBasicCvrSourceValidation(cvrSource)) {
       tableViewCvrFiles.getItems().add(cvrSource);
+      choiceCvrProvider.setValue(null);
       textFieldCvrFilePath.clear();
       textFieldCvrFirstVoteCol.clear();
       textFieldCvrFirstVoteRow.clear();
       textFieldCvrIdCol.clear();
       textFieldCvrPrecinctCol.clear();
-      textFieldCvrProvider.clear();
     }
   }
 
@@ -575,12 +576,12 @@ public class GuiConfigController implements Initializable {
     checkBoxTabulateByPrecinct.setSelected(false);
     checkBoxGenerateCdfJson.setSelected(false);
 
+    choiceCvrProvider.setValue(null);
     textFieldCvrFilePath.clear();
     textFieldCvrFirstVoteCol.clear();
     textFieldCvrFirstVoteRow.clear();
     textFieldCvrIdCol.clear();
     textFieldCvrPrecinctCol.clear();
-    textFieldCvrProvider.clear();
     tableViewCvrFiles.getItems().clear();
 
     textFieldCandidateName.clear();
@@ -744,6 +745,8 @@ public class GuiConfigController implements Initializable {
           }
         });
 
+    choiceCvrProvider.getItems().addAll(Provider.values());
+    choiceCvrProvider.getItems().remove(Provider.PROVIDER_UNKNOWN);
     tableColumnCvrFilePath.setCellValueFactory(new PropertyValueFactory<>("filePath"));
     tableColumnCvrFilePath.setCellFactory(TextFieldTableCell.forTableColumn());
     tableColumnCvrFirstVoteCol.setCellValueFactory(

--- a/src/main/java/network/brightspots/rcv/GuiConfigController.java
+++ b/src/main/java/network/brightspots/rcv/GuiConfigController.java
@@ -33,7 +33,7 @@ import java.util.ResourceBundle;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 import javafx.application.Platform;
-import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.collections.FXCollections;
 import javafx.concurrent.Service;
 import javafx.concurrent.Task;
@@ -776,8 +776,7 @@ public class GuiConfigController implements Initializable {
           checkBox
               .selectedProperty()
               .addListener((ov, oldVal, newVal) -> candidate.setExcluded(newVal));
-          //noinspection unchecked
-          return new SimpleObjectProperty(checkBox);
+          return new SimpleBooleanProperty(checkBox.isSelected());
         });
     tableViewCandidates.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
     tableViewCandidates.setEditable(true);

--- a/src/main/java/network/brightspots/rcv/TabulatorSession.java
+++ b/src/main/java/network/brightspots/rcv/TabulatorSession.java
@@ -42,6 +42,7 @@ import java.util.Set;
 import java.util.logging.Level;
 import javax.xml.parsers.ParserConfigurationException;
 import network.brightspots.rcv.CastVoteRecord.CvrParseException;
+import network.brightspots.rcv.ContestConfig.Provider;
 import network.brightspots.rcv.FileUtils.UnableToCreateDirectoryException;
 import network.brightspots.rcv.ResultsWriter.RoundSnapshotDataMissingException;
 import network.brightspots.rcv.StreamingCvrReader.CvrDataFormatException;
@@ -272,7 +273,13 @@ class TabulatorSession {
           Logger.log(Level.INFO, "Reading CDF cast vote record file: %s...", cvrPath);
           CommonDataFormatReader reader = new CommonDataFormatReader(cvrPath, config);
           reader.parseCvrFile(castVoteRecords);
-        } else if (ContestConfig.isHart(source)) {
+        } else if (ContestConfig.getProvider(source) == Provider.ESS) {
+          Logger.log(Level.INFO, "Reading ES&S cast vote record file: %s...", cvrPath);
+          new StreamingCvrReader(config, source).parseCvrFile(castVoteRecords, precinctIds);
+        } else if (ContestConfig.getProvider(source) == Provider.GENERIC) {
+          Logger.log(Level.INFO, "Reading generic format cast vote record file: %s...", cvrPath);
+          new StreamingCvrReader(config, source).parseCvrFile(castVoteRecords, precinctIds);
+        } else if (ContestConfig.getProvider(source) == Provider.HART) {
           HartCvrReader reader = new HartCvrReader(cvrPath, config);
           try {
             Logger.log(Level.INFO, "Reading Hart cast vote records from folder: %s...", cvrPath);
@@ -281,9 +288,6 @@ class TabulatorSession {
             Logger.log(Level.SEVERE, "Exception parsing Hart CVR!");
             encounteredSourceProblem = true;
           }
-        } else {
-          Logger.log(Level.INFO, "Reading ES&S cast vote record file: %s...", cvrPath);
-          new StreamingCvrReader(config, source).parseCvrFile(castVoteRecords, precinctIds);
         }
       } catch (UnrecognizedCandidatesException exception) {
         Logger.log(Level.SEVERE, "Source file contains unrecognized candidate(s): %s", cvrPath);

--- a/src/main/java/network/brightspots/rcv/TabulatorSession.java
+++ b/src/main/java/network/brightspots/rcv/TabulatorSession.java
@@ -43,6 +43,7 @@ import java.util.logging.Level;
 import javax.xml.parsers.ParserConfigurationException;
 import network.brightspots.rcv.CastVoteRecord.CvrParseException;
 import network.brightspots.rcv.ContestConfig.Provider;
+import network.brightspots.rcv.ContestConfig.UnrecognizedProviderException;
 import network.brightspots.rcv.FileUtils.UnableToCreateDirectoryException;
 import network.brightspots.rcv.ResultsWriter.RoundSnapshotDataMissingException;
 import network.brightspots.rcv.StreamingCvrReader.CvrDataFormatException;
@@ -273,22 +274,22 @@ class TabulatorSession {
           Logger.log(Level.INFO, "Reading CDF cast vote record file: %s...", cvrPath);
           CommonDataFormatReader reader = new CommonDataFormatReader(cvrPath, config);
           reader.parseCvrFile(castVoteRecords);
+          continue;
         } else if (ContestConfig.getProvider(source) == Provider.ESS) {
           Logger.log(Level.INFO, "Reading ES&S cast vote record file: %s...", cvrPath);
           new StreamingCvrReader(config, source).parseCvrFile(castVoteRecords, precinctIds);
+          continue;
         } else if (ContestConfig.getProvider(source) == Provider.GENERIC) {
           Logger.log(Level.INFO, "Reading generic format cast vote record file: %s...", cvrPath);
           new StreamingCvrReader(config, source).parseCvrFile(castVoteRecords, precinctIds);
+          continue;
         } else if (ContestConfig.getProvider(source) == Provider.HART) {
           HartCvrReader reader = new HartCvrReader(cvrPath, config);
-          try {
-            Logger.log(Level.INFO, "Reading Hart cast vote records from folder: %s...", cvrPath);
-            reader.readCastVoteRecordsFromFolder(castVoteRecords);
-          } catch (CvrParseException exception) {
-            Logger.log(Level.SEVERE, "Exception parsing Hart CVR!");
-            encounteredSourceProblem = true;
-          }
+          Logger.log(Level.INFO, "Reading Hart cast vote records from folder: %s...", cvrPath);
+          reader.readCastVoteRecordsFromFolder(castVoteRecords);
+          continue;
         }
+        throw new UnrecognizedProviderException();
       } catch (UnrecognizedCandidatesException exception) {
         Logger.log(Level.SEVERE, "Source file contains unrecognized candidate(s): %s", cvrPath);
         // map from name to number of times encountered
@@ -324,6 +325,12 @@ class TabulatorSession {
       } catch (CvrDataFormatException e) {
         Logger.log(Level.SEVERE, "Data format error while parsing source file: %s", cvrPath);
         Logger.log(Level.INFO, "See the log for details.");
+        encounteredSourceProblem = true;
+      } catch (UnrecognizedProviderException e) {
+        Logger.log(Level.SEVERE, "Unrecognized provider \"%s\" in source file: %s",
+            source.getProvider(), cvrPath);
+        encounteredSourceProblem = true;
+      } catch (CvrParseException e) {
         encounteredSourceProblem = true;
       }
     }

--- a/src/main/java/network/brightspots/rcv/TabulatorSession.java
+++ b/src/main/java/network/brightspots/rcv/TabulatorSession.java
@@ -279,10 +279,6 @@ class TabulatorSession {
           Logger.log(Level.INFO, "Reading ES&S cast vote record file: %s...", cvrPath);
           new StreamingCvrReader(config, source).parseCvrFile(castVoteRecords, precinctIds);
           continue;
-        } else if (ContestConfig.getProvider(source) == Provider.GENERIC) {
-          Logger.log(Level.INFO, "Reading generic format cast vote record file: %s...", cvrPath);
-          new StreamingCvrReader(config, source).parseCvrFile(castVoteRecords, precinctIds);
-          continue;
         } else if (ContestConfig.getProvider(source) == Provider.HART) {
           HartCvrReader reader = new HartCvrReader(cvrPath, config);
           Logger.log(Level.INFO, "Reading Hart cast vote records from folder: %s...", cvrPath);

--- a/src/main/resources/network/brightspots/rcv/GuiConfigLayout.fxml
+++ b/src/main/resources/network/brightspots/rcv/GuiConfigLayout.fxml
@@ -119,17 +119,17 @@
               <HBox alignment="CENTER_LEFT" spacing="4.0">
                 <VBox spacing="4.0">
                   <HBox alignment="CENTER_LEFT" spacing="4.0">
+                    <Label text="Provider *"/>
+                    <ChoiceBox maxWidth="250.0" prefWidth="120.0" fx:id="choiceCvrProvider"/>
                     <Button mnemonicParsing="false" onAction="#buttonAddCvrFileClicked" text="Add"/>
                     <Button mnemonicParsing="false" onAction="#buttonDeleteCvrFileClicked"
                       text="Delete Selected"/>
-                    <ChoiceBox maxWidth="250.0" prefWidth="100.0" fx:id="choiceCvrProvider"/>
-                    <Label text="Provider *"/>
                   </HBox>
                   <HBox alignment="CENTER_LEFT" spacing="4.0">
-                    <Button mnemonicParsing="false" onAction="#buttonCvrFilePathClicked"
-                      text="Select"/>
                     <TextField prefHeight="25.0" prefWidth="396.0" promptText="File Path *"
                       fx:id="textFieldCvrFilePath"/>
+                    <Button mnemonicParsing="false" onAction="#buttonCvrFilePathClicked"
+                      text="Select"/>
                   </HBox>
                   <HBox alignment="CENTER_LEFT" spacing="4.0">
                     <TextField prefHeight="25.0" prefWidth="160.0" promptText="First Vote Col Index"

--- a/src/main/resources/network/brightspots/rcv/GuiConfigLayout.fxml
+++ b/src/main/resources/network/brightspots/rcv/GuiConfigLayout.fxml
@@ -119,33 +119,28 @@
               <HBox alignment="CENTER_LEFT" spacing="4.0">
                 <VBox spacing="4.0">
                   <HBox alignment="CENTER_LEFT" spacing="4.0">
-                    <TextField fx:id="textFieldCvrFilePath" prefHeight="25.0" prefWidth="396.0"
-                      promptText="File Path *"/>
+                    <Button mnemonicParsing="false" onAction="#buttonAddCvrFileClicked" text="Add"/>
+                    <Button mnemonicParsing="false" onAction="#buttonDeleteCvrFileClicked"
+                      text="Delete Selected"/>
+                    <ChoiceBox maxWidth="250.0" prefWidth="100.0" fx:id="choiceCvrProvider"/>
+                    <Label text="Provider *"/>
+                  </HBox>
+                  <HBox alignment="CENTER_LEFT" spacing="4.0">
                     <Button mnemonicParsing="false" onAction="#buttonCvrFilePathClicked"
                       text="Select"/>
+                    <TextField prefHeight="25.0" prefWidth="396.0" promptText="File Path *"
+                      fx:id="textFieldCvrFilePath"/>
                   </HBox>
                   <HBox alignment="CENTER_LEFT" spacing="4.0">
-                    <TextField fx:id="textFieldCvrFirstVoteCol" prefHeight="25.0" prefWidth="160.0"
-                      promptText="First Vote Col Index"/>
-                    <TextField fx:id="textFieldCvrFirstVoteRow" prefHeight="25.0" prefWidth="160.0"
-                      promptText="First Vote Row Index"/>
-                    <TextField fx:id="textFieldCvrIdCol" prefHeight="25.0" prefWidth="120.0"
-                      promptText="ID Col Index"/>
-                  </HBox>
-                  <HBox alignment="CENTER_LEFT" spacing="4.0">
+                    <TextField prefHeight="25.0" prefWidth="160.0" promptText="First Vote Col Index"
+                      fx:id="textFieldCvrFirstVoteCol"/>
+                    <TextField prefHeight="25.0" prefWidth="160.0" promptText="First Vote Row Index"
+                      fx:id="textFieldCvrFirstVoteRow"/>
+                    <TextField prefHeight="25.0" prefWidth="120.0" promptText="ID Col Index"
+                      fx:id="textFieldCvrIdCol"/>
                     <TextField fx:id="textFieldCvrPrecinctCol" prefHeight="25.0" prefWidth="175.0"
                       promptText="Precinct Col Index"/>
-                    <TextField fx:id="textFieldCvrProvider" maxWidth="250.0" prefHeight="25.0"
-                      prefWidth="175.0" promptText="Provider"/>
                   </HBox>
-                </VBox>
-                <VBox alignment="BOTTOM_LEFT" spacing="4.0">
-                  <padding>
-                    <Insets left="4.0" right="4.0" top="4.0"/>
-                  </padding>
-                  <Button mnemonicParsing="false" onAction="#buttonAddCvrFileClicked" text="Add"/>
-                  <Button mnemonicParsing="false" onAction="#buttonDeleteCvrFileClicked"
-                    text="Delete Selected"/>
                 </VBox>
                 <padding>
                   <Insets bottom="4.0" left="4.0" right="4.0" top="4.0"/>

--- a/src/main/resources/network/brightspots/rcv/config_file_documentation.txt
+++ b/src/main/resources/network/brightspots/rcv/config_file_documentation.txt
@@ -58,9 +58,7 @@ Config file must be valid JSON format. Examples can be found in the test_data fo
       "provider" required
         text description of the vendor / machine which generated this file
         if set to "CDF" (and the filePath is ".json") the CVR file will be read as NIST Common Data Format (CDF)
-        example: "ES&S"
-        value: text string of length [1..1000]
-        if not supplied: file will be read as ES&S format
+        value: "CDF" | "ES&S" | "Generic format" | "Hart"
 
       "filePath" required
         location of the CVR file

--- a/src/main/resources/network/brightspots/rcv/config_file_documentation.txt
+++ b/src/main/resources/network/brightspots/rcv/config_file_documentation.txt
@@ -58,7 +58,7 @@ Config file must be valid JSON format. Examples can be found in the test_data fo
       "provider" required
         text description of the vendor / machine which generated this file
         if set to "CDF" (and the filePath is ".json") the CVR file will be read as NIST Common Data Format (CDF)
-        value: "CDF" | "ES&S" | "Generic format" | "Hart"
+        value: "CDF" | "ES&S" | "Hart"
 
       "filePath" required
         location of the CVR file

--- a/src/main/resources/network/brightspots/rcv/config_file_documentation.txt
+++ b/src/main/resources/network/brightspots/rcv/config_file_documentation.txt
@@ -55,6 +55,13 @@ Config file must be valid JSON format. Examples can be found in the test_data fo
     list of input cast vote record (CVR) file paths and their associated parameters
     each "cvrFileSources" list item contains the following parameters:
 
+      "provider" required
+        text description of the vendor / machine which generated this file
+        if set to "CDF" (and the filePath is ".json") the CVR file will be read as NIST Common Data Format (CDF)
+        example: "ES&S"
+        value: text string of length [1..1000]
+        if not supplied: file will be read as ES&S format
+
       "filePath" required
         location of the CVR file
         if this is a ".json" file (and the provider is "CDF") the CVR file will be read as NIST Common Data Format (CDF)
@@ -80,13 +87,6 @@ Config file must be valid JSON format. Examples can be found in the test_data fo
         index of the column (starting from 1) that contains the precinct name for each CVR
         example: 2
         value: [1..1000]
-
-      "provider" optional
-        text description of the vendor / machine which generated this file
-        if set to "CDF" (and the filePath is ".json") the CVR file will be read as NIST Common Data Format (CDF)
-        example: "ES&S"
-        value: text string of length [1..1000]
-        if not supplied: file will be read as ES&S format
 
   "candidates" required
     list of registered candidate names and associated candidate code (note: leave empty when CVR is in Common Data Format)

--- a/src/test/resources/network/brightspots/rcv/test_data/continue_until_two_with_batch_elimination_test/continue_until_two_with_batch_elimination_test_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/continue_until_two_with_batch_elimination_test/continue_until_two_with_batch_elimination_test_config.json
@@ -15,7 +15,7 @@
     "firstVoteRowIndex" : "2",
     "idColumnIndex" : "",
     "precinctColumnIndex" : "",
-    "provider" : ""
+    "provider": "ES&S"
   } ],
   "candidates" : [ {
     "name" : "A",

--- a/src/test/resources/network/brightspots/rcv/test_data/hart_cedar_park_school_board/hart_cedar_park_school_board_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/hart_cedar_park_school_board/hart_cedar_park_school_board_config.json
@@ -16,7 +16,7 @@
     "firstVoteRowIndex" : "1",
     "idColumnIndex" : "1",
     "precinctColumnIndex" : "1",
-    "provider" : "HART"
+    "provider": "Hart"
   } ],
 
   "candidates" : [

--- a/src/test/resources/network/brightspots/rcv/test_data/hart_travis_county_officers/hart_travis_county_officers_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/hart_travis_county_officers/hart_travis_county_officers_config.json
@@ -15,7 +15,7 @@
     "firstVoteRowIndex" : "1",
     "idColumnIndex" : "1",
     "precinctColumnIndex" : "1",
-    "provider" : "HART"
+    "provider": "Hart"
   } ],
   "candidates" : [
     {

--- a/src/test/resources/network/brightspots/rcv/test_data/minneapolis_multi_seat_threshold/minneapolis_multi_seat_threshold_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/minneapolis_multi_seat_threshold/minneapolis_multi_seat_threshold_config.json
@@ -16,7 +16,7 @@
     "firstVoteRowIndex" : "2",
     "idColumnIndex" : "",
     "precinctColumnIndex" : "",
-    "provider" : ""
+    "provider": "ES&S"
   } ],
   "candidates" : [ {
     "name" : "A",

--- a/src/test/resources/network/brightspots/rcv/test_data/multi_seat_bottoms_up_with_threshold/multi_seat_bottoms_up_with_threshold_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/multi_seat_bottoms_up_with_threshold/multi_seat_bottoms_up_with_threshold_config.json
@@ -16,7 +16,7 @@
     "firstVoteRowIndex" : "2",
     "idColumnIndex" : "1",
     "precinctColumnIndex" : "",
-    "provider" : ""
+    "provider": "ES&S"
   } ],
   "candidates" : [ {
     "name" : "A",

--- a/src/test/resources/network/brightspots/rcv/test_data/multi_seat_uwi_test/multi_seat_uwi_test_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/multi_seat_uwi_test/multi_seat_uwi_test_config.json
@@ -15,7 +15,7 @@
     "firstVoteRowIndex" : "2",
     "idColumnIndex" : "",
     "precinctColumnIndex" : "",
-    "provider" : ""
+    "provider": "ES&S"
   } ],
   "candidates" : [ {
     "name" : "A",

--- a/src/test/resources/network/brightspots/rcv/test_data/test_set_allow_only_one_winner_per_round/test_set_allow_only_one_winner_per_round_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/test_set_allow_only_one_winner_per_round/test_set_allow_only_one_winner_per_round_config.json
@@ -16,7 +16,7 @@
     "firstVoteRowIndex" : "2",
     "idColumnIndex" : "1",
     "precinctColumnIndex" : "",
-    "provider" : "ESS"
+    "provider": "ES&S"
   } ],
   "candidates" : [ {
     "name" : "A",

--- a/src/test/resources/network/brightspots/rcv/test_data/test_set_treat_blank_as_undeclared_write_in/test_set_treat_blank_as_undeclared_write_in_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/test_set_treat_blank_as_undeclared_write_in/test_set_treat_blank_as_undeclared_write_in_config.json
@@ -16,7 +16,7 @@
     "firstVoteRowIndex" : "2",
     "idColumnIndex" : "1",
     "precinctColumnIndex" : "",
-    "provider" : ""
+    "provider": "ES&S"
   } ],
   "candidates" : [ {
     "name" : "A",

--- a/src/test/resources/network/brightspots/rcv/test_data/tiebreak_previous_round_counts_then_random_test/tiebreak_previous_round_counts_then_random_test_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/tiebreak_previous_round_counts_then_random_test/tiebreak_previous_round_counts_then_random_test_config.json
@@ -16,7 +16,7 @@
     "firstVoteRowIndex" : "2",
     "idColumnIndex" : "1",
     "precinctColumnIndex" : "",
-    "provider" : ""
+    "provider": "ES&S"
   } ],
   "candidates" : [ {
     "name" : "Happy",

--- a/src/test/resources/network/brightspots/rcv/test_data/uwi_cannot_win_test/uwi_cannot_win_test_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/uwi_cannot_win_test/uwi_cannot_win_test_config.json
@@ -15,7 +15,7 @@
     "firstVoteRowIndex" : "2",
     "idColumnIndex" : "",
     "precinctColumnIndex" : "",
-    "provider" : ""
+    "provider": "ES&S"
   } ],
   "candidates" : [ {
     "name" : "A",


### PR DESCRIPTION
Changes "Provider" field for CVR source to required, bases it on an enum of valid values, and changes it to a ChoiceBox at the start of the "CVR Files" tab in the GUI. Adds log message to help identify which CVR source validation errors pertain to. (Progress on #460 and #461)

Open questions:
* Do we anticipate any problems with making "Provider" a required field?
* If you have a config file with, e.g., "ES&s" it'll say invalid provider because it's not "ES&S". This is desired behavior, right?
* Do we care about re-ordering fields in the RawConfig? i.e. so provider is first in the CVR area?
* If you double click a cell to edit provider in the table do we care enough to try to make that an embedded dropdown?
