### PR TITLE
Creates combo text box / check box input for `maxSkippedRanksAllowed` and `maxRankingsAllowed`

### DIFF
--- a/src/main/java/network/brightspots/rcv/ContestConfig.java
+++ b/src/main/java/network/brightspots/rcv/ContestConfig.java
@@ -51,6 +51,7 @@ class ContestConfig {
   static final boolean SUGGESTED_TABULATE_BY_PRECINCT = false;
   static final boolean SUGGESTED_GENERATE_CDF_JSON = false;
   static final boolean SUGGESTED_CANDIDATE_EXCLUDED = false;
+  static final boolean SUGGESTED_MAX_RANKINGS_ALLOWED_MAXIMUM = true;
   static final boolean SUGGESTED_NON_INTEGER_WINNING_THRESHOLD = false;
   static final boolean SUGGESTED_HARE_QUOTA = false;
   static final boolean SUGGESTED_BATCH_ELIMINATION = false;
@@ -63,9 +64,12 @@ class ContestConfig {
   static final int SUGGESTED_CVR_PRECINCT_COLUMN = 2;
   static final int SUGGESTED_DECIMAL_PLACES_FOR_VOTE_ARITHMETIC = 4;
   static final int SUGGESTED_MAX_SKIPPED_RANKS_ALLOWED = 1;
+  static final boolean SUGGESTED_MAX_SKIPPED_RANKS_ALLOWED_UNLIMITED = false;
   static final String SUGGESTED_OVERVOTE_LABEL = "overvote";
   static final String SUGGESTED_UNDERVOTE_LABEL = "undervote";
   static final String UNDECLARED_WRITE_INS = "Undeclared Write-ins";
+  static final String MAX_SKIPPED_RANKS_ALLOWED_UNLIMITED_OPTION = "unlimited";
+  static final String MAX_RANKINGS_ALLOWED_NUM_CANDIDATES_OPTION = "max";
   private static final int MIN_COLUMN_INDEX = 1;
   private static final int MAX_COLUMN_INDEX = 1000;
   private static final int MIN_ROW_INDEX = 1;
@@ -81,9 +85,6 @@ class ContestConfig {
   private static final int MAX_MULTI_SEAT_BOTTOMS_UP_PERCENTAGE_THRESHOLD = 100;
   private static final long MIN_RANDOM_SEED = -140737488355328L;
   private static final long MAX_RANDOM_SEED = 140737488355327L;
-  private static final String MAX_SKIPPED_RANKS_ALLOWED_UNLIMITED_OPTION = "unlimited";
-  private static final String MAX_RANKINGS_ALLOWED_NUM_CANDIDATES_OPTION = "max";
-  static final String SUGGESTED_MAX_RANKINGS_ALLOWED = MAX_RANKINGS_ALLOWED_NUM_CANDIDATES_OPTION;
   // underlying rawConfig object data
   final RawContestConfig rawConfig;
   // this is used if we have a permutation-based tie-break mode

--- a/src/main/java/network/brightspots/rcv/GuiConfigController.java
+++ b/src/main/java/network/brightspots/rcv/GuiConfigController.java
@@ -256,6 +256,29 @@ public class GuiConfigController implements Initializable {
     return textField.getText() != null ? textField.getText().trim() : "";
   }
 
+  private static String loadTxtFileIntoString(String configFileDocumentationFilename) {
+    String text;
+    try {
+      text =
+          new BufferedReader(
+              new InputStreamReader(
+                  Objects.requireNonNull(
+                      ClassLoader.getSystemResourceAsStream(configFileDocumentationFilename))))
+              .lines()
+              .collect(Collectors.joining("\n"));
+    } catch (Exception exception) {
+      Logger.log(
+          Level.SEVERE,
+          "Error loading text file: %s\n%s",
+          configFileDocumentationFilename,
+          exception.toString());
+      text =
+          String.format(
+              "<Error loading text file: %s>", configFileDocumentationFilename);
+    }
+    return text;
+  }
+
   private String getOvervoteRuleChoice() {
     String overvoteRuleString = OvervoteRule.RULE_UNKNOWN.toString();
     if (radioOvervoteAlwaysSkip.isSelected()) {
@@ -926,29 +949,6 @@ public class GuiConfigController implements Initializable {
     return willContinue;
   }
 
-  private static String loadTxtFileIntoString(String configFileDocumentationFilename) {
-    String text;
-    try {
-      text =
-          new BufferedReader(
-              new InputStreamReader(
-                  Objects.requireNonNull(
-                      ClassLoader.getSystemResourceAsStream(configFileDocumentationFilename))))
-              .lines()
-              .collect(Collectors.joining("\n"));
-    } catch (Exception exception) {
-      Logger.log(
-          Level.SEVERE,
-          "Error loading text file: %s\n%s",
-          configFileDocumentationFilename,
-          exception.toString());
-      text =
-          String.format(
-              "<Error loading text file: %s>", configFileDocumentationFilename);
-    }
-    return text;
-  }
-
   @Override
   public void initialize(URL location, ResourceBundle resources) {
     Logger.addGuiLogging(this.textAreaStatus);
@@ -1071,43 +1071,25 @@ public class GuiConfigController implements Initializable {
     choiceWinnerElectionMode.setOnAction(event -> {
       clearAndDisableWinningRuleFields();
       setWinningRulesDefaultValues();
+      checkBoxMaxRankingsAllowedMax.setDisable(false);
+      textFieldMinimumVoteThreshold.setDisable(false);
+      choiceTiebreakMode.setDisable(false);
       switch (getWinnerElectionModeChoice(choiceWinnerElectionMode)) {
         case STANDARD_SINGLE_WINNER -> {
-          checkBoxMaxRankingsAllowedMax.setDisable(false);
-          checkBoxMaxRankingsAllowedMax
-              .setSelected(ContestConfig.SUGGESTED_MAX_RANKINGS_ALLOWED_MAXIMUM);
-          textFieldMinimumVoteThreshold.setDisable(false);
           checkBoxBatchElimination.setDisable(false);
           checkBoxContinueUntilTwoCandidatesRemain.setDisable(false);
-          choiceTiebreakMode.setDisable(false);
           textFieldNumberOfWinners.setText("1");
         }
         case MULTI_SEAT_ALLOW_ONLY_ONE_WINNER_PER_ROUND, MULTI_SEAT_ALLOW_MULTIPLE_WINNERS_PER_ROUND -> {
-          checkBoxMaxRankingsAllowedMax.setDisable(false);
-          checkBoxMaxRankingsAllowedMax
-              .setSelected(ContestConfig.SUGGESTED_MAX_RANKINGS_ALLOWED_MAXIMUM);
-          textFieldMinimumVoteThreshold.setDisable(false);
-          choiceTiebreakMode.setDisable(false);
           radioThresholdMostCommon.setDisable(false);
           radioThresholdHbQuota.setDisable(false);
           radioThresholdHareQuota.setDisable(false);
           textFieldDecimalPlacesForVoteArithmetic.setDisable(false);
           textFieldNumberOfWinners.setDisable(false);
         }
-        case MULTI_SEAT_BOTTOMS_UP_UNTIL_N_WINNERS, MULTI_SEAT_SEQUENTIAL_WINNER_TAKES_ALL -> {
-          checkBoxMaxRankingsAllowedMax.setDisable(false);
-          checkBoxMaxRankingsAllowedMax
-              .setSelected(ContestConfig.SUGGESTED_MAX_RANKINGS_ALLOWED_MAXIMUM);
-          textFieldMinimumVoteThreshold.setDisable(false);
-          choiceTiebreakMode.setDisable(false);
-          textFieldNumberOfWinners.setDisable(false);
-        }
+        case MULTI_SEAT_BOTTOMS_UP_UNTIL_N_WINNERS, MULTI_SEAT_SEQUENTIAL_WINNER_TAKES_ALL -> textFieldNumberOfWinners
+            .setDisable(false);
         case MULTI_SEAT_BOTTOMS_UP_USING_PERCENTAGE_THRESHOLD -> {
-          checkBoxMaxRankingsAllowedMax.setDisable(false);
-          checkBoxMaxRankingsAllowedMax
-              .setSelected(ContestConfig.SUGGESTED_MAX_RANKINGS_ALLOWED_MAXIMUM);
-          textFieldMinimumVoteThreshold.setDisable(false);
-          choiceTiebreakMode.setDisable(false);
           textFieldNumberOfWinners.setText("0");
           textFieldMultiSeatBottomsUpPercentageThreshold.setDisable(false);
         }

--- a/src/main/java/network/brightspots/rcv/GuiConfigController.java
+++ b/src/main/java/network/brightspots/rcv/GuiConfigController.java
@@ -192,7 +192,11 @@ public class GuiConfigController implements Initializable {
   @FXML
   private TextField textFieldMaxSkippedRanksAllowed;
   @FXML
+  private CheckBox checkBoxMaxSkippedRanksAllowedUnlimited;
+  @FXML
   private TextField textFieldMaxRankingsAllowed;
+  @FXML
+  private CheckBox checkBoxMaxRankingsAllowedMax;
   @FXML
   private TextField textFieldOvervoteLabel;
   @FXML
@@ -732,6 +736,8 @@ public class GuiConfigController implements Initializable {
   private void clearAndDisableWinningRuleFields() {
     textFieldMaxRankingsAllowed.clear();
     textFieldMaxRankingsAllowed.setDisable(true);
+    checkBoxMaxRankingsAllowedMax.setSelected(false);
+    checkBoxMaxRankingsAllowedMax.setDisable(true);
     textFieldMinimumVoteThreshold.clear();
     textFieldMinimumVoteThreshold.setDisable(true);
     checkBoxBatchElimination.setSelected(false);
@@ -768,7 +774,7 @@ public class GuiConfigController implements Initializable {
         .setSelected(ContestConfig.SUGGESTED_CONTINUE_UNTIL_TWO_CANDIDATES_REMAIN);
     textFieldDecimalPlacesForVoteArithmetic.setText(
         String.valueOf(ContestConfig.SUGGESTED_DECIMAL_PLACES_FOR_VOTE_ARITHMETIC));
-    textFieldMaxRankingsAllowed.setText(ContestConfig.SUGGESTED_MAX_RANKINGS_ALLOWED);
+    checkBoxMaxRankingsAllowedMax.setSelected(ContestConfig.SUGGESTED_MAX_RANKINGS_ALLOWED_MAXIMUM);
   }
 
   private void setDefaultValues() {
@@ -785,6 +791,8 @@ public class GuiConfigController implements Initializable {
 
     textFieldMaxSkippedRanksAllowed.setText(
         String.valueOf(ContestConfig.SUGGESTED_MAX_SKIPPED_RANKS_ALLOWED));
+    checkBoxMaxSkippedRanksAllowedUnlimited
+        .setSelected(ContestConfig.SUGGESTED_MAX_SKIPPED_RANKS_ALLOWED_UNLIMITED);
     checkBoxExhaustOnDuplicateCandidate.setSelected(
         ContestConfig.SUGGESTED_EXHAUST_ON_DUPLICATE_CANDIDATES);
 
@@ -821,6 +829,8 @@ public class GuiConfigController implements Initializable {
     radioOvervoteExhaustImmediately.setSelected(false);
     radioOvervoteExhaustIfMultiple.setSelected(false);
     textFieldMaxSkippedRanksAllowed.clear();
+    textFieldMaxSkippedRanksAllowed.setDisable(false);
+    checkBoxMaxSkippedRanksAllowedUnlimited.setSelected(false);
     checkBoxExhaustOnDuplicateCandidate.setSelected(false);
 
     textFieldOutputDirectory.clear();
@@ -1063,7 +1073,9 @@ public class GuiConfigController implements Initializable {
       setWinningRulesDefaultValues();
       switch (getWinnerElectionModeChoice(choiceWinnerElectionMode)) {
         case STANDARD_SINGLE_WINNER -> {
-          textFieldMaxRankingsAllowed.setDisable(false);
+          checkBoxMaxRankingsAllowedMax.setDisable(false);
+          checkBoxMaxRankingsAllowedMax
+              .setSelected(ContestConfig.SUGGESTED_MAX_RANKINGS_ALLOWED_MAXIMUM);
           textFieldMinimumVoteThreshold.setDisable(false);
           checkBoxBatchElimination.setDisable(false);
           checkBoxContinueUntilTwoCandidatesRemain.setDisable(false);
@@ -1071,7 +1083,9 @@ public class GuiConfigController implements Initializable {
           textFieldNumberOfWinners.setText("1");
         }
         case MULTI_SEAT_ALLOW_ONLY_ONE_WINNER_PER_ROUND, MULTI_SEAT_ALLOW_MULTIPLE_WINNERS_PER_ROUND -> {
-          textFieldMaxRankingsAllowed.setDisable(false);
+          checkBoxMaxRankingsAllowedMax.setDisable(false);
+          checkBoxMaxRankingsAllowedMax
+              .setSelected(ContestConfig.SUGGESTED_MAX_RANKINGS_ALLOWED_MAXIMUM);
           textFieldMinimumVoteThreshold.setDisable(false);
           choiceTiebreakMode.setDisable(false);
           radioThresholdMostCommon.setDisable(false);
@@ -1081,13 +1095,17 @@ public class GuiConfigController implements Initializable {
           textFieldNumberOfWinners.setDisable(false);
         }
         case MULTI_SEAT_BOTTOMS_UP_UNTIL_N_WINNERS, MULTI_SEAT_SEQUENTIAL_WINNER_TAKES_ALL -> {
-          textFieldMaxRankingsAllowed.setDisable(false);
+          checkBoxMaxRankingsAllowedMax.setDisable(false);
+          checkBoxMaxRankingsAllowedMax
+              .setSelected(ContestConfig.SUGGESTED_MAX_RANKINGS_ALLOWED_MAXIMUM);
           textFieldMinimumVoteThreshold.setDisable(false);
           choiceTiebreakMode.setDisable(false);
           textFieldNumberOfWinners.setDisable(false);
         }
         case MULTI_SEAT_BOTTOMS_UP_USING_PERCENTAGE_THRESHOLD -> {
-          textFieldMaxRankingsAllowed.setDisable(false);
+          checkBoxMaxRankingsAllowedMax.setDisable(false);
+          checkBoxMaxRankingsAllowedMax
+              .setSelected(ContestConfig.SUGGESTED_MAX_RANKINGS_ALLOWED_MAXIMUM);
           textFieldMinimumVoteThreshold.setDisable(false);
           choiceTiebreakMode.setDisable(false);
           textFieldNumberOfWinners.setText("0");
@@ -1095,10 +1113,20 @@ public class GuiConfigController implements Initializable {
         }
       }
     });
+    checkBoxMaxRankingsAllowedMax.setOnAction(event -> {
+      textFieldMaxRankingsAllowed.clear();
+      textFieldMaxRankingsAllowed.setDisable(
+          checkBoxMaxRankingsAllowedMax.isSelected());
+    });
 
     radioOvervoteAlwaysSkip.setText(Tabulator.OVERVOTE_RULE_ALWAYS_SKIP_TEXT);
     radioOvervoteExhaustImmediately.setText(Tabulator.OVERVOTE_RULE_EXHAUST_IMMEDIATELY_TEXT);
     radioOvervoteExhaustIfMultiple.setText(Tabulator.OVERVOTE_RULE_EXHAUST_IF_MULTIPLE_TEXT);
+    checkBoxMaxSkippedRanksAllowedUnlimited.setOnAction(event -> {
+      textFieldMaxSkippedRanksAllowed.clear();
+      textFieldMaxSkippedRanksAllowed.setDisable(
+          checkBoxMaxSkippedRanksAllowedUnlimited.isSelected());
+    });
 
     setDefaultValues();
 
@@ -1253,8 +1281,27 @@ public class GuiConfigController implements Initializable {
         .setText(rules.multiSeatBottomsUpPercentageThreshold);
     textFieldDecimalPlacesForVoteArithmetic.setText(rules.decimalPlacesForVoteArithmetic);
     textFieldMinimumVoteThreshold.setText(rules.minimumVoteThreshold);
-    textFieldMaxSkippedRanksAllowed.setText(rules.maxSkippedRanksAllowed);
-    textFieldMaxRankingsAllowed.setText(rules.maxRankingsAllowed);
+    if (rules.maxSkippedRanksAllowed
+        .equalsIgnoreCase(ContestConfig.MAX_SKIPPED_RANKS_ALLOWED_UNLIMITED_OPTION)) {
+      checkBoxMaxSkippedRanksAllowedUnlimited.setSelected(true);
+      textFieldMaxSkippedRanksAllowed.clear();
+      textFieldMaxSkippedRanksAllowed.setDisable(true);
+    } else {
+      checkBoxMaxSkippedRanksAllowedUnlimited.setSelected(false);
+      textFieldMaxSkippedRanksAllowed.setText(rules.maxSkippedRanksAllowed);
+      textFieldMaxSkippedRanksAllowed.setDisable(false);
+    }
+    if (rules.maxRankingsAllowed
+        .equalsIgnoreCase(ContestConfig.MAX_RANKINGS_ALLOWED_NUM_CANDIDATES_OPTION)) {
+      checkBoxMaxRankingsAllowedMax.setSelected(true);
+      checkBoxMaxRankingsAllowedMax.setDisable(false);
+      textFieldMaxRankingsAllowed.clear();
+      textFieldMaxRankingsAllowed.setDisable(true);
+    } else {
+      checkBoxMaxRankingsAllowedMax.setSelected(false);
+      textFieldMaxRankingsAllowed.setText(rules.maxRankingsAllowed);
+      textFieldMaxRankingsAllowed.setDisable(false);
+    }
     textFieldOvervoteLabel.setText(rules.overvoteLabel);
     textFieldUndervoteLabel.setText(rules.undervoteLabel);
     textFieldUndeclaredWriteInLabel.setText(rules.undeclaredWriteInLabel);
@@ -1334,8 +1381,12 @@ public class GuiConfigController implements Initializable {
     rules.decimalPlacesForVoteArithmetic =
         getTextOrEmptyString(textFieldDecimalPlacesForVoteArithmetic);
     rules.minimumVoteThreshold = getTextOrEmptyString(textFieldMinimumVoteThreshold);
-    rules.maxSkippedRanksAllowed = getTextOrEmptyString(textFieldMaxSkippedRanksAllowed);
-    rules.maxRankingsAllowed = getTextOrEmptyString(textFieldMaxRankingsAllowed);
+    rules.maxSkippedRanksAllowed = checkBoxMaxSkippedRanksAllowedUnlimited.isSelected()
+        ? ContestConfig.MAX_SKIPPED_RANKS_ALLOWED_UNLIMITED_OPTION
+        : getTextOrEmptyString(textFieldMaxSkippedRanksAllowed);
+    rules.maxRankingsAllowed = checkBoxMaxRankingsAllowedMax.isSelected()
+        ? ContestConfig.MAX_RANKINGS_ALLOWED_NUM_CANDIDATES_OPTION
+        : getTextOrEmptyString(textFieldMaxRankingsAllowed);
     rules.nonIntegerWinningThreshold = radioThresholdHbQuota.isSelected();
     rules.hareQuota = radioThresholdHareQuota.isSelected();
     rules.batchElimination = checkBoxBatchElimination.isSelected();

--- a/src/main/resources/network/brightspots/rcv/GuiConfigLayout.fxml
+++ b/src/main/resources/network/brightspots/rcv/GuiConfigLayout.fxml
@@ -385,6 +385,12 @@
                       <Label text="Maximum Number of Candidates&#xD; That Can Be Ranked *"
                         prefWidth="180.0"/>
                       <TextField fx:id="textFieldMaxRankingsAllowed" maxWidth="220.0"/>
+                      <CheckBox mnemonicParsing="false" text="Maximum"
+                        fx:id="checkBoxMaxRankingsAllowedMax">
+                        <VBox.margin>
+                          <Insets bottom="8.0" top="8.0"/>
+                        </VBox.margin>
+                      </CheckBox>
                       <padding>
                         <Insets bottom="4.0" left="4.0" right="4.0" top="4.0"/>
                       </padding>
@@ -558,6 +564,12 @@
                   <Label text="How Many Consecutive&#xD; Skipped Ranks Are Allowed *"
                     prefWidth="160.0"/>
                   <TextField fx:id="textFieldMaxSkippedRanksAllowed" maxWidth="220.0"/>
+                  <CheckBox mnemonicParsing="false" text="Unlimited"
+                    fx:id="checkBoxMaxSkippedRanksAllowedUnlimited">
+                    <VBox.margin>
+                      <Insets bottom="8.0" top="8.0"/>
+                    </VBox.margin>
+                  </CheckBox>
                   <padding>
                     <Insets bottom="4.0" left="4.0" right="4.0" top="4.0"/>
                   </padding>


### PR DESCRIPTION
Adds check boxes next to `textFieldMaxSkippedRanksAllowed` and `textFieldMaxRankingsAllowed` to substitute "unlimited" and "max" values in, respectively (fixes #498).