### PR TITLE
make contestId a real config field

### DIFF
--- a/src/main/java/network/brightspots/rcv/ContestConfig.java
+++ b/src/main/java/network/brightspots/rcv/ContestConfig.java
@@ -447,6 +447,18 @@ class ContestConfig {
                 cvrPath);
           }
         }
+
+        if (isNullOrBlank(getContestId()) && isHart(source)) {
+          isValid = false;
+          Logger.log(
+              Level.SEVERE,
+              "contestId is required for Hart files.");
+        } else if (!isNullOrBlank(getContestId()) && !isHart(source)) {
+          isValid = false;
+          Logger.log(
+              Level.SEVERE,
+              "contestId may not be used with this type of CVR file.");
+        }
       }
     }
   }

--- a/src/main/java/network/brightspots/rcv/GuiConfigController.java
+++ b/src/main/java/network/brightspots/rcv/GuiConfigController.java
@@ -93,6 +93,8 @@ public class GuiConfigController implements Initializable {
   @FXML
   private TextField textFieldContestName;
   @FXML
+  private TextField textFieldContestId;
+  @FXML
   private TextField textFieldOutputDirectory;
   @FXML
   private DatePicker datePickerContestDate;
@@ -568,6 +570,7 @@ public class GuiConfigController implements Initializable {
 
   private void clearConfig() {
     textFieldContestName.clear();
+    textFieldContestId.clear();
     textFieldOutputDirectory.clear();
     datePickerContestDate.setValue(null);
     textFieldContestJurisdiction.clear();
@@ -821,6 +824,7 @@ public class GuiConfigController implements Initializable {
     migrateConfigVersion(config);
     OutputSettings outputSettings = rawConfig.outputSettings;
     textFieldContestName.setText(outputSettings.contestName);
+    textFieldContestId.setText(outputSettings.contestId);
     textFieldOutputDirectory.setText(config.getOutputDirectoryRaw());
     if (!isNullOrBlank(outputSettings.contestDate)) {
       try {
@@ -878,6 +882,7 @@ public class GuiConfigController implements Initializable {
     config.tabulatorVersion = Main.APP_VERSION;
     OutputSettings outputSettings = new OutputSettings();
     outputSettings.contestName = getTextOrEmptyString(textFieldContestName);
+    outputSettings.contestId = getTextOrEmptyString(textFieldContestId);
     outputSettings.outputDirectory = getTextOrEmptyString(textFieldOutputDirectory);
     outputSettings.contestDate =
         datePickerContestDate.getValue() != null ? datePickerContestDate.getValue().toString() : "";

--- a/src/main/java/network/brightspots/rcv/HartCvrReader.java
+++ b/src/main/java/network/brightspots/rcv/HartCvrReader.java
@@ -68,8 +68,7 @@ class HartCvrReader {
       HartCvrXml xmlCvr = xmlMapper.readValue(inputStream, HartCvrXml.class);
 
       for (Contest contest : xmlCvr.Contests) {
-        // TODO: use contest Id (blocked by #456)
-        if (!contest.Name.equals(contestConfig.getContestName())) {
+        if (!contest.Id.equals(contestConfig.getContestId())) {
           continue;
         }
 

--- a/src/main/java/network/brightspots/rcv/RawContestConfig.java
+++ b/src/main/java/network/brightspots/rcv/RawContestConfig.java
@@ -46,11 +46,11 @@ public class RawContestConfig {
   public static class OutputSettings {
 
     public String contestName;
+    public String contestId;
     public String outputDirectory;
     public String contestDate;
     public String contestJurisdiction;
     public String contestOffice;
-    public String contestId;
     public boolean tabulateByPrecinct;
     public boolean generateCdfJson;
   }

--- a/src/main/resources/network/brightspots/rcv/GuiConfigLayout.fxml
+++ b/src/main/resources/network/brightspots/rcv/GuiConfigLayout.fxml
@@ -78,6 +78,8 @@
             <VBox spacing="8.0">
               <Label text="Contest Name *"/>
               <TextField fx:id="textFieldContestName" maxWidth="220.0" promptText="Contest Name *"/>
+              <Label text="Contest ID"/>
+              <TextField fx:id="textFieldContestId" maxWidth="220.0" promptText="Contest ID"/>
               <Label text="Output Directory"/>
               <HBox alignment="CENTER_LEFT" spacing="8.0">
                 <TextField fx:id="textFieldOutputDirectory" prefWidth="400.0"

--- a/src/main/resources/network/brightspots/rcv/config_file_documentation.txt
+++ b/src/main/resources/network/brightspots/rcv/config_file_documentation.txt
@@ -17,7 +17,7 @@ Config file must be valid JSON format. Examples can be found in the test_data fo
         example: "Portland Mayoral Race 2017"
         value: text string of length [1..1000]
 
-      "contestId" required when CVR source files are from Hart
+      "contestId" required when CVR source files are from Hart; must be blank otherwise
         the ID of the contest to tabulate, as represented in the CVR file(s)
         example: "b651b997-417a-46d9-a676-a43d4df94ddc"
         value: text string of length [1..1000]

--- a/src/main/resources/network/brightspots/rcv/config_file_documentation.txt
+++ b/src/main/resources/network/brightspots/rcv/config_file_documentation.txt
@@ -17,6 +17,11 @@ Config file must be valid JSON format. Examples can be found in the test_data fo
         example: "Portland Mayoral Race 2017"
         value: text string of length [1..1000]
 
+      "contestId" required when CVR source files are from Hart
+        the ID of the contest to tabulate, as represented in the CVR file(s)
+        example: "b651b997-417a-46d9-a676-a43d4df94ddc"
+        value: text string of length [1..1000]
+
       "outputDirectory" optional
         directory for output files
         if a relative path is supplied it will be appended to the current working directory

--- a/src/test/resources/network/brightspots/rcv/test_data/hart_cedar_park_school_board/hart_cedar_park_school_board_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/hart_cedar_park_school_board/hart_cedar_park_school_board_config.json
@@ -21,10 +21,10 @@
 
   "candidates" : [
     {
-    "name" : "Tony Hernandez",
-    "code" : "6f2df7d3-5c83-4fc7-b4a5-c2eca9e5fdb4",
-    "excluded" : false
-  },
+      "name" : "Tony Hernandez",
+      "code" : "6f2df7d3-5c83-4fc7-b4a5-c2eca9e5fdb4",
+      "excluded" : false
+    },
     {
       "name" : "Betty McCollum",
       "code" : "5f1a7e93-d5d7-498d-94d5-101356477f30",

--- a/src/test/resources/network/brightspots/rcv/test_data/hart_travis_county_officers/hart_travis_county_officers_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/hart_travis_county_officers/hart_travis_county_officers_config.json
@@ -2,6 +2,7 @@
   "tabulatorVersion" : "TEST",
   "outputSettings" : {
     "contestName" : "TRAVIS COUNTY OFFICERS",
+    "contestId" : "e9ca8235-893e-43df-93eb-3cc61eeb133c",
     "outputDirectory" : "output",
     "contestDate" : "",
     "contestJurisdiction" : "",
@@ -19,10 +20,10 @@
   } ],
   "candidates" : [
     {
-    "name" : "Michael Gottner",
-    "code" : "bdc77efc-2f86-48d0-a0de-2efb02e1f4d9",
-    "excluded" : false
-  },
+      "name" : "Michael Gottner",
+      "code" : "bdc77efc-2f86-48d0-a0de-2efb02e1f4d9",
+      "excluded" : false
+    },
     {
       "name" : "Jim Sylvester",
       "code" : "bfb4eda8-35e8-4d13-b152-99b8e5d6b777",


### PR DESCRIPTION
Fixes #456.

I confirmed that the Hart tests still pass.

I ignored Dominion for now, but if/when we add direct tabulation for that source provider, it should be easy to update my logic here to accommodate it.