### PR TITLE
Adds hints for each tab

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="EntryPointsManager">
+    <list size="1">
+      <item index="0" class="java.lang.String" itemvalue="com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty" />
+    </list>
+  </component>
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_14" default="true" project-jdk-name="14.0.1" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />

--- a/src/main/resources/network/brightspots/rcv/GuiConfigLayout.fxml
+++ b/src/main/resources/network/brightspots/rcv/GuiConfigLayout.fxml
@@ -79,7 +79,7 @@
     <center>
       <VBox BorderPane.alignment="CENTER">
         <TabPane fx:id="tabPane" minHeight="450.0" tabClosingPolicy="UNAVAILABLE">
-          <Tab text="Contest Info">
+          <Tab text="Contest Info" fx:id="tabContestInfo">
             <VBox>
               <VBox styleClass="bordered-box" maxWidth="450.0">
                 <HBox alignment="CENTER_LEFT" spacing="4.0">
@@ -132,7 +132,7 @@
               </padding>
             </VBox>
           </Tab>
-          <Tab text="CVR Files">
+          <Tab text="CVR Files" fx:id="tabCvrFiles">
             <VBox>
               <VBox styleClass="bordered-box" maxWidth="700.0">
                 <HBox alignment="CENTER_LEFT" spacing="4.0">
@@ -277,7 +277,7 @@
               </padding>
             </VBox>
           </Tab>
-          <Tab text="Candidates">
+          <Tab text="Candidates" fx:id="tabCandidates">
             <VBox>
               <VBox styleClass="bordered-box" maxWidth="400.0">
                 <HBox alignment="CENTER_LEFT" spacing="4.0">
@@ -364,7 +364,7 @@
               </padding>
             </VBox>
           </Tab>
-          <Tab text="Winning Rules">
+          <Tab text="Winning Rules" fx:id="tabWinningRules">
             <VBox>
               <VBox styleClass="bordered-box" maxWidth="820.0">
                 <HBox alignment="CENTER_LEFT" spacing="4.0">
@@ -534,7 +534,7 @@
               </padding>
             </VBox>
           </Tab>
-          <Tab text="Voter Error Rules">
+          <Tab text="Voter Error Rules" fx:id="tabVoterErrorRules">
             <VBox>
               <VBox styleClass="bordered-box" maxWidth="418.0">
                 <HBox spacing="4.0">
@@ -585,7 +585,7 @@
               </padding>
             </VBox>
           </Tab>
-          <Tab text="Output">
+          <Tab text="Output" fx:id="tabOutput">
             <VBox>
               <VBox styleClass="bordered-box" maxWidth="580.0">
                 <HBox alignment="CENTER_LEFT" spacing="4.0">

--- a/src/main/resources/network/brightspots/rcv/hints_candidates.txt
+++ b/src/main/resources/network/brightspots/rcv/hints_candidates.txt
@@ -1,0 +1,9 @@
+Hints for this tab
+
+Fill in the fields and click the Add button:
+
+Name (required): E.g.: Dave Harris.
+
+Code (optional): Some CVR files use codes in lieu of full candidate name. E.g.: "JCD" or "14".
+
+Excluded (optional): When checked, the candidate will be ignored during tabulation. An example of when this might be used: a candidate dropped out after the ballots were printed.

--- a/src/main/resources/network/brightspots/rcv/hints_contest_info.txt
+++ b/src/main/resources/network/brightspots/rcv/hints_contest_info.txt
@@ -1,0 +1,20 @@
+Hints for this tab
+
+The tabulator calculates results for one contest at a time, rather than the results of several contests for an election all at once. The information on this tab is for the particular contest you will be tabulating.
+
+These fields do not influence the computations. They are shown in the final output file(s) to help connect the data (results) with the contest the results belong to. 
+
+* Think long term, e.g. from the perspective of looking at the results files 6 months after the election and wanting to be clear what contest the results belong to.
+
+* You may find it helpful to revisit this tab once you have done a few test runs and see what the output looks like.
+
+Contest Name (required): Enter a name to identify it.
+  Examples: City Council 2018, Board of Election Ward13 2017, Mayor, Referendum 289b
+
+Contest Date (optional): The date on which the election for this contest was run.
+
+Contest Jurisdiction (optional): E.g.: Minneapolis, Eastpointe
+  Whether this is helpful may depend on what you put into the Contest Name field
+
+Contest Office (optional): E.g.: Mayor, County Clerk
+  Whether this is helpful may depend on what you put into the Contest Name field

--- a/src/main/resources/network/brightspots/rcv/hints_cvr_files.txt
+++ b/src/main/resources/network/brightspots/rcv/hints_cvr_files.txt
@@ -1,0 +1,19 @@
+Hints for this tab
+
+The tabulator needs to know where each of your CVR files is and how to interpret each of them. As you add files, it will build up a list of files to use when it tabulates the results of this contest.
+
+For each of your CVR files, provide the necessary information and then use the Add button to add it to the list.
+
+Provider (required): The vendor/machine that generated (produced) the file. After you select the field, the tabulator will fill in as many of the other fields as it can based on what it knows about that provider. You can adjust those values as necessary.
+
+File (required): Location of the CVR file.
+  * Example: /Users/test data/2015-portland-mayor-cvr.xlsx
+  * Example: C:\Users\test data\precinct14.json
+
+First Vote Column (required for ES&S): the column where the first vote record is.
+
+First Vote Row (required for ES&S): the row where the first vote record.
+
+ID Column (optional): The column the IDs are in. Not all CVR files contain an ID column.
+
+Precinct Column: The column that contains the precinct. Required if you want to tabulate by precinct (if the CVR file is from ES&S).

--- a/src/main/resources/network/brightspots/rcv/hints_output.txt
+++ b/src/main/resources/network/brightspots/rcv/hints_output.txt
@@ -1,0 +1,9 @@
+Hints for this tab
+
+Tell the tabulator where results files go and what additional results files you want.
+
+Output directory: The location where results files will go. If no value (or a relative path, like "output") is supplied, the location where the config file is saved will be used as the base directory. Absolute paths, like "C:\output" work too.
+
+Tabulate by Precinct: Produce round-by-round results at the precinct level. Results are how ballots at the precinct level transferred in the contest as a whole, not a simulated round-by-round count in the precinct. Requires precinct information in CVR Files tab.
+
+Generate a CDF JSON: Produce a VVSG common data format JSON file of the CVR.

--- a/src/main/resources/network/brightspots/rcv/hints_voter_error_rules.txt
+++ b/src/main/resources/network/brightspots/rcv/hints_voter_error_rules.txt
@@ -1,0 +1,14 @@
+Hints for this tab
+
+The tabulator needs to know how to handle voter errors in your jurisdiction. These requirements are typically included in statute or regulation.
+
+Overvote Rule (required): How to handle a ballot where a voter has marked multiple candidates at the same ranking when that ballot is encountered in the round-by-round count. This rule relies on overvote labels as filled out in a different tab.
+  * Always skip to next rank: Skips over an overvote and goes to the next validly-marked ranking on a ballot.
+  * Exhaust immediately: A ballot with an overvote exhausts when that overvote is encountered in the rounds of counting.
+  * Exhaust if multiple continuing: If a voter has an overvote but only one candidate at that overvote is still in the race when that overvote is encountered, the ballot counts for that candidate. If multiple candidates at the overvote are still in the race, the ballot exhausts.
+
+How Many Consecutive Skipped Ranks Are Allowed (required): How many rankings in a row can a voter skip and still have later rankings count? 0 allows no skipped rankings. 1 allows voters to skip rankings one at a time, but not more than 1 in a row, and so on.
+  Example: A voter could rank in 1, 3, 5 and not exhaust under this rule, for example. Implementation of this rule depends on the undervote labels as filled out in a different tab.
+
+Exhaust on Multiple Ranks for the Same Candidate: When checked, the tabulator will exhaust a ballot that includes multiple rankings for the same candidate when that repeat ranking is reached.
+  Example: A voter ranks the same candidate 1st and 3rd, a different candidate 2nd, and another candidate 4th. If their original first choice and their second choice are eliminated, the ballot exhausts when it reaches the repeat ranking in rank 3. The ranking in the 4th rank does not count.

--- a/src/main/resources/network/brightspots/rcv/hints_winning_rules.txt
+++ b/src/main/resources/network/brightspots/rcv/hints_winning_rules.txt
@@ -1,0 +1,17 @@
+Hints for this tab
+
+Winner Election Mode (required): What process to use for selecting winner(s) for this contest).
+  * Single-winner majority determines winner: Elects one winner. Eliminate candidates one-by-one or using batch elimination until only two candidates remain. Candidate with the most votes at the end wins.
+  * Multi-winner allow only one winner per round: Elects multiple winners. Elect and transfer the surplus vote of only the candidate with the most votes if multiple candidates exceed the winning threshold in a round of counting.
+  * Multi-winner allow multiple winners per round: Elects multiple winners. Elect and transfer the surplus vote of all candidates crossing the winning threshold if multiple candidates exceed the winning threshold in a round of counting.
+  * Bottoms-up: Eliminate candidates until the desired number of winners is reached, then stop. Bottoms up does not transfer surplus votes.
+  * Bottoms-up using percentage threshold: Elects multiple winners. Eliminate candidates until the remaining candidates have a vote share equal to or greater than a specified percentage of the vote.
+  * Multi-pass IRV: Elects multiple winners. Eliminate candidates one-by-one or using batch elimination until only two candidates remain. Candidate with the most votes at the end wins. Run a new set of rounds with any winning candidates ignored.
+
+Overvote Label: Some CVRs used a particular word to indicate an overvote.
+
+Undervote Label: Some CVRs used a particular word to indicate an undervote.
+
+Undeclared Write-in Label: Some CVRs used a particular word to indicate a write-in.
+
+Treat Blank as Undeclared Write-in: When checked, the tabulator will interpret blank cells in the CVRs as a votes for an undeclared write-ins.


### PR DESCRIPTION
* Changes the `TextArea` on the right to display hints specific to the currently-selected tab (addressing #499).
* Creates `throwIfNoUwiLabel` helper function in `CommonDataFormatReader`, with minor refactoring. Suppresses warnings that aren't useful. Auto-rearranging of some methods.