### PR TITLE
throw error when candidates are missing from Dominion config

### DIFF
--- a/src/main/java/network/brightspots/rcv/DominionCvrReader.java
+++ b/src/main/java/network/brightspots/rcv/DominionCvrReader.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import java.util.logging.Level;
 import javafx.util.Pair;
 import network.brightspots.rcv.CastVoteRecord.CvrParseException;
+import network.brightspots.rcv.TabulatorSession.UnrecognizedCandidatesException;
 
 class DominionCvrReader {
 
@@ -36,6 +37,7 @@ class DominionCvrReader {
   private static final String CANDIDATE_MANIFEST = "CandidateManifest.json";
   private static final String CONTEST_MANIFEST = "ContestManifest.json";
   private static final String CVR_EXPORT = "CvrExport.json";
+  private final ContestConfig config;
   private final String manifestFolder;
   // map of precinct Id to precinct description
   private Map<Integer, String> precincts;
@@ -44,8 +46,11 @@ class DominionCvrReader {
   // map of contest Id to Contest data
   private Map<String, Contest> contests;
   private List<Candidate> candidates;
+  // map for tracking unrecognized candidates during parsing
+  private final Map<String, Integer> unrecognizedCandidateCounts = new HashMap<>();
 
-  DominionCvrReader(String manifestFolder) {
+  DominionCvrReader(ContestConfig config, String manifestFolder) {
+    this.config = config;
     this.manifestFolder = manifestFolder;
   }
 
@@ -121,7 +126,7 @@ class DominionCvrReader {
   // parse Cvr json into CastVoteRecord objects and add them to the input list
   // (If contestId is specified, we'll only load CVRs for that contest.)
   void readCastVoteRecords(List<CastVoteRecord> castVoteRecords, String contestId)
-      throws CvrParseException {
+      throws CvrParseException, UnrecognizedCandidatesException {
     // read metadata files for precincts, precinct portions, contest, and candidates
     Path precinctPath = Paths.get(manifestFolder, PRECINCT_MANIFEST);
     this.precincts = getPrecinctData(precinctPath.toString());
@@ -153,6 +158,9 @@ class DominionCvrReader {
     if (castVoteRecords.isEmpty()) {
       Logger.log(Level.SEVERE, "No cast vote record data found!");
       throw new CvrParseException();
+    }
+    if (unrecognizedCandidateCounts.size() > 0) {
+      throw new UnrecognizedCandidatesException(unrecognizedCandidateCounts);
     }
   }
 
@@ -265,6 +273,12 @@ class DominionCvrReader {
                   contestId);
               throw new CvrParseException();
             }
+            // We also need to throw an error if this candidate doesn't appear in the tabulator's
+            // config file for this contest.
+            if (!config.getCandidateCodeList().contains(candidateCode)
+                && !candidateCode.equals(config.getUndeclaredWriteInLabel())) {
+              unrecognizedCandidateCounts.merge(candidateCode, 1, Integer::sum);
+            }
 
             Integer rank = (Integer) rankingMap.get("Rank");
             Pair<Integer, String> ranking = new Pair<>(rank, candidateCode);
@@ -291,9 +305,9 @@ class DominionCvrReader {
   // Candidate data from a Dominion candidate manifest Json
   static class Candidate {
 
-    private String name;
-    private String code;
-    private String contestId;
+    private final String name;
+    private final String code;
+    private final String contestId;
 
     Candidate(String name, String code, String contestId) {
       this.name = name;

--- a/src/main/java/network/brightspots/rcv/StreamingCvrReader.java
+++ b/src/main/java/network/brightspots/rcv/StreamingCvrReader.java
@@ -37,6 +37,7 @@ import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 import network.brightspots.rcv.RawContestConfig.CvrSource;
+import network.brightspots.rcv.TabulatorSession.UnrecognizedCandidatesException;
 import org.apache.poi.openxml4j.exceptions.OpenXML4JException;
 import org.apache.poi.openxml4j.opc.OPCPackage;
 import org.apache.poi.xssf.eventusermodel.ReadOnlySharedStringsTable;
@@ -325,15 +326,5 @@ class StreamingCvrReader {
 
   static class CvrDataFormatException extends Exception {
 
-  }
-
-  static class UnrecognizedCandidatesException extends Exception {
-
-    // count of how many times each unrecognized candidate was encountered during CVR parsing
-    final Map<String, Integer> candidateCounts;
-
-    UnrecognizedCandidatesException(Map<String, Integer> candidateCounts) {
-      this.candidateCounts = candidateCounts;
-    }
   }
 }


### PR DESCRIPTION
Just mimicking the logic from `StreamingCvrReader`.

Fixes #473.