### PR TITLE
make some fields per-source instead of per-config

### DIFF
--- a/src/main/java/network/brightspots/rcv/ClearBallotCvrReader.java
+++ b/src/main/java/network/brightspots/rcv/ClearBallotCvrReader.java
@@ -83,12 +83,10 @@ class ClearBallotCvrReader {
         }
         // validate and store the ranking associated with this choice column
         String choiceName = choiceFields[RcvChoiceHeaderField.CHOICE_NAME.ordinal()];
-        if (!contestConfig.getCandidateCodeList().contains(choiceName)
-            && !choiceName.equals(undeclaredWriteInLabel)) {
-          unrecognizedCandidateCounts.merge(choiceName, 1, Integer::sum);
-        }
         if (choiceName.equals(undeclaredWriteInLabel)) {
           choiceName = Tabulator.UNDECLARED_WRITE_IN_OUTPUT_LABEL;
+        } else if (!contestConfig.getCandidateCodeList().contains(choiceName)) {
+          unrecognizedCandidateCounts.merge(choiceName, 1, Integer::sum);
         }
         Integer rank = Integer.parseInt(choiceFields[RcvChoiceHeaderField.RANK.ordinal()]);
         if (rank > this.contestConfig.getMaxRankingsAllowed()) {

--- a/src/main/java/network/brightspots/rcv/ClearBallotCvrReader.java
+++ b/src/main/java/network/brightspots/rcv/ClearBallotCvrReader.java
@@ -34,10 +34,12 @@ class ClearBallotCvrReader {
 
   private final String cvrPath;
   private final ContestConfig contestConfig;
+  private final String undeclaredWriteInLabel;
 
-  ClearBallotCvrReader(String cvrPath, ContestConfig contestConfig) {
+  ClearBallotCvrReader(String cvrPath, ContestConfig contestConfig, String undeclaredWriteInLabel) {
     this.cvrPath = cvrPath;
     this.contestConfig = contestConfig;
+    this.undeclaredWriteInLabel = undeclaredWriteInLabel;
   }
 
   // parse Cvr json into CastVoteRecord objects and append them to the input castVoteRecords list
@@ -82,8 +84,11 @@ class ClearBallotCvrReader {
         // validate and store the ranking associated with this choice column
         String choiceName = choiceFields[RcvChoiceHeaderField.CHOICE_NAME.ordinal()];
         if (!contestConfig.getCandidateCodeList().contains(choiceName)
-            && !choiceName.equals(contestConfig.getUndeclaredWriteInLabel())) {
+            && !choiceName.equals(undeclaredWriteInLabel)) {
           unrecognizedCandidateCounts.merge(choiceName, 1, Integer::sum);
+        }
+        if (choiceName.equals(undeclaredWriteInLabel)) {
+          choiceName = Tabulator.UNDECLARED_WRITE_IN_OUTPUT_LABEL;
         }
         Integer rank = Integer.parseInt(choiceFields[RcvChoiceHeaderField.RANK.ordinal()]);
         if (rank > this.contestConfig.getMaxRankingsAllowed()) {

--- a/src/main/java/network/brightspots/rcv/ContestConfig.java
+++ b/src/main/java/network/brightspots/rcv/ContestConfig.java
@@ -67,7 +67,6 @@ class ContestConfig {
   static final boolean SUGGESTED_MAX_SKIPPED_RANKS_ALLOWED_UNLIMITED = false;
   static final String SUGGESTED_OVERVOTE_LABEL = "overvote";
   static final String SUGGESTED_UNDERVOTE_LABEL = "undervote";
-  static final String UNDECLARED_WRITE_INS = "Undeclared Write-ins";
   static final String MAX_SKIPPED_RANKS_ALLOWED_UNLIMITED_OPTION = "unlimited";
   static final String MAX_RANKINGS_ALLOWED_NUM_CANDIDATES_OPTION = "max";
   private static final int MIN_COLUMN_INDEX = 1;
@@ -210,6 +209,13 @@ class ContestConfig {
             source.getOvervoteDelimiter().matches(".*\\\\.*|[a-zA-Z0-9.',\\-\"\\s]+")) {
           sourceValid = false;
           Logger.log(Level.SEVERE, "overvoteDelimiter is invalid.");
+        }
+
+        if (source.isTreatBlankAsUndeclaredWriteInEnabled() && isNullOrBlank(source.getUndeclaredWriteInLabel())) {
+          sourceValid = false;
+          Logger.log(
+              Level.SEVERE,
+              "undeclaredWriteInLabel must be supplied if treatBlankAsUndeclaredWriteIn is true!");
         }
       } else {
         if (provider == Provider.CDF) {
@@ -455,27 +461,32 @@ class ContestConfig {
     }
   }
 
-  // function: stringAlreadyInUseElsewhere
-  // purpose: Checks to make sure string isn't reserved or used by other fields
-  // param: string string to check
-  // param: field field name of provided string
-  private boolean stringAlreadyInUseElsewhere(String string, String field) {
-    boolean inUse = false;
+  private boolean stringConflictsWithReservedString(String string, String field) {
+    boolean reserved = false;
     for (String reservedString : TallyTransfers.RESERVED_STRINGS) {
       if (string.equalsIgnoreCase(reservedString)) {
-        inUse = true;
+        reserved = true;
         Logger.log(
             Level.SEVERE, "\"%s\" is a reserved term and can't be used for %s!", string, field);
         break;
       }
     }
+    return reserved;
+  }
+
+  // function: stringAlreadyInUseElsewhere
+  // purpose: Checks to make sure string isn't reserved or used by other fields
+  // param: string string to check
+  // param: field field name of provided string
+  private boolean stringAlreadyInUseElsewhereInSource(String string, CvrSource source, String field) {
+    boolean inUse = stringConflictsWithReservedString(string, field);
     if (!inUse) {
       inUse =
-          stringMatchesAnotherFieldValue(string, field, getOvervoteLabel(), "overvoteLabel")
+          stringMatchesAnotherFieldValue(string, field, source.getOvervoteLabel(), "overvoteLabel")
               || stringMatchesAnotherFieldValue(
-              string, field, getUndervoteLabel(), "undervoteLabel")
+              string, field, source.getUndervoteLabel(), "undervoteLabel")
               || stringMatchesAnotherFieldValue(
-              string, field, getUndeclaredWriteInLabel(), "undeclaredWriteInLabel");
+              string, field, source.getUndeclaredWriteInLabel(), "undeclaredWriteInLabel");
     }
     return inUse;
   }
@@ -486,13 +497,19 @@ class ContestConfig {
   // param: candidateStringsSeen is a running set of names/codes we've already encountered
   private boolean candidateStringAlreadyInUseElsewhere(
       String candidateString, String field, Set<String> candidateStringsSeen) {
-    boolean inUse;
+    boolean inUse = false;
     if (candidateStringsSeen.contains(candidateString)) {
       inUse = true;
       Logger.log(
           Level.SEVERE, "Duplicate candidate %ss are not allowed: %s", field, candidateString);
     } else {
-      inUse = stringAlreadyInUseElsewhere(candidateString, "a candidate " + field);
+      for (CvrSource source : getRawConfig().cvrFileSources) {
+        inUse = stringAlreadyInUseElsewhereInSource(candidateString, source,
+            "a candidate " + field);
+        if (inUse) {
+          break;
+        }
+      }
     }
     return inUse;
   }
@@ -526,6 +543,29 @@ class ContestConfig {
           Logger.log(Level.SEVERE, "Cast vote record file not found: %s", cvrPath);
         }
 
+        if (!isNullOrBlank(source.getOvervoteLabel())
+            && stringAlreadyInUseElsewhereInSource(source.getOvervoteLabel(), source, "overvoteLabel")) {
+          isValid = false;
+        }
+        if (!isNullOrBlank(source.getUndervoteLabel())
+            && stringAlreadyInUseElsewhereInSource(source.getUndervoteLabel(), source, "undervoteLabel")) {
+          isValid = false;
+        }
+        if (!isNullOrBlank(source.getUndeclaredWriteInLabel())
+            && stringAlreadyInUseElsewhereInSource(source.getUndeclaredWriteInLabel(), source, "undeclaredWriteInLabel")) {
+          isValid = false;
+        }
+
+        if (!isNullOrBlank(source.getOvervoteLabel())
+            && getOvervoteRule() != Tabulator.OvervoteRule.EXHAUST_IMMEDIATELY
+            && getOvervoteRule() != Tabulator.OvervoteRule.ALWAYS_SKIP_TO_NEXT_RANK) {
+          isValid = false;
+          Logger.log(Level.SEVERE,
+              "When overvoteLabel is supplied, overvoteRule must be either \"%s\" or \"%s\"!",
+              Tabulator.OVERVOTE_RULE_ALWAYS_SKIP_TEXT,
+              Tabulator.OVERVOTE_RULE_EXHAUST_IF_MULTIPLE_TEXT);
+        }
+
         if (isCdf(source)) {
           // perform CDF checks
           if (rawConfig.cvrFileSources.size() != 1) {
@@ -546,7 +586,7 @@ class ContestConfig {
                 cvrPath);
           }
           if (!isNullOrBlank(source.getOvervoteDelimiter())) {
-            if (!isNullOrBlank(getOvervoteLabel())) {
+            if (!isNullOrBlank(source.getOvervoteLabel())) {
               isValid = false;
               Logger.log(
                   Level.SEVERE,
@@ -626,14 +666,6 @@ class ContestConfig {
     if (getOvervoteRule() == OvervoteRule.RULE_UNKNOWN) {
       isValid = false;
       Logger.log(Level.SEVERE, "Invalid overvoteRule!");
-    } else if (!isNullOrBlank(getOvervoteLabel())
-        && getOvervoteRule() != Tabulator.OvervoteRule.EXHAUST_IMMEDIATELY
-        && getOvervoteRule() != Tabulator.OvervoteRule.ALWAYS_SKIP_TO_NEXT_RANK) {
-      isValid = false;
-      Logger.log(Level.SEVERE,
-          "When overvoteLabel is supplied, overvoteRule must be either \"%s\" or \"%s\"!",
-          Tabulator.OVERVOTE_RULE_ALWAYS_SKIP_TEXT,
-          Tabulator.OVERVOTE_RULE_EXHAUST_IF_MULTIPLE_TEXT);
     }
 
     if (getWinnerElectionMode() == WinnerElectionMode.MODE_UNKNOWN) {
@@ -772,26 +804,6 @@ class ContestConfig {
       isValid = false;
       Logger.log(Level.SEVERE,
           "nonIntegerWinningThreshold and hareQuota can't both be true at the same time!");
-    }
-
-    if (!isNullOrBlank(getOvervoteLabel())
-        && stringAlreadyInUseElsewhere(getOvervoteLabel(), "overvoteLabel")) {
-      isValid = false;
-    }
-    if (!isNullOrBlank(getUndervoteLabel())
-        && stringAlreadyInUseElsewhere(getUndervoteLabel(), "undervoteLabel")) {
-      isValid = false;
-    }
-    if (!isNullOrBlank(getUndeclaredWriteInLabel())
-        && stringAlreadyInUseElsewhere(getUndeclaredWriteInLabel(), "undeclaredWriteInLabel")) {
-      isValid = false;
-    }
-
-    if (isTreatBlankAsUndeclaredWriteInEnabled() && isNullOrBlank(getUndeclaredWriteInLabel())) {
-      isValid = false;
-      Logger.log(
-          Level.SEVERE,
-          "undeclaredWriteInLabel must be supplied if treatBlankAsUndeclaredWriteIn is true!");
     }
   }
 
@@ -959,12 +971,8 @@ class ContestConfig {
   }
 
   int getNumDeclaredCandidates() {
-    int num = getCandidateCodeList().size();
-    if (!isNullOrBlank(getUndeclaredWriteInLabel())
-        && getCandidateCodeList().contains(getUndeclaredWriteInLabel())) {
-      num--;
-    }
-    return num;
+    // we subtract one for UNDECLARED_WRITE_IN_OUTPUT_LABEL;
+    return getCandidateCodeList().size() - 1;
   }
 
   int getNumCandidates() {
@@ -1000,18 +1008,6 @@ class ContestConfig {
         Integer.MAX_VALUE);
   }
 
-  String getUndeclaredWriteInLabel() {
-    return rawConfig.rules.undeclaredWriteInLabel;
-  }
-
-  String getOvervoteLabel() {
-    return rawConfig.rules.overvoteLabel;
-  }
-
-  String getUndervoteLabel() {
-    return rawConfig.rules.undervoteLabel;
-  }
-
   TieBreakMode getTiebreakMode() {
     TieBreakMode mode = TieBreakMode.getByLabel(rawConfig.rules.tiebreakMode);
     return mode == null ? TieBreakMode.MODE_UNKNOWN : mode;
@@ -1029,10 +1025,6 @@ class ContestConfig {
     return getTiebreakMode() == TieBreakMode.RANDOM
         || getTiebreakMode() == TieBreakMode.PREVIOUS_ROUND_COUNTS_THEN_RANDOM
         || getTiebreakMode() == TieBreakMode.GENERATE_PERMUTATION;
-  }
-
-  boolean isTreatBlankAsUndeclaredWriteInEnabled() {
-    return rawConfig.rules.treatBlankAsUndeclaredWriteIn;
   }
 
   boolean isExhaustOnDuplicateCandidateEnabled() {
@@ -1082,9 +1074,18 @@ class ContestConfig {
       }
     }
 
-    String uwiLabel = getUndeclaredWriteInLabel();
-    if (!isNullOrBlank(uwiLabel)) {
-      candidateCodeToNameMap.put(uwiLabel, UNDECLARED_WRITE_INS);
+    // If any of the sources support undeclared write-ins, we need to recognize them as a valid
+    // "candidate" option.
+    boolean includeUwi = false;
+    for (CvrSource source : rawConfig.cvrFileSources) {
+      if (!isNullOrBlank(source.getUndeclaredWriteInLabel()) || source.isTreatBlankAsUndeclaredWriteInEnabled()) {
+        includeUwi = true;
+        break;
+      }
+    }
+    if (includeUwi) {
+      candidateCodeToNameMap.put(Tabulator.UNDECLARED_WRITE_IN_OUTPUT_LABEL,
+          Tabulator.UNDECLARED_WRITE_IN_OUTPUT_LABEL);
     }
   }
 

--- a/src/main/java/network/brightspots/rcv/ContestConfig.java
+++ b/src/main/java/network/brightspots/rcv/ContestConfig.java
@@ -226,14 +226,6 @@ class ContestConfig {
           sourceValid = false;
           Logger.log(Level.SEVERE, "overvoteDelimiter is invalid.");
         }
-
-        if (source.isTreatBlankAsUndeclaredWriteIn() && isNullOrBlank(
-            source.getUndeclaredWriteInLabel())) {
-          sourceValid = false;
-          Logger.log(
-              Level.SEVERE,
-              "undeclaredWriteInLabel must be supplied if treatBlankAsUndeclaredWriteIn is true!");
-        }
       } else {
         if (provider == Provider.CDF) {
           if (!source.getFilePath().toLowerCase().endsWith(".xml") && !source.getFilePath()

--- a/src/main/java/network/brightspots/rcv/ContestConfigMigration.java
+++ b/src/main/java/network/brightspots/rcv/ContestConfigMigration.java
@@ -1,0 +1,109 @@
+/*
+ * Universal RCV Tabulator
+ * Copyright (c) 2017-2020 Bright Spots Developers.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+ * the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this
+ * program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package network.brightspots.rcv;
+
+import java.util.Map;
+import java.util.logging.Level;
+import network.brightspots.rcv.Tabulator.OvervoteRule;
+import network.brightspots.rcv.Tabulator.TieBreakMode;
+import network.brightspots.rcv.Tabulator.WinnerElectionMode;
+
+class ContestConfigMigration {
+  static void migrateConfigVersion(ContestConfig config) {
+    if (config.rawConfig.tabulatorVersion == null
+        || !config.rawConfig.tabulatorVersion.equals(Main.APP_VERSION)) {
+      // Any necessary future version migration logic goes here
+
+      if (config.getWinnerElectionMode() == WinnerElectionMode.MODE_UNKNOWN) {
+        String oldWinnerElectionMode = config.rawConfig.rules.winnerElectionMode;
+        switch (oldWinnerElectionMode) {
+          case "standard" -> config.rawConfig.rules.winnerElectionMode =
+              config.getNumberOfWinners() > 1
+                  ? WinnerElectionMode.MULTI_SEAT_ALLOW_MULTIPLE_WINNERS_PER_ROUND.toString()
+                  : WinnerElectionMode.STANDARD_SINGLE_WINNER.toString();
+          case "singleSeatContinueUntilTwoCandidatesRemain" -> {
+            config.rawConfig.rules.winnerElectionMode = WinnerElectionMode.STANDARD_SINGLE_WINNER
+                .toString();
+            config.rawConfig.rules.continueUntilTwoCandidatesRemain = true;
+          }
+          case "multiSeatAllowOnlyOneWinnerPerRound" -> config.rawConfig.rules.winnerElectionMode =
+              WinnerElectionMode.MULTI_SEAT_ALLOW_ONLY_ONE_WINNER_PER_ROUND.toString();
+          case "multiSeatBottomsUp" -> config.rawConfig.rules.winnerElectionMode =
+              config.getNumberOfWinners() == 0
+                  || config.getMultiSeatBottomsUpPercentageThreshold() != null
+                  ? WinnerElectionMode.MULTI_SEAT_BOTTOMS_UP_USING_PERCENTAGE_THRESHOLD.toString()
+                  : WinnerElectionMode.MULTI_SEAT_BOTTOMS_UP_UNTIL_N_WINNERS.toString();
+          case "multiSeatSequentialWinnerTakesAll" -> config.rawConfig.rules.winnerElectionMode =
+              WinnerElectionMode.MULTI_SEAT_SEQUENTIAL_WINNER_TAKES_ALL.toString();
+          default -> {
+            Logger.log(Level.WARNING,
+                "winnerElectionMode \"%s\" is unrecognized! Please supply a valid "
+                    + "winnerElectionMode.", oldWinnerElectionMode);
+            config.rawConfig.rules.winnerElectionMode = null;
+          }
+        }
+      }
+
+      if (config.getTiebreakMode() == TieBreakMode.MODE_UNKNOWN) {
+        Map<String, String> tiebreakModeMigrationMap = Map.of(
+            "random", TieBreakMode.RANDOM.toString(),
+            "interactive", TieBreakMode.INTERACTIVE.toString(),
+            "previousRoundCountsThenRandom",
+            TieBreakMode.PREVIOUS_ROUND_COUNTS_THEN_RANDOM.toString(),
+            "previousRoundCountsThenInteractive",
+            TieBreakMode.PREVIOUS_ROUND_COUNTS_THEN_INTERACTIVE.toString(),
+            "usePermutationInConfig", TieBreakMode.USE_PERMUTATION_IN_CONFIG.toString(),
+            "generatePermutation", TieBreakMode.GENERATE_PERMUTATION.toString()
+        );
+        String oldTiebreakMode = config.rawConfig.rules.tiebreakMode;
+        if (tiebreakModeMigrationMap.containsKey(oldTiebreakMode)) {
+          config.rawConfig.rules.tiebreakMode = tiebreakModeMigrationMap.get(oldTiebreakMode);
+        } else {
+          Logger.log(Level.WARNING,
+              "tiebreakMode \"%s\" is unrecognized! Please supply a valid tiebreakMode.",
+              oldTiebreakMode);
+          config.rawConfig.rules.tiebreakMode = null;
+        }
+      }
+
+      if (config.getOvervoteRule() == OvervoteRule.RULE_UNKNOWN) {
+        String oldOvervoteRule = config.rawConfig.rules.overvoteRule;
+        switch (oldOvervoteRule) {
+          case "alwaysSkipToNextRank" -> config.rawConfig.rules.overvoteRule = OvervoteRule.ALWAYS_SKIP_TO_NEXT_RANK
+              .toString();
+          case "exhaustImmediately" -> config.rawConfig.rules.overvoteRule = OvervoteRule.EXHAUST_IMMEDIATELY
+              .toString();
+          case "exhaustIfMultipleContinuing" -> config.rawConfig.rules.overvoteRule = OvervoteRule.EXHAUST_IF_MULTIPLE_CONTINUING
+              .toString();
+          default -> {
+            Logger.log(Level.WARNING,
+                "overvoteRule \"%s\" is unrecognized! Please supply a valid overvoteRule.",
+                oldOvervoteRule);
+            config.rawConfig.rules.overvoteRule = null;
+          }
+        }
+      }
+
+      Logger.log(
+          Level.INFO,
+          "Migrated tabulator config version from %s to %s.",
+          config.rawConfig.tabulatorVersion != null ? config.rawConfig.tabulatorVersion : "unknown",
+          Main.APP_VERSION);
+      config.rawConfig.tabulatorVersion = Main.APP_VERSION;
+    }
+  }
+}

--- a/src/main/java/network/brightspots/rcv/ContestConfigMigration.java
+++ b/src/main/java/network/brightspots/rcv/ContestConfigMigration.java
@@ -16,94 +16,169 @@
 
 package network.brightspots.rcv;
 
+import java.util.ArrayList;
 import java.util.Map;
-import java.util.logging.Level;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import network.brightspots.rcv.Tabulator.OvervoteRule;
 import network.brightspots.rcv.Tabulator.TieBreakMode;
 import network.brightspots.rcv.Tabulator.WinnerElectionMode;
 
 class ContestConfigMigration {
-  static void migrateConfigVersion(ContestConfig config) {
-    if (config.rawConfig.tabulatorVersion == null
-        || !config.rawConfig.tabulatorVersion.equals(Main.APP_VERSION)) {
-      // Any necessary future version migration logic goes here
 
-      if (config.getWinnerElectionMode() == WinnerElectionMode.MODE_UNKNOWN) {
-        String oldWinnerElectionMode = config.rawConfig.rules.winnerElectionMode;
-        switch (oldWinnerElectionMode) {
-          case "standard" -> config.rawConfig.rules.winnerElectionMode =
-              config.getNumberOfWinners() > 1
-                  ? WinnerElectionMode.MULTI_SEAT_ALLOW_MULTIPLE_WINNERS_PER_ROUND.toString()
-                  : WinnerElectionMode.STANDARD_SINGLE_WINNER.toString();
-          case "singleSeatContinueUntilTwoCandidatesRemain" -> {
-            config.rawConfig.rules.winnerElectionMode = WinnerElectionMode.STANDARD_SINGLE_WINNER
-                .toString();
-            config.rawConfig.rules.continueUntilTwoCandidatesRemain = true;
-          }
-          case "multiSeatAllowOnlyOneWinnerPerRound" -> config.rawConfig.rules.winnerElectionMode =
-              WinnerElectionMode.MULTI_SEAT_ALLOW_ONLY_ONE_WINNER_PER_ROUND.toString();
-          case "multiSeatBottomsUp" -> config.rawConfig.rules.winnerElectionMode =
-              config.getNumberOfWinners() == 0
-                  || config.getMultiSeatBottomsUpPercentageThreshold() != null
-                  ? WinnerElectionMode.MULTI_SEAT_BOTTOMS_UP_USING_PERCENTAGE_THRESHOLD.toString()
-                  : WinnerElectionMode.MULTI_SEAT_BOTTOMS_UP_UNTIL_N_WINNERS.toString();
-          case "multiSeatSequentialWinnerTakesAll" -> config.rawConfig.rules.winnerElectionMode =
-              WinnerElectionMode.MULTI_SEAT_SEQUENTIAL_WINNER_TAKES_ALL.toString();
-          default -> {
-            Logger.log(Level.WARNING,
-                "winnerElectionMode \"%s\" is unrecognized! Please supply a valid "
-                    + "winnerElectionMode.", oldWinnerElectionMode);
-            config.rawConfig.rules.winnerElectionMode = null;
-          }
-        }
+  private static final Pattern versionNumPattern = Pattern.compile("(\\d+).*");
+
+  private static ArrayList<Integer> parseVersionString(String version) {
+    ArrayList<Integer> parsed = new ArrayList<>();
+    String[] arr = version.split("\\.");
+    for (String numString : arr) {
+      Matcher m = versionNumPattern.matcher(numString);
+      if (m.matches()) {
+        parsed.add(Integer.parseInt(m.group(1)));
       }
-
-      if (config.getTiebreakMode() == TieBreakMode.MODE_UNKNOWN) {
-        Map<String, String> tiebreakModeMigrationMap = Map.of(
-            "random", TieBreakMode.RANDOM.toString(),
-            "interactive", TieBreakMode.INTERACTIVE.toString(),
-            "previousRoundCountsThenRandom",
-            TieBreakMode.PREVIOUS_ROUND_COUNTS_THEN_RANDOM.toString(),
-            "previousRoundCountsThenInteractive",
-            TieBreakMode.PREVIOUS_ROUND_COUNTS_THEN_INTERACTIVE.toString(),
-            "usePermutationInConfig", TieBreakMode.USE_PERMUTATION_IN_CONFIG.toString(),
-            "generatePermutation", TieBreakMode.GENERATE_PERMUTATION.toString()
-        );
-        String oldTiebreakMode = config.rawConfig.rules.tiebreakMode;
-        if (tiebreakModeMigrationMap.containsKey(oldTiebreakMode)) {
-          config.rawConfig.rules.tiebreakMode = tiebreakModeMigrationMap.get(oldTiebreakMode);
-        } else {
-          Logger.log(Level.WARNING,
-              "tiebreakMode \"%s\" is unrecognized! Please supply a valid tiebreakMode.",
-              oldTiebreakMode);
-          config.rawConfig.rules.tiebreakMode = null;
-        }
-      }
-
-      if (config.getOvervoteRule() == OvervoteRule.RULE_UNKNOWN) {
-        String oldOvervoteRule = config.rawConfig.rules.overvoteRule;
-        switch (oldOvervoteRule) {
-          case "alwaysSkipToNextRank" -> config.rawConfig.rules.overvoteRule = OvervoteRule.ALWAYS_SKIP_TO_NEXT_RANK
-              .toString();
-          case "exhaustImmediately" -> config.rawConfig.rules.overvoteRule = OvervoteRule.EXHAUST_IMMEDIATELY
-              .toString();
-          case "exhaustIfMultipleContinuing" -> config.rawConfig.rules.overvoteRule = OvervoteRule.EXHAUST_IF_MULTIPLE_CONTINUING
-              .toString();
-          default -> {
-            Logger.log(Level.WARNING,
-                "overvoteRule \"%s\" is unrecognized! Please supply a valid overvoteRule.",
-                oldOvervoteRule);
-            config.rawConfig.rules.overvoteRule = null;
-          }
-        }
-      }
-
-      Logger.log(
-          Level.INFO,
-          "Migrated tabulator config version from %s to %s.",
-          config.rawConfig.tabulatorVersion != null ? config.rawConfig.tabulatorVersion : "unknown",
-          Main.APP_VERSION);
-      config.rawConfig.tabulatorVersion = Main.APP_VERSION;
     }
+
+    return parsed;
+  }
+
+  // not intended to be used if either version is null
+  private static boolean isVersionNewer(String version1, String version2) {
+    if (version1.equals(version2)) {
+      return false;
+    }
+
+    ArrayList<Integer> version1Parsed = parseVersionString(version1);
+    ArrayList<Integer> version2Parsed = parseVersionString(version2);
+
+    for (int i = 0; i < version1Parsed.size(); i++) {
+      if (version2Parsed.size() <= i) {
+        return true;
+      }
+      int version1Num = version1Parsed.get(i);
+      int version2Num = version2Parsed.get(i);
+      if (version1Num > version2Num) {
+        return true;
+      } else if (version2Num > version1Num) {
+        return false;
+      }
+    }
+
+    return false;
+  }
+
+  static boolean isConfigVersionOlderThanAppVersion(String configVersion) {
+    return configVersion == null || isVersionNewer(Main.APP_VERSION, configVersion);
+  }
+
+  static boolean isConfigVersionNewerThanAppVersion(String configVersion) {
+    if (configVersion == null) {
+      return false;
+    }
+
+    if (isVersionNewer(configVersion, Main.APP_VERSION)) {
+      Logger.severe(
+          "Unable to process a config file with version %s using older version %s of the app!",
+          configVersion, Main.APP_VERSION);
+      return true;
+    }
+
+    return false;
+  }
+
+  static void migrateConfigVersion(ContestConfig config)
+      throws ConfigVersionIsNewerThanAppVersionException {
+    String version = config.rawConfig.tabulatorVersion;
+    if (version != null &&
+        (version.equals(Main.APP_VERSION) || version
+            .equals(ContestConfig.AUTOMATED_TEST_VERSION))) {
+      return;
+    }
+
+    if (isConfigVersionNewerThanAppVersion(version)) {
+      throw new ConfigVersionIsNewerThanAppVersionException();
+    }
+
+    // Any necessary future version migration logic goes here
+
+    if (config.getWinnerElectionMode() == WinnerElectionMode.MODE_UNKNOWN) {
+      String oldWinnerElectionMode = config.rawConfig.rules.winnerElectionMode;
+      switch (oldWinnerElectionMode) {
+        case "standard" -> config.rawConfig.rules.winnerElectionMode =
+            config.getNumberOfWinners() > 1
+                ? WinnerElectionMode.MULTI_SEAT_ALLOW_MULTIPLE_WINNERS_PER_ROUND.toString()
+                : WinnerElectionMode.STANDARD_SINGLE_WINNER.toString();
+        case "singleSeatContinueUntilTwoCandidatesRemain" -> {
+          config.rawConfig.rules.winnerElectionMode = WinnerElectionMode.STANDARD_SINGLE_WINNER
+              .toString();
+          config.rawConfig.rules.continueUntilTwoCandidatesRemain = true;
+        }
+        case "multiSeatAllowOnlyOneWinnerPerRound" -> config.rawConfig.rules.winnerElectionMode =
+            WinnerElectionMode.MULTI_SEAT_ALLOW_ONLY_ONE_WINNER_PER_ROUND.toString();
+        case "multiSeatBottomsUp" -> config.rawConfig.rules.winnerElectionMode =
+            config.getNumberOfWinners() == 0
+                || config.getMultiSeatBottomsUpPercentageThreshold() != null
+                ? WinnerElectionMode.MULTI_SEAT_BOTTOMS_UP_USING_PERCENTAGE_THRESHOLD.toString()
+                : WinnerElectionMode.MULTI_SEAT_BOTTOMS_UP_UNTIL_N_WINNERS.toString();
+        case "multiSeatSequentialWinnerTakesAll" -> config.rawConfig.rules.winnerElectionMode =
+            WinnerElectionMode.MULTI_SEAT_SEQUENTIAL_WINNER_TAKES_ALL.toString();
+        default -> {
+          Logger.warning(
+              "winnerElectionMode \"%s\" is unrecognized! Please supply a valid "
+                  + "winnerElectionMode.", oldWinnerElectionMode);
+          config.rawConfig.rules.winnerElectionMode = null;
+        }
+      }
+    }
+
+    if (config.getTiebreakMode() == TieBreakMode.MODE_UNKNOWN) {
+      Map<String, String> tiebreakModeMigrationMap = Map.of(
+          "random", TieBreakMode.RANDOM.toString(),
+          "interactive", TieBreakMode.INTERACTIVE.toString(),
+          "previousRoundCountsThenRandom",
+          TieBreakMode.PREVIOUS_ROUND_COUNTS_THEN_RANDOM.toString(),
+          "previousRoundCountsThenInteractive",
+          TieBreakMode.PREVIOUS_ROUND_COUNTS_THEN_INTERACTIVE.toString(),
+          "usePermutationInConfig", TieBreakMode.USE_PERMUTATION_IN_CONFIG.toString(),
+          "generatePermutation", TieBreakMode.GENERATE_PERMUTATION.toString()
+      );
+      String oldTiebreakMode = config.rawConfig.rules.tiebreakMode;
+      if (tiebreakModeMigrationMap.containsKey(oldTiebreakMode)) {
+        config.rawConfig.rules.tiebreakMode = tiebreakModeMigrationMap.get(oldTiebreakMode);
+      } else {
+        Logger.warning(
+            "tiebreakMode \"%s\" is unrecognized! Please supply a valid tiebreakMode.",
+            oldTiebreakMode);
+        config.rawConfig.rules.tiebreakMode = null;
+      }
+    }
+
+    if (config.getOvervoteRule() == OvervoteRule.RULE_UNKNOWN) {
+      String oldOvervoteRule = config.rawConfig.rules.overvoteRule;
+      switch (oldOvervoteRule) {
+        case "alwaysSkipToNextRank" -> config.rawConfig.rules.overvoteRule = OvervoteRule.ALWAYS_SKIP_TO_NEXT_RANK
+            .toString();
+        case "exhaustImmediately" -> config.rawConfig.rules.overvoteRule = OvervoteRule.EXHAUST_IMMEDIATELY
+            .toString();
+        case "exhaustIfMultipleContinuing" -> config.rawConfig.rules.overvoteRule = OvervoteRule.EXHAUST_IF_MULTIPLE_CONTINUING
+            .toString();
+        default -> {
+          Logger.warning(
+              "overvoteRule \"%s\" is unrecognized! Please supply a valid overvoteRule.",
+              oldOvervoteRule);
+          config.rawConfig.rules.overvoteRule = null;
+        }
+      }
+    }
+
+    Logger.info(
+        "Migrated tabulator config version from %s to %s.",
+        config.rawConfig.tabulatorVersion != null ? config.rawConfig.tabulatorVersion : "unknown",
+        Main.APP_VERSION);
+
+    config.rawConfig.tabulatorVersion = Main.APP_VERSION;
+  }
+
+  static class ConfigVersionIsNewerThanAppVersionException extends Exception {
+
   }
 }

--- a/src/main/java/network/brightspots/rcv/DominionCvrReader.java
+++ b/src/main/java/network/brightspots/rcv/DominionCvrReader.java
@@ -39,6 +39,7 @@ class DominionCvrReader {
   private static final String CVR_EXPORT = "CvrExport.json";
   private final ContestConfig config;
   private final String manifestFolder;
+  private final String undeclaredWriteInLabel;
   // map of precinct Id to precinct description
   private Map<Integer, String> precincts;
   // map of precinct portion Id to precinct portion description
@@ -49,9 +50,10 @@ class DominionCvrReader {
   // map for tracking unrecognized candidates during parsing
   private final Map<String, Integer> unrecognizedCandidateCounts = new HashMap<>();
 
-  DominionCvrReader(ContestConfig config, String manifestFolder) {
+  DominionCvrReader(ContestConfig config, String manifestFolder, String undeclaredWriteInLabel) {
     this.config = config;
     this.manifestFolder = manifestFolder;
+    this.undeclaredWriteInLabel = undeclaredWriteInLabel;
   }
 
   // returns map of contestId to Contest parsed from input file
@@ -275,8 +277,9 @@ class DominionCvrReader {
             }
             // We also need to throw an error if this candidate doesn't appear in the tabulator's
             // config file for this contest.
-            if (!config.getCandidateCodeList().contains(candidateCode)
-                && !candidateCode.equals(config.getUndeclaredWriteInLabel())) {
+            if (candidateCode.equals(undeclaredWriteInLabel)) {
+              candidateCode = Tabulator.UNDECLARED_WRITE_IN_OUTPUT_LABEL;
+            } else if (!config.getCandidateCodeList().contains(candidateCode)) {
               unrecognizedCandidateCounts.merge(candidateCode, 1, Integer::sum);
             }
 

--- a/src/main/java/network/brightspots/rcv/GuiConfigController.java
+++ b/src/main/java/network/brightspots/rcv/GuiConfigController.java
@@ -137,6 +137,14 @@ public class GuiConfigController implements Initializable {
   @FXML
   private TableColumn<CvrSource, String> tableColumnCvrContestId;
   @FXML
+  private TableColumn<CvrSource, String> tableColumnCvrOvervoteLabel;
+  @FXML
+  private TableColumn<CvrSource, String> tableColumnCvrUndervoteLabel;
+  @FXML
+  private TableColumn<CvrSource, String> tableColumnCvrUndeclaredWriteInLabel;
+  @FXML
+  private TableColumn<CvrSource, Boolean> tableColumnCvrTreatBlankAsUndeclaredWriteIn;
+  @FXML
   private ChoiceBox<Provider> choiceCvrProvider;
   @FXML
   private Button buttonAddCvrFile;
@@ -156,6 +164,14 @@ public class GuiConfigController implements Initializable {
   private TextField textFieldCvrPrecinctCol;
   @FXML
   private TextField textFieldCvrOvervoteDelimiter;
+  @FXML
+  private TextField textFieldCvrOvervoteLabel;
+  @FXML
+  private TextField textFieldCvrUndervoteLabel;
+  @FXML
+  private TextField textFieldCvrUndeclaredWriteInLabel;
+  @FXML
+  private CheckBox checkBoxCvrTreatBlankAsUndeclaredWriteIn;
   @FXML
   private TableView<Candidate> tableViewCandidates;
   @FXML
@@ -199,12 +215,6 @@ public class GuiConfigController implements Initializable {
   @FXML
   private CheckBox checkBoxMaxRankingsAllowedMax;
   @FXML
-  private TextField textFieldOvervoteLabel;
-  @FXML
-  private TextField textFieldUndervoteLabel;
-  @FXML
-  private TextField textFieldUndeclaredWriteInLabel;
-  @FXML
   private TextField textFieldRulesDescription;
   @FXML
   private RadioButton radioThresholdMostCommon;
@@ -218,8 +228,6 @@ public class GuiConfigController implements Initializable {
   private CheckBox checkBoxContinueUntilTwoCandidatesRemain;
   @FXML
   private CheckBox checkBoxExhaustOnDuplicateCandidate;
-  @FXML
-  private CheckBox checkBoxTreatBlankAsUndeclaredWriteIn;
   @FXML
   private MenuBar menuBar;
   @FXML
@@ -576,7 +584,12 @@ public class GuiConfigController implements Initializable {
             getTextOrEmptyString(textFieldCvrPrecinctCol),
             getTextOrEmptyString(textFieldCvrOvervoteDelimiter),
             getProviderChoice(choiceCvrProvider).toString(),
-            getTextOrEmptyString(textFieldCvrContestId));
+            getTextOrEmptyString(textFieldCvrContestId),
+            getTextOrEmptyString(textFieldCvrOvervoteLabel),
+            getTextOrEmptyString(textFieldCvrUndervoteLabel),
+            getTextOrEmptyString(textFieldCvrUndeclaredWriteInLabel),
+            checkBoxCvrTreatBlankAsUndeclaredWriteIn.isSelected()
+        );
     if (ContestConfig.passesBasicCvrSourceValidation(cvrSource)) {
       tableViewCvrFiles.getItems().add(cvrSource);
       textFieldCvrFilePath.clear();
@@ -606,6 +619,14 @@ public class GuiConfigController implements Initializable {
     textFieldCvrOvervoteDelimiter.setDisable(true);
     textFieldCvrContestId.clear();
     textFieldCvrContestId.setDisable(true);
+    textFieldCvrOvervoteLabel.clear();
+    textFieldCvrOvervoteLabel.setDisable(true);
+    textFieldCvrUndervoteLabel.clear();
+    textFieldCvrUndervoteLabel.setDisable(true);
+    textFieldCvrUndeclaredWriteInLabel.clear();
+    textFieldCvrUndeclaredWriteInLabel.setDisable(true);
+    checkBoxCvrTreatBlankAsUndeclaredWriteIn.setSelected(false);
+    checkBoxCvrTreatBlankAsUndeclaredWriteIn.setDisable(true);
   }
 
   /**
@@ -704,6 +725,32 @@ public class GuiConfigController implements Initializable {
         .setContestId(cellEditEvent.getNewValue().toString().trim());
     tableViewCvrFiles.refresh();
   }
+
+  public void changeCvrOvervoteLabel(CellEditEvent cellEditEvent) {
+    tableViewCvrFiles
+        .getSelectionModel()
+        .getSelectedItem()
+        .setOvervoteLabel(cellEditEvent.getNewValue().toString().trim());
+    tableViewCvrFiles.refresh();
+  }
+
+  public void changeCvrUndervoteLabel(CellEditEvent cellEditEvent) {
+    tableViewCvrFiles
+        .getSelectionModel()
+        .getSelectedItem()
+        .setUndervoteLabel(cellEditEvent.getNewValue().toString().trim());
+    tableViewCvrFiles.refresh();
+  }
+
+  public void changeCvrUndeclaredWriteInLabel(CellEditEvent cellEditEvent) {
+    tableViewCvrFiles
+        .getSelectionModel()
+        .getSelectedItem()
+        .setUndeclaredWriteInLabel(cellEditEvent.getNewValue().toString().trim());
+    tableViewCvrFiles.refresh();
+  }
+
+  // louis
 
   /**
    * Action when add candidate button is clicked.
@@ -806,12 +853,7 @@ public class GuiConfigController implements Initializable {
 
     checkBoxCandidateExcluded.setSelected(ContestConfig.SUGGESTED_CANDIDATE_EXCLUDED);
 
-    checkBoxTreatBlankAsUndeclaredWriteIn.setSelected(
-        ContestConfig.SUGGESTED_TREAT_BLANK_AS_UNDECLARED_WRITE_IN);
-
     setWinningRulesDefaultValues();
-    textFieldOvervoteLabel.setText(ContestConfig.SUGGESTED_OVERVOTE_LABEL);
-    textFieldUndervoteLabel.setText(ContestConfig.SUGGESTED_UNDERVOTE_LABEL);
 
     textFieldMaxSkippedRanksAllowed.setText(
         String.valueOf(ContestConfig.SUGGESTED_MAX_SKIPPED_RANKS_ALLOWED));
@@ -843,11 +885,6 @@ public class GuiConfigController implements Initializable {
 
     choiceWinnerElectionMode.setValue(null);
     clearAndDisableWinningRuleFields();
-
-    textFieldOvervoteLabel.clear();
-    textFieldUndervoteLabel.clear();
-    textFieldUndeclaredWriteInLabel.clear();
-    checkBoxTreatBlankAsUndeclaredWriteIn.setSelected(false);
 
     radioOvervoteAlwaysSkip.setSelected(false);
     radioOvervoteExhaustImmediately.setSelected(false);
@@ -991,6 +1028,7 @@ public class GuiConfigController implements Initializable {
     choiceCvrProvider.getItems().remove(Provider.PROVIDER_UNKNOWN);
     choiceCvrProvider.setOnAction(event -> {
       clearAndDisableCvrFilesTabFields();
+      textFieldCvrUndeclaredWriteInLabel.setDisable(false);
       switch (getProviderChoice(choiceCvrProvider)) {
         case ESS -> {
           buttonAddCvrFile.setDisable(false);
@@ -1008,12 +1046,26 @@ public class GuiConfigController implements Initializable {
           textFieldCvrPrecinctCol
               .setText(String.valueOf(ContestConfig.SUGGESTED_CVR_PRECINCT_COLUMN));
           textFieldCvrOvervoteDelimiter.setDisable(false);
+          textFieldCvrOvervoteLabel.setDisable(false);
+          textFieldCvrOvervoteLabel.setText(ContestConfig.SUGGESTED_OVERVOTE_LABEL);
+          textFieldCvrUndervoteLabel.setDisable(false);
+          textFieldCvrUndervoteLabel.setText(ContestConfig.SUGGESTED_UNDERVOTE_LABEL);
+          checkBoxCvrTreatBlankAsUndeclaredWriteIn.setDisable(false);
+          checkBoxCvrTreatBlankAsUndeclaredWriteIn.setSelected(ContestConfig.SUGGESTED_TREAT_BLANK_AS_UNDECLARED_WRITE_IN);
         }
-        case CLEAR_BALLOT, DOMINION, HART, CDF -> {
+        case CLEAR_BALLOT, DOMINION, HART -> {
           buttonAddCvrFile.setDisable(false);
           textFieldCvrFilePath.setDisable(false);
           buttonCvrFilePath.setDisable(false);
           textFieldCvrContestId.setDisable(false);
+        }
+        case CDF -> {
+          buttonAddCvrFile.setDisable(false);
+          textFieldCvrFilePath.setDisable(false);
+          buttonCvrFilePath.setDisable(false);
+          textFieldCvrContestId.setDisable(false);
+          textFieldCvrOvervoteLabel.setDisable(false);
+          textFieldCvrOvervoteLabel.setText(ContestConfig.SUGGESTED_OVERVOTE_LABEL);
         }
       }
     });
@@ -1036,6 +1088,23 @@ public class GuiConfigController implements Initializable {
     tableColumnCvrProvider.setCellFactory(TextFieldTableCell.forTableColumn());
     tableColumnCvrContestId.setCellValueFactory(new PropertyValueFactory<>("contestId"));
     tableColumnCvrContestId.setCellFactory(TextFieldTableCell.forTableColumn());
+    tableColumnCvrOvervoteLabel.setCellValueFactory(new PropertyValueFactory<>("overvoteLabel"));
+    tableColumnCvrOvervoteLabel.setCellFactory(TextFieldTableCell.forTableColumn());
+    tableColumnCvrUndervoteLabel.setCellValueFactory(new PropertyValueFactory<>("undervoteLabel"));
+    tableColumnCvrUndervoteLabel.setCellFactory(TextFieldTableCell.forTableColumn());
+    tableColumnCvrUndeclaredWriteInLabel.setCellValueFactory(new PropertyValueFactory<>("undeclaredWriteInLabel"));
+    tableColumnCvrUndeclaredWriteInLabel.setCellFactory(TextFieldTableCell.forTableColumn());
+    tableColumnCvrTreatBlankAsUndeclaredWriteIn.setCellValueFactory(
+        c -> {
+          CvrSource source = c.getValue();
+          CheckBox checkBox = new CheckBox();
+          checkBox.selectedProperty().setValue(source.isTreatBlankAsUndeclaredWriteInEnabled());
+          checkBox
+              .selectedProperty()
+              .addListener((ov, oldVal, newVal) -> source.setTreatBlankAsUndeclaredWriteIn(newVal));
+          //noinspection unchecked
+          return new SimpleObjectProperty(checkBox);
+        });
     tableViewCvrFiles.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
     tableViewCvrFiles.setEditable(true);
 
@@ -1205,15 +1274,11 @@ public class GuiConfigController implements Initializable {
       textFieldMaxRankingsAllowed.setText(rules.maxRankingsAllowed);
       textFieldMaxRankingsAllowed.setDisable(false);
     }
-    textFieldOvervoteLabel.setText(rules.overvoteLabel);
-    textFieldUndervoteLabel.setText(rules.undervoteLabel);
-    textFieldUndeclaredWriteInLabel.setText(rules.undeclaredWriteInLabel);
     textFieldRulesDescription.setText(rules.rulesDescription);
     setThresholdCalculationMethodRadioButton(rules.nonIntegerWinningThreshold, rules.hareQuota);
     checkBoxBatchElimination.setSelected(rules.batchElimination);
     checkBoxContinueUntilTwoCandidatesRemain.setSelected(rules.continueUntilTwoCandidatesRemain);
     checkBoxExhaustOnDuplicateCandidate.setSelected(rules.exhaustOnDuplicateCandidate);
-    checkBoxTreatBlankAsUndeclaredWriteIn.setSelected(rules.treatBlankAsUndeclaredWriteIn);
   }
 
   private void setThresholdCalculationMethodRadioButton(boolean nonIntegerWinningThreshold,
@@ -1263,6 +1328,9 @@ public class GuiConfigController implements Initializable {
           source.getOvervoteDelimiter() != null ? source.getOvervoteDelimiter().trim() : "");
       source.setProvider(source.getProvider() != null ? source.getProvider().trim() : "");
       source.setContestId(source.getContestId() != null ? source.getContestId().trim() : "");
+      source.setOvervoteLabel(source.getOvervoteLabel() != null ? source.getOvervoteLabel().trim() : "");
+      source.setUndervoteLabel(source.getUndervoteLabel() != null ? source.getUndervoteLabel().trim() : "");
+      source.setUndeclaredWriteInLabel(source.getUndeclaredWriteInLabel() != null ? source.getUndeclaredWriteInLabel().trim() : "");
     }
     config.cvrFileSources = cvrSources;
 
@@ -1295,10 +1363,6 @@ public class GuiConfigController implements Initializable {
     rules.batchElimination = checkBoxBatchElimination.isSelected();
     rules.continueUntilTwoCandidatesRemain = checkBoxContinueUntilTwoCandidatesRemain.isSelected();
     rules.exhaustOnDuplicateCandidate = checkBoxExhaustOnDuplicateCandidate.isSelected();
-    rules.treatBlankAsUndeclaredWriteIn = checkBoxTreatBlankAsUndeclaredWriteIn.isSelected();
-    rules.overvoteLabel = getTextOrEmptyString(textFieldOvervoteLabel);
-    rules.undervoteLabel = getTextOrEmptyString(textFieldUndervoteLabel);
-    rules.undeclaredWriteInLabel = getTextOrEmptyString(textFieldUndeclaredWriteInLabel);
     rules.rulesDescription = getTextOrEmptyString(textFieldRulesDescription);
     config.rules = rules;
 

--- a/src/main/java/network/brightspots/rcv/GuiConfigController.java
+++ b/src/main/java/network/brightspots/rcv/GuiConfigController.java
@@ -68,6 +68,7 @@ import javafx.stage.FileChooser;
 import javafx.stage.FileChooser.ExtensionFilter;
 import javafx.util.StringConverter;
 import network.brightspots.rcv.ContestConfig.Provider;
+import network.brightspots.rcv.ContestConfigMigration.ConfigVersionIsNewerThanAppVersionException;
 import network.brightspots.rcv.RawContestConfig.Candidate;
 import network.brightspots.rcv.RawContestConfig.ContestRules;
 import network.brightspots.rcv.RawContestConfig.CvrSource;
@@ -1138,7 +1139,11 @@ public class GuiConfigController implements Initializable {
   private void loadConfig(ContestConfig config) {
     clearConfig();
     RawContestConfig rawConfig = config.getRawConfig();
-    ContestConfigMigration.migrateConfigVersion(config);
+    try {
+      ContestConfigMigration.migrateConfigVersion(config);
+    } catch (ConfigVersionIsNewerThanAppVersionException e) {
+      return;
+    }
     OutputSettings outputSettings = rawConfig.outputSettings;
     textFieldContestName.setText(outputSettings.contestName);
     textFieldOutputDirectory.setText(config.getOutputDirectoryRaw());

--- a/src/main/java/network/brightspots/rcv/GuiConfigController.java
+++ b/src/main/java/network/brightspots/rcv/GuiConfigController.java
@@ -752,8 +752,6 @@ public class GuiConfigController implements Initializable {
     tableViewCvrFiles.refresh();
   }
 
-  // louis
-
   /**
    * Action when add candidate button is clicked.
    */

--- a/src/main/java/network/brightspots/rcv/RawContestConfig.java
+++ b/src/main/java/network/brightspots/rcv/RawContestConfig.java
@@ -70,6 +70,12 @@ public class RawContestConfig {
     private String overvoteDelimiter;
     private String provider;
 
+    // These used to be defined at the config level, but now they're per-source.
+    public String overvoteLabel;
+    public String undervoteLabel;
+    public String undeclaredWriteInLabel;
+    public boolean treatBlankAsUndeclaredWriteIn;
+
     CvrSource() {
     }
 
@@ -81,7 +87,11 @@ public class RawContestConfig {
         String precinctColumnIndex,
         String overvoteDelimiter,
         String provider,
-        String contestId) {
+        String contestId,
+        String overvoteLabel,
+        String undervoteLabel,
+        String undeclaredWriteInLabel,
+        boolean treatBlankAsUndeclaredWriteIn) {
       this.filePath = filePath;
       this.firstVoteColumnIndex = firstVoteColumnIndex;
       this.firstVoteRowIndex = firstVoteRowIndex;
@@ -90,6 +100,10 @@ public class RawContestConfig {
       this.overvoteDelimiter = overvoteDelimiter;
       this.provider = provider;
       this.contestId = contestId;
+      this.overvoteLabel = overvoteLabel;
+      this.undervoteLabel = undervoteLabel;
+      this.undeclaredWriteInLabel = undeclaredWriteInLabel;
+      this.treatBlankAsUndeclaredWriteIn = treatBlankAsUndeclaredWriteIn;
     }
 
     public String getFilePath() {
@@ -154,6 +168,38 @@ public class RawContestConfig {
 
     public void setProvider(String provider) {
       this.provider = provider;
+    }
+
+    public String getOvervoteLabel() {
+      return overvoteLabel;
+    }
+
+    public void setOvervoteLabel(String overvoteLabel) {
+      this.overvoteLabel = overvoteLabel;
+    }
+
+    public String getUndervoteLabel() {
+      return undervoteLabel;
+    }
+
+    public void setUndervoteLabel(String undervoteLabel) {
+      this.undervoteLabel = undervoteLabel;
+    }
+
+    public String getUndeclaredWriteInLabel() {
+      return undeclaredWriteInLabel;
+    }
+
+    public void setUndeclaredWriteInLabel(String undeclaredWriteInLabel) {
+      this.undeclaredWriteInLabel = undeclaredWriteInLabel;
+    }
+
+    public boolean isTreatBlankAsUndeclaredWriteInEnabled() {
+      return treatBlankAsUndeclaredWriteIn;
+    }
+
+    public void setTreatBlankAsUndeclaredWriteIn(boolean treatBlankAsUndeclaredWriteIn) {
+      this.treatBlankAsUndeclaredWriteIn = treatBlankAsUndeclaredWriteIn;
     }
   }
 
@@ -221,10 +267,13 @@ public class RawContestConfig {
     public boolean batchElimination;
     public boolean continueUntilTwoCandidatesRemain;
     public boolean exhaustOnDuplicateCandidate;
+    public String rulesDescription;
+
+    // These are deprecated (moved to individual CVRs), but we need to leave them in place here for
+    // the purpose of supporting automatic migration from older config versions.
     public boolean treatBlankAsUndeclaredWriteIn;
     public String overvoteLabel;
     public String undervoteLabel;
     public String undeclaredWriteInLabel;
-    public String rulesDescription;
   }
 }

--- a/src/main/java/network/brightspots/rcv/RawContestConfig.java
+++ b/src/main/java/network/brightspots/rcv/RawContestConfig.java
@@ -70,7 +70,6 @@ public class RawContestConfig {
     private String overvoteDelimiter;
     private String provider;
 
-    // These used to be defined at the config level, but now they're per-source.
     public String overvoteLabel;
     public String undervoteLabel;
     public String undeclaredWriteInLabel;
@@ -194,7 +193,7 @@ public class RawContestConfig {
       this.undeclaredWriteInLabel = undeclaredWriteInLabel;
     }
 
-    public boolean isTreatBlankAsUndeclaredWriteInEnabled() {
+    public boolean isTreatBlankAsUndeclaredWriteIn() {
       return treatBlankAsUndeclaredWriteIn;
     }
 

--- a/src/main/java/network/brightspots/rcv/ResultsWriter.java
+++ b/src/main/java/network/brightspots/rcv/ResultsWriter.java
@@ -477,9 +477,9 @@ class ResultsWriter {
     entries.sort(
         (firstObject, secondObject) -> {
           int ret;
-          if (firstObject.getKey().equals(config.getUndeclaredWriteInLabel())) {
+          if (firstObject.getKey().equals(Tabulator.UNDECLARED_WRITE_IN_OUTPUT_LABEL)) {
             ret = 1;
-          } else if (secondObject.getKey().equals(config.getUndeclaredWriteInLabel())) {
+          } else if (secondObject.getKey().equals(Tabulator.UNDECLARED_WRITE_IN_OUTPUT_LABEL)) {
             ret = -1;
           } else {
             ret = (secondObject.getValue()).compareTo(firstObject.getValue());

--- a/src/main/java/network/brightspots/rcv/ResultsWriter.java
+++ b/src/main/java/network/brightspots/rcv/ResultsWriter.java
@@ -510,7 +510,8 @@ class ResultsWriter {
       List<CastVoteRecord> castVoteRecords,
       Collection<Contest> contests,
       String csvOutputFolder,
-      String contestId
+      String contestId,
+      String undeclaredWriteInLabel
   ) throws IOException {
     List<String> filesWritten = new ArrayList<>();
     try {
@@ -567,6 +568,11 @@ class ResultsWriter {
               assert !candidateSet.isEmpty();
               if (candidateSet.size() == 1) {
                 String selection = candidateSet.iterator().next();
+                // We map all undeclared write-ins to our constant string when we read them in,
+                // so we need to translate it back to the original candidate ID here.
+                if (selection.equals(Tabulator.UNDECLARED_WRITE_IN_OUTPUT_LABEL)) {
+                  selection = undeclaredWriteInLabel;
+                }
                 csvPrinter.print(selection);
               } else {
                 csvPrinter.print("overvote");

--- a/src/main/java/network/brightspots/rcv/StreamingCvrReader.java
+++ b/src/main/java/network/brightspots/rcv/StreamingCvrReader.java
@@ -116,7 +116,7 @@ class StreamingCvrReader {
     this.overvoteLabel = source.getOvervoteLabel();
     this.undervoteLabel = source.getUndervoteLabel();
     this.undeclaredWriteInLabel = source.getUndeclaredWriteInLabel();
-    this.treatBlankAsUndeclaredWriteIn = source.isTreatBlankAsUndeclaredWriteInEnabled();
+    this.treatBlankAsUndeclaredWriteIn = source.isTreatBlankAsUndeclaredWriteIn();
   }
 
   // given Excel-style address string return the cell address as a pair of Integers

--- a/src/main/java/network/brightspots/rcv/Tabulator.java
+++ b/src/main/java/network/brightspots/rcv/Tabulator.java
@@ -50,7 +50,7 @@ class Tabulator {
   // When the CVR contains an overvote we "normalize" it to use this string
   static final String EXPLICIT_OVERVOTE_LABEL = "overvote";
   // Similarly, we normalize undeclared write-ins to use this string
-  static final String UNDECLARED_WRITE_IN_OUTPUT_LABEL = "Undeclared Write-Ins";
+  static final String UNDECLARED_WRITE_IN_OUTPUT_LABEL = "Undeclared Write-ins";
   // cast vote records parsed from CVR input files
   private final List<CastVoteRecord> castVoteRecords;
   // all candidate IDs for this contest parsed from the contest config

--- a/src/main/java/network/brightspots/rcv/Tabulator.java
+++ b/src/main/java/network/brightspots/rcv/Tabulator.java
@@ -49,6 +49,8 @@ class Tabulator {
   static final String OVERVOTE_RULE_EXHAUST_IF_MULTIPLE_TEXT = "Exhaust if multiple continuing";
   // When the CVR contains an overvote we "normalize" it to use this string
   static final String EXPLICIT_OVERVOTE_LABEL = "overvote";
+  // Similarly, we normalize undeclared write-ins to use this string
+  static final String UNDECLARED_WRITE_IN_OUTPUT_LABEL = "Undeclared Write-Ins";
   // cast vote records parsed from CVR input files
   private final List<CastVoteRecord> castVoteRecords;
   // all candidate IDs for this contest parsed from the contest config
@@ -245,7 +247,7 @@ class Tabulator {
         "There are %d declared candidates for this contest:",
         config.getNumDeclaredCandidates());
     for (String candidate : candidateIds) {
-      if (!candidate.equals(config.getUndeclaredWriteInLabel())) {
+      if (!candidate.equals(UNDECLARED_WRITE_IN_OUTPUT_LABEL)) {
         Logger.log(
             Level.INFO,
             "%s%s",
@@ -430,7 +432,7 @@ class Tabulator {
       status = CandidateStatus.WINNER;
     } else if (candidateToRoundEliminated.containsKey(candidate)) {
       status = CandidateStatus.ELIMINATED;
-    } else if (candidate.equals(config.getOvervoteLabel())) {
+    } else if (candidate.equals(EXPLICIT_OVERVOTE_LABEL)) {
       status = CandidateStatus.INVALID;
     }
     return status;
@@ -476,7 +478,7 @@ class Tabulator {
               List<String> winningCandidates = currentRoundTallyToCandidates.get(tally);
               for (String candidate : winningCandidates) {
                 // The undeclared write-in placeholder can't win!
-                if (!candidate.equals(config.getUndeclaredWriteInLabel())) {
+                if (!candidate.equals(UNDECLARED_WRITE_IN_OUTPUT_LABEL)) {
                   selectedWinners.add(candidate);
                 }
               }
@@ -539,10 +541,8 @@ class Tabulator {
   private List<String> dropUndeclaredWriteIns(
       Map<String, BigDecimal> currentRoundCandidateToTally) {
     List<String> eliminated = new LinkedList<>();
-    // undeclared label
-    String label = config.getUndeclaredWriteInLabel();
-    if (!isNullOrBlank(label)
-        && currentRoundCandidateToTally.get(label) != null
+    String label = UNDECLARED_WRITE_IN_OUTPUT_LABEL;
+    if (currentRoundCandidateToTally.get(label) != null
         && currentRoundCandidateToTally.get(label).signum() == 1) {
       eliminated.add(label);
       Logger.log(

--- a/src/main/java/network/brightspots/rcv/TabulatorSession.java
+++ b/src/main/java/network/brightspots/rcv/TabulatorSession.java
@@ -274,18 +274,19 @@ class TabulatorSession {
       try {
         if (ContestConfig.isCdf(source)) {
           Logger.log(Level.INFO, "Reading CDF cast vote record file: %s...", cvrPath);
-          new CommonDataFormatReader(cvrPath, config, source.getContestId())
+          new CommonDataFormatReader(cvrPath, config, source.getContestId(),
+              source.getOvervoteLabel())
               .parseCvrFile(castVoteRecords);
           continue;
         } else if (ContestConfig.getProvider(source) == Provider.CLEAR_BALLOT) {
           Logger
               .log(Level.INFO, "Reading Clear Ballot cast vote records from file: %s...", cvrPath);
-          new ClearBallotCvrReader(cvrPath, config)
+          new ClearBallotCvrReader(cvrPath, config, source.getUndeclaredWriteInLabel())
               .readCastVoteRecords(castVoteRecords, source.getContestId());
           continue;
         } else if (provider == Provider.DOMINION) {
           Logger.log(Level.INFO, "Reading Dominion cast vote records from folder: %s...", cvrPath);
-          DominionCvrReader reader = new DominionCvrReader(config, cvrPath);
+          DominionCvrReader reader = new DominionCvrReader(config, cvrPath, source.getUndeclaredWriteInLabel());
           reader.readCastVoteRecords(castVoteRecords, source.getContestId());
           // Before we tabulate, we output a converted generic CSV for the CVRs.
           try {
@@ -305,7 +306,7 @@ class TabulatorSession {
           continue;
         } else if (provider == Provider.HART) {
           Logger.log(Level.INFO, "Reading Hart cast vote records from folder: %s...", cvrPath);
-          new HartCvrReader(cvrPath, source.getContestId(), config)
+          new HartCvrReader(cvrPath, source.getContestId(), config, source.getUndeclaredWriteInLabel())
               .readCastVoteRecordsFromFolder(castVoteRecords);
           continue;
         }

--- a/src/main/java/network/brightspots/rcv/TabulatorSession.java
+++ b/src/main/java/network/brightspots/rcv/TabulatorSession.java
@@ -72,14 +72,16 @@ class TabulatorSession {
   private static void checkConfigVersionMatchesApp(ContestConfig config) {
     String version = config.getRawConfig().tabulatorVersion;
 
-    if (ContestConfigMigration.isConfigVersionNewerThanAppVersion(version)) {
-      // It will log a severe message already, so no need to add one here.
-    } else if (ContestConfigMigration.isConfigVersionOlderThanAppVersion(version)) {
-      Logger.severe(
-          "Can't use a config with older version %s in newer version %s of the app! To " +
-              "automatically migrate the config to the newer version, load it in the graphical " +
-              "version of the app (i.e. don't use the -cli flag when starting the tabulator).",
-          version, Main.APP_VERSION);
+    if (!version.equals(ContestConfig.AUTOMATED_TEST_VERSION)) {
+      if (ContestConfigMigration.isConfigVersionNewerThanAppVersion(version)) {
+        // It will log a severe message already, so no need to add one here.
+      } else if (ContestConfigMigration.isConfigVersionOlderThanAppVersion(version)) {
+        Logger.severe(
+            "Can't use a config with older version %s in newer version %s of the app! To " +
+                "automatically migrate the config to the newer version, load it in the graphical " +
+                "version of the app (i.e. don't use the -cli flag when starting the tabulator).",
+            version, Main.APP_VERSION);
+      }
     }
   }
 

--- a/src/main/java/network/brightspots/rcv/TabulatorSession.java
+++ b/src/main/java/network/brightspots/rcv/TabulatorSession.java
@@ -76,8 +76,9 @@ class TabulatorSession {
       // It will log a severe message already, so no need to add one here.
     } else if (ContestConfigMigration.isConfigVersionOlderThanAppVersion(version)) {
       Logger.severe(
-          "Can't use a config with older version %s in newer version %s of the app! Use the " +
-              "graphical version of the app to migrate the config to the current version.",
+          "Can't use a config with older version %s in newer version %s of the app! To " +
+              "automatically migrate the config to the newer version, load it in the graphical " +
+              "version of the app (i.e. don't use the -cli flag when starting the tabulator).",
           version, Main.APP_VERSION);
     }
   }

--- a/src/main/java/network/brightspots/rcv/TabulatorSession.java
+++ b/src/main/java/network/brightspots/rcv/TabulatorSession.java
@@ -298,7 +298,8 @@ class TabulatorSession {
                 castVoteRecords,
                 reader.getContests().values(),
                 config.getOutputDirectory(),
-                source.getContestId());
+                source.getContestId(),
+                source.getUndeclaredWriteInLabel());
           } catch (IOException e) {
             // error already logged in ResultsWriter
           }

--- a/src/main/resources/network/brightspots/rcv/GuiConfigLayout.fxml
+++ b/src/main/resources/network/brightspots/rcv/GuiConfigLayout.fxml
@@ -262,7 +262,7 @@
                   <Insets bottom="8.0" left="8.0" right="4.0"/>
                 </VBox.margin>
               </VBox>
-              <VBox styleClass="bordered-box" maxWidth="800.0">
+              <VBox styleClass="bordered-box">
                 <HBox alignment="CENTER_LEFT" spacing="4.0">
                   <Label
                     text="Note: double-click existing entries below to edit and press Enter to save changes.">
@@ -412,10 +412,10 @@
           </Tab>
           <Tab text="Winning Rules" fx:id="tabWinningRules">
             <VBox>
-              <VBox styleClass="bordered-box" maxWidth="820.0">
+              <VBox styleClass="bordered-box">
                 <HBox alignment="CENTER_LEFT" spacing="4.0">
                   <Label text="Winner Election Mode *" prefWidth="180.0"/>
-                  <ChoiceBox fx:id="choiceWinnerElectionMode" prefWidth="280.0"/>
+                  <ChoiceBox fx:id="choiceWinnerElectionMode" prefWidth="300.0"/>
                   <padding>
                     <Insets bottom="4.0" left="4.0" right="4.0" top="4.0"/>
                   </padding>
@@ -428,9 +428,9 @@
                 <HBox alignment="CENTER_LEFT" spacing="4.0">
                   <VBox spacing="4.0">
                     <HBox alignment="CENTER_LEFT" spacing="4.0">
-                      <Label text="Maximum Number of Candidates&#xD; That Can Be Ranked *"
-                        prefWidth="180.0"/>
-                      <TextField fx:id="textFieldMaxRankingsAllowed" maxWidth="220.0"/>
+                      <Label text="Maximum Number of Candidates&#xD;That Can Be Ranked *"
+                        prefWidth="200.0"/>
+                      <TextField fx:id="textFieldMaxRankingsAllowed" maxWidth="80.0"/>
                       <CheckBox mnemonicParsing="false" text="Maximum"
                         fx:id="checkBoxMaxRankingsAllowedMax">
                         <VBox.margin>
@@ -442,8 +442,8 @@
                       </padding>
                     </HBox>
                     <HBox alignment="CENTER_LEFT" spacing="4.0">
-                      <Label text="Minimum Vote Threshold" prefWidth="180.0"/>
-                      <TextField fx:id="textFieldMinimumVoteThreshold" maxWidth="220.0"/>
+                      <Label text="Minimum Vote Threshold" prefWidth="200.0"/>
+                      <TextField fx:id="textFieldMinimumVoteThreshold" maxWidth="80.0"/>
                       <padding>
                         <Insets bottom="4.0" left="4.0" right="4.0" top="4.0"/>
                       </padding>
@@ -472,8 +472,8 @@
                       </padding>
                     </HBox>
                     <HBox alignment="CENTER_LEFT" spacing="4.0">
-                      <Label text="Tiebreak Mode *" prefWidth="180.0"/>
-                      <ChoiceBox fx:id="choiceTiebreakMode" prefWidth="220.0"/>
+                      <Label text="Tiebreak Mode *" prefWidth="100.0"/>
+                      <ChoiceBox fx:id="choiceTiebreakMode" prefWidth="320.0"/>
                       <padding>
                         <Insets bottom="4.0" left="4.0" right="4.0" top="4.0"/>
                       </padding>
@@ -567,10 +567,10 @@
                   </padding>
                 </HBox>
                 <HBox alignment="CENTER_LEFT" spacing="4.0">
-                  <Label text="How Many Consecutive&#xD; Skipped Ranks Are Allowed *"
-                    prefWidth="160.0"/>
+                  <Label text="How Many Consecutive&#xD;Skipped Ranks Are Allowed *"
+                    prefWidth="220.0"/>
                   <TextField fx:id="textFieldMaxSkippedRanksAllowed" maxWidth="220.0"/>
-                  <CheckBox mnemonicParsing="false" text="Unlimited"
+                  <CheckBox mnemonicParsing="false" text="Unlimited" prefWidth="180.0"
                     fx:id="checkBoxMaxSkippedRanksAllowedUnlimited">
                     <VBox.margin>
                       <Insets bottom="8.0" top="8.0"/>

--- a/src/main/resources/network/brightspots/rcv/GuiConfigLayout.fxml
+++ b/src/main/resources/network/brightspots/rcv/GuiConfigLayout.fxml
@@ -218,6 +218,41 @@
                         <Insets bottom="4.0" left="4.0" right="4.0" top="4.0"/>
                       </padding>
                     </HBox>
+                    <HBox alignment="CENTER_LEFT" spacing="4.0">
+                      <Label prefWidth="160.0" text="Overvote Label"/>
+                      <TextField prefHeight="25.0" prefWidth="200.0"
+                        fx:id="textFieldCvrOvervoteLabel"/>
+                      <padding>
+                        <Insets bottom="4.0" left="4.0" right="4.0" top="4.0"/>
+                      </padding>
+                    </HBox>
+                    <HBox alignment="CENTER_LEFT" spacing="4.0">
+                      <Label prefWidth="160.0" text="Undervote Label"/>
+                      <TextField prefHeight="25.0" prefWidth="200.0"
+                        fx:id="textFieldCvrUndervoteLabel"/>
+                      <padding>
+                        <Insets bottom="4.0" left="4.0" right="4.0" top="4.0"/>
+                      </padding>
+                    </HBox>
+                    <HBox alignment="CENTER_LEFT" spacing="4.0">
+                      <Label prefWidth="160.0" text="Undeclared Write-In Label"/>
+                      <TextField prefHeight="25.0" prefWidth="200.0"
+                        fx:id="textFieldCvrUndeclaredWriteInLabel"/>
+                      <padding>
+                        <Insets bottom="4.0" left="4.0" right="4.0" top="4.0"/>
+                      </padding>
+                    </HBox>
+                    <HBox alignment="CENTER_LEFT" spacing="4.0">
+                      <CheckBox fx:id="checkBoxCvrTreatBlankAsUndeclaredWriteIn"
+                        mnemonicParsing="false" text="Treat Blank as Undeclared Write-in">
+                        <VBox.margin>
+                          <Insets top="8.0" bottom="8.0"/>
+                        </VBox.margin>
+                      </CheckBox>
+                      <padding>
+                        <Insets bottom="4.0" left="4.0" right="4.0" top="4.0"/>
+                      </padding>
+                    </HBox>
                   </VBox>
                 </HBox>
                 <padding>
@@ -263,6 +298,17 @@
                     <TableColumn minWidth="20.0" onEditCommit="#changeCvrOvervoteDelimiter"
                       prefWidth="60.0" text="Overvote&#10;Delimiter"
                       fx:id="tableColumnCvrOvervoteDelimiter"/>
+                    <TableColumn minWidth="20.0" onEditCommit="#changeCvrOvervoteLabel"
+                      prefWidth="60.0" text="Overvote&#10;Label"
+                      fx:id="tableColumnCvrOvervoteLabel"/>
+                    <TableColumn minWidth="20.0" onEditCommit="#changeCvrUndervoteLabel"
+                      prefWidth="60.0" text="Undervote&#10;Label"
+                      fx:id="tableColumnCvrUndervoteLabel"/>
+                    <TableColumn minWidth="20.0" onEditCommit="#changeCvrUndeclaredWriteInLabel"
+                      prefWidth="60.0" text="Undeclared&#10;Write-In&#10;Label"
+                      fx:id="tableColumnCvrUndeclaredWriteInLabel"/>
+                    <TableColumn fx:id="tableColumnCvrTreatBlankAsUndeclaredWriteIn" minWidth="20.0"
+                      prefWidth="100.0" text="Treat Blank&#10;As Undeclared&#10;Write-In"/>
                   </columns>
                 </TableView>
                 <padding>
@@ -487,46 +533,6 @@
                       </padding>
                     </HBox>
                   </VBox>
-                </HBox>
-                <padding>
-                  <Insets bottom="4.0" left="4.0" right="4.0" top="4.0"/>
-                </padding>
-                <VBox.margin>
-                  <Insets bottom="8.0" left="8.0" right="4.0"/>
-                </VBox.margin>
-              </VBox>
-              <VBox styleClass="bordered-box" maxWidth="400.0">
-                <HBox alignment="CENTER_LEFT" spacing="4.0">
-                  <Label text="Overvote Label" prefWidth="150.0"/>
-                  <TextField fx:id="textFieldOvervoteLabel" prefWidth="210.0"/>
-                  <padding>
-                    <Insets bottom="4.0" left="4.0" right="4.0" top="4.0"/>
-                  </padding>
-                </HBox>
-                <HBox alignment="CENTER_LEFT" spacing="4.0">
-                  <Label text="Undervote Label" prefWidth="150.0"/>
-                  <TextField fx:id="textFieldUndervoteLabel" prefWidth="210.0"/>
-                  <padding>
-                    <Insets bottom="4.0" left="4.0" right="4.0" top="4.0"/>
-                  </padding>
-                </HBox>
-                <HBox alignment="CENTER_LEFT" spacing="4.0">
-                  <Label text="Undeclared Write-in Label" prefWidth="150.0"/>
-                  <TextField fx:id="textFieldUndeclaredWriteInLabel" prefWidth="210.0"/>
-                  <padding>
-                    <Insets bottom="4.0" left="4.0" right="4.0" top="4.0"/>
-                  </padding>
-                </HBox>
-                <HBox alignment="CENTER_LEFT" spacing="4.0">
-                  <CheckBox fx:id="checkBoxTreatBlankAsUndeclaredWriteIn" mnemonicParsing="false"
-                    text="Treat Blank as Undeclared Write-in">
-                    <VBox.margin>
-                      <Insets top="8.0" bottom="8.0"/>
-                    </VBox.margin>
-                  </CheckBox>
-                  <padding>
-                    <Insets bottom="4.0" left="4.0" right="4.0" top="4.0"/>
-                  </padding>
                 </HBox>
                 <padding>
                   <Insets bottom="4.0" left="4.0" right="4.0" top="4.0"/>

--- a/src/main/resources/network/brightspots/rcv/GuiConfigLayout.fxml
+++ b/src/main/resources/network/brightspots/rcv/GuiConfigLayout.fxml
@@ -199,14 +199,6 @@
                         <Insets bottom="4.0" left="4.0" right="4.0" top="4.0"/>
                       </padding>
                     </HBox>
-                    <HBox alignment="CENTER_LEFT" spacing="4.0">
-                      <Label prefWidth="110.0" text="Overvote Delimiter"/>
-                      <TextField prefHeight="25.0" prefWidth="40.0"
-                        fx:id="textFieldCvrOvervoteDelimiter"/>
-                      <padding>
-                        <Insets bottom="4.0" left="4.0" right="4.0" top="4.0"/>
-                      </padding>
-                    </HBox>
                   </VBox>
                   <VBox spacing="4.0">
                     <HBox alignment="CENTER_LEFT" spacing="4.0">
@@ -214,6 +206,14 @@
                       <TextField prefHeight="25.0" prefWidth="300.0" fx:id="textFieldCvrFilePath"/>
                       <Button mnemonicParsing="false" onAction="#buttonCvrFilePathClicked"
                         text="Select" fx:id="buttonCvrFilePath"/>
+                      <padding>
+                        <Insets bottom="4.0" left="4.0" right="4.0" top="4.0"/>
+                      </padding>
+                    </HBox>
+                    <HBox alignment="CENTER_LEFT" spacing="4.0">
+                      <Label prefWidth="110.0" text="Overvote Delimiter"/>
+                      <TextField prefHeight="25.0" prefWidth="40.0"
+                        fx:id="textFieldCvrOvervoteDelimiter"/>
                       <padding>
                         <Insets bottom="4.0" left="4.0" right="4.0" top="4.0"/>
                       </padding>

--- a/src/main/resources/network/brightspots/rcv/config_file_documentation.txt
+++ b/src/main/resources/network/brightspots/rcv/config_file_documentation.txt
@@ -94,6 +94,26 @@ Config file must be valid JSON format. Examples can be found in the test_data fo
         example: //
         value: any string that contains no backslashes and at least one character that is not a letter, number, hyphen, period, comma, apostrophe, quote, or space
 
+      "overvoteLabel" optional
+        label used in the CVR to denote an overvote; if this parameter is present overvoteRule must be either "Always skip to next rank" or "Exhaust immediately" (because the other option, "Exhaust if multiple continuing", relies on knowing which specific candidates were involved in each overvote)
+        example: "OVERVOTE"
+        value: string of length [1..1000]
+
+      "undervoteLabel" optional
+        the special label used in the cast vote records to denote an undervote
+        example: "UNDERVOTE"
+        value: string of length [1..1000]
+
+      "undeclaredWriteInLabel" optional
+        the special label used in the cast vote records to denote a vote for an undeclared write-in
+        example: "UWI"
+        value: string of length [1..1000]
+
+      "treatBlankAsUndeclaredWriteIn" optional and can be used only if provider is ES&S
+        tabulator will interpret a blank cell in a CVR as a vote for an undeclared write-in
+        value: true | false
+        if not supplied: false
+
   "candidates" required
     list of registered candidate names and associated candidate code (note: leave empty when CVR is in Common Data Format)
     each "candidates" list item has the following parameters:
@@ -212,22 +232,6 @@ Config file must be valid JSON format. Examples can be found in the test_data fo
         the integer seed for the application's pseudorandom number generator
         value: [-140737488355328..140737488355327]
 
-      "overvoteLabel" optional
-        label used in the CVR to denote an overvote; if this parameter is present overvoteRule must be either "Always skip to next rank" or "Exhaust immediately" (because the other option, "Exhaust if multiple continuing", relies on knowing which specific candidates were involved in each overvote)
-        example: "OVERVOTE"
-        value: string of length [1..1000]
-
-      "undervoteLabel" optional
-        the special label used in the cast vote records to denote an undervote
-        example: "UNDERVOTE"
-        value: string of length [1..1000]
-
-      "undeclaredWriteInLabel" required if treatBlankAsUndeclaredWriteIn is enabled
-        the special label used in the cast vote records to denote a vote for an undeclared write-in
-        also used to represent undeclared write-ins in the results output
-        example: "UWI"
-        value: string of length [1..1000]
-
       "multiSeatBottomsUpPercentageThreshold" required if winnerElectionMode is "Bottoms-up using percentage threshold" and numberOfWinners is 0
         the percentage threshold used to determine when to stop the tabulation and declare winners
         note: only valid when winnerElectionMode is "Bottoms-up using percentage threshold" and numberOfWinners is 0
@@ -267,10 +271,5 @@ Config file must be valid JSON format. Examples can be found in the test_data fo
 
       "exhaustOnDuplicateCandidate" optional
         tabulator will exhaust a ballot when it encounters a duplicate candidate (instead of just skipping the duplicate)
-        value: true | false
-        if not supplied: false
-
-      "treatBlankAsUndeclaredWriteIn" optional
-        tabulator will interpret a blank cell in a CVR as a vote for an undeclared write-in
         value: true | false
         if not supplied: false

--- a/src/main/resources/network/brightspots/rcv/hints_cvr_files.txt
+++ b/src/main/resources/network/brightspots/rcv/hints_cvr_files.txt
@@ -21,3 +21,11 @@ ID Column (optional): The column the IDs are in. Not all CVR files contain an ID
 Precinct Column (required for ES&S if you want to tabulate by precinct): The column that contains the precinct.
 
 Overvote Delimiter (optional, but must be blank if "Overvote Label" is provided): If using a CVR in ES&S style, overvotes can be reflected in a CVR by displaying all candidates marked at a ranking. Those candidate names will be differentiated from each other by a delimiter, something like a vertical bar | or a slash /. If your overvotes are delimited like this, enter the delimiter used in this field. Note that ES&S files may include only the label "overvote" and no additional information, in which case the "Overvote Label" field should be used instead.
+
+Overvote Label: Some CVRs used a particular word/phrase to indicate an overvote.
+
+Undervote Label: Some CVRs used a particular word/phrase to indicate an undervote.
+
+Undeclared Write-in Label: Some CVRs used a particular word/phrase to indicate a write-in.
+
+Treat Blank as Undeclared Write-in: When checked, the tabulator will interpret blank cells in the CVRs as votes for undeclared write-ins.

--- a/src/main/resources/network/brightspots/rcv/hints_winning_rules.txt
+++ b/src/main/resources/network/brightspots/rcv/hints_winning_rules.txt
@@ -51,11 +51,3 @@ Threshold Calculation Method: The threshold of election is the number of votes a
   * Compute using Hare Quota: The Hare quota divides the number of votes by the number of seats. It requires candidates to receive that number of votes (or more) to win.
 
 Decimal Places for Vote Arithmetic (Multi-Winner Only): Sets how many decimal places after the decimal point are used in surplus transfers and in calculating the threshold.
-
-Overvote Label: Some CVRs used a particular word to indicate an overvote.
-
-Undervote Label: Some CVRs used a particular word to indicate an undervote.
-
-Undeclared Write-in Label: Some CVRs used a particular word to indicate a write-in.
-
-Treat Blank as Undeclared Write-in: When checked, the tabulator will interpret blank cells in the CVRs as a votes for an undeclared write-ins.

--- a/src/test/resources/network/brightspots/rcv/test_data/2013_minneapolis_mayor/2013_minneapolis_mayor_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/2013_minneapolis_mayor/2013_minneapolis_mayor_config.json
@@ -16,7 +16,11 @@
     "firstVoteRowIndex" : "2",
     "idColumnIndex" : "",
     "precinctColumnIndex" : "1",
-    "provider" : "ES&S"
+    "provider" : "ES&S",
+    "treatBlankAsUndeclaredWriteIn": false,
+    "overvoteLabel": "overvote",
+    "undervoteLabel": "undervote",
+    "undeclaredWriteInLabel": "UWI"
   } ],
   "candidates" : [ {
     "name" : "TROY BENJEGERDES",
@@ -173,10 +177,6 @@
     "hareQuota": false,
     "batchElimination": true,
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "overvote",
-    "undervoteLabel": "undervote",
-    "undeclaredWriteInLabel": "UWI",
     "rulesDescription": "Maine Rules"
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/2013_minneapolis_mayor_scale/2013_minneapolis_mayor_scale_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/2013_minneapolis_mayor_scale/2013_minneapolis_mayor_scale_config.json
@@ -1,106 +1,183 @@
 {
-  "tabulatorVersion": "TEST",
-  "outputSettings": {
-    "contestName": "2013 Minneapolis Mayor",
-    "outputDirectory": "output",
-    "contestDate": "",
-    "contestJurisdiction": "",
-    "contestOffice": "",
-    "tabulateByPrecinct": false,
-    "generateCdfJson": false
+  "tabulatorVersion" : "TEST",
+  "outputSettings" : {
+    "contestName" : "2013 Minneapolis Mayor",
+    "outputDirectory" : "output",
+    "contestDate" : "",
+    "contestJurisdiction" : "",
+    "contestOffice" : "",
+    "tabulateByPrecinct" : false,
+    "generateCdfJson" : false
   },
-  "cvrFileSources": [
-    {
+  "cvrFileSources" : [ {
     "filePath" : "2013_minneapolis_mayor_cvr_1.xlsx",
+    "contestId" : "",
     "firstVoteColumnIndex" : "2",
     "firstVoteRowIndex" : "2",
     "idColumnIndex" : "",
     "precinctColumnIndex" : "",
-    "provider" : "ES&S"
+    "overvoteDelimiter" : "",
+    "provider" : "ES&S",
+    "overvoteLabel" : "overvote",
+    "undervoteLabel" : "undervote",
+    "undeclaredWriteInLabel" : "UWI",
+    "treatBlankAsUndeclaredWriteIn" : false
   }, {
     "filePath" : "2013_minneapolis_mayor_cvr_2.xlsx",
+    "contestId" : "",
     "firstVoteColumnIndex" : "2",
     "firstVoteRowIndex" : "2",
     "idColumnIndex" : "",
     "precinctColumnIndex" : "",
-    "provider" : "ES&S"
+    "overvoteDelimiter" : "",
+    "provider" : "ES&S",
+    "overvoteLabel" : "overvote",
+    "undervoteLabel" : "undervote",
+    "undeclaredWriteInLabel" : "UWI",
+    "treatBlankAsUndeclaredWriteIn" : false
   }, {
     "filePath" : "2013_minneapolis_mayor_cvr_3.xlsx",
+    "contestId" : "",
     "firstVoteColumnIndex" : "2",
     "firstVoteRowIndex" : "2",
     "idColumnIndex" : "",
     "precinctColumnIndex" : "",
-    "provider" : "ES&S"
+    "overvoteDelimiter" : "",
+    "provider" : "ES&S",
+    "overvoteLabel" : "overvote",
+    "undervoteLabel" : "undervote",
+    "undeclaredWriteInLabel" : "UWI",
+    "treatBlankAsUndeclaredWriteIn" : false
   }, {
     "filePath" : "2013_minneapolis_mayor_cvr_4.xlsx",
+    "contestId" : "",
     "firstVoteColumnIndex" : "2",
     "firstVoteRowIndex" : "2",
     "idColumnIndex" : "",
     "precinctColumnIndex" : "",
-    "provider" : "ES&S"
+    "overvoteDelimiter" : "",
+    "provider" : "ES&S",
+    "overvoteLabel" : "overvote",
+    "undervoteLabel" : "undervote",
+    "undeclaredWriteInLabel" : "UWI",
+    "treatBlankAsUndeclaredWriteIn" : false
   }, {
     "filePath" : "2013_minneapolis_mayor_cvr_5.xlsx",
+    "contestId" : "",
     "firstVoteColumnIndex" : "2",
     "firstVoteRowIndex" : "2",
     "idColumnIndex" : "",
     "precinctColumnIndex" : "",
-    "provider" : "ES&S"
+    "overvoteDelimiter" : "",
+    "provider" : "ES&S",
+    "overvoteLabel" : "overvote",
+    "undervoteLabel" : "undervote",
+    "undeclaredWriteInLabel" : "UWI",
+    "treatBlankAsUndeclaredWriteIn" : false
   }, {
     "filePath" : "2013_minneapolis_mayor_cvr_6.xlsx",
+    "contestId" : "",
     "firstVoteColumnIndex" : "2",
     "firstVoteRowIndex" : "2",
     "idColumnIndex" : "",
     "precinctColumnIndex" : "",
-    "provider" : "ES&S"
+    "overvoteDelimiter" : "",
+    "provider" : "ES&S",
+    "overvoteLabel" : "overvote",
+    "undervoteLabel" : "undervote",
+    "undeclaredWriteInLabel" : "UWI",
+    "treatBlankAsUndeclaredWriteIn" : false
   }, {
     "filePath" : "2013_minneapolis_mayor_cvr_7.xlsx",
+    "contestId" : "",
     "firstVoteColumnIndex" : "2",
     "firstVoteRowIndex" : "2",
     "idColumnIndex" : "",
     "precinctColumnIndex" : "",
-    "provider" : "ES&S"
+    "overvoteDelimiter" : "",
+    "provider" : "ES&S",
+    "overvoteLabel" : "overvote",
+    "undervoteLabel" : "undervote",
+    "undeclaredWriteInLabel" : "UWI",
+    "treatBlankAsUndeclaredWriteIn" : false
   }, {
     "filePath" : "2013_minneapolis_mayor_cvr_8.xlsx",
+    "contestId" : "",
     "firstVoteColumnIndex" : "2",
     "firstVoteRowIndex" : "2",
     "idColumnIndex" : "",
     "precinctColumnIndex" : "",
-    "provider" : "ES&S"
+    "overvoteDelimiter" : "",
+    "provider" : "ES&S",
+    "overvoteLabel" : "overvote",
+    "undervoteLabel" : "undervote",
+    "undeclaredWriteInLabel" : "UWI",
+    "treatBlankAsUndeclaredWriteIn" : false
   }, {
     "filePath" : "2013_minneapolis_mayor_cvr_9.xlsx",
+    "contestId" : "",
     "firstVoteColumnIndex" : "2",
     "firstVoteRowIndex" : "2",
     "idColumnIndex" : "",
     "precinctColumnIndex" : "",
-    "provider" : "ES&S"
+    "overvoteDelimiter" : "",
+    "provider" : "ES&S",
+    "overvoteLabel" : "overvote",
+    "undervoteLabel" : "undervote",
+    "undeclaredWriteInLabel" : "UWI",
+    "treatBlankAsUndeclaredWriteIn" : false
   }, {
     "filePath" : "2013_minneapolis_mayor_cvr_10.xlsx",
+    "contestId" : "",
     "firstVoteColumnIndex" : "2",
     "firstVoteRowIndex" : "2",
     "idColumnIndex" : "",
     "precinctColumnIndex" : "",
-    "provider" : "ES&S"
+    "overvoteDelimiter" : "",
+    "provider" : "ES&S",
+    "overvoteLabel" : "overvote",
+    "undervoteLabel" : "undervote",
+    "undeclaredWriteInLabel" : "UWI",
+    "treatBlankAsUndeclaredWriteIn" : false
   }, {
     "filePath" : "2013_minneapolis_mayor_cvr_11.xlsx",
+    "contestId" : "",
     "firstVoteColumnIndex" : "2",
     "firstVoteRowIndex" : "2",
     "idColumnIndex" : "",
     "precinctColumnIndex" : "",
-    "provider" : "ES&S"
+    "overvoteDelimiter" : "",
+    "provider" : "ES&S",
+    "overvoteLabel" : "overvote",
+    "undervoteLabel" : "undervote",
+    "undeclaredWriteInLabel" : "UWI",
+    "treatBlankAsUndeclaredWriteIn" : false
   }, {
     "filePath" : "2013_minneapolis_mayor_cvr_12.xlsx",
+    "contestId" : "",
     "firstVoteColumnIndex" : "2",
     "firstVoteRowIndex" : "2",
     "idColumnIndex" : "",
     "precinctColumnIndex" : "",
-    "provider" : "ES&S"
+    "overvoteDelimiter" : "",
+    "provider" : "ES&S",
+    "overvoteLabel" : "overvote",
+    "undervoteLabel" : "undervote",
+    "undeclaredWriteInLabel" : "UWI",
+    "treatBlankAsUndeclaredWriteIn" : false
   }, {
     "filePath" : "2013_minneapolis_mayor_cvr_13.xlsx",
+    "contestId" : "",
     "firstVoteColumnIndex" : "2",
     "firstVoteRowIndex" : "2",
     "idColumnIndex" : "",
     "precinctColumnIndex" : "",
-    "provider" : "ES&S"
+    "overvoteDelimiter" : "",
+    "provider" : "ES&S",
+    "overvoteLabel" : "overvote",
+    "undervoteLabel" : "undervote",
+    "undeclaredWriteInLabel" : "UWI",
+    "treatBlankAsUndeclaredWriteIn" : false
   } ],
   "candidates" : [ {
     "name" : "TROY BENJEGERDES",
@@ -244,23 +321,22 @@
     "excluded" : false
   } ],
   "rules" : {
-    "tiebreakMode": "Random",
-    "overvoteRule": "Exhaust immediately",
-    "winnerElectionMode": "Single-winner majority determines winner",
-    "randomSeed": "0",
-    "numberOfWinners": "1",
-    "decimalPlacesForVoteArithmetic": "4",
-    "minimumVoteThreshold": "0",
-    "maxSkippedRanksAllowed": "1",
-    "maxRankingsAllowed": "3",
-    "nonIntegerWinningThreshold": false,
-    "hareQuota": false,
-    "batchElimination": true,
-    "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "overvote",
-    "undervoteLabel": "undervote",
-    "undeclaredWriteInLabel": "UWI",
-    "rulesDescription": "Maine Rules"
+    "tiebreakMode" : "Random",
+    "overvoteRule" : "Exhaust immediately",
+    "winnerElectionMode" : "Single-winner majority determines winner",
+    "randomSeed" : "0",
+    "numberOfWinners" : "1",
+    "multiSeatBottomsUpPercentageThreshold" : "",
+    "decimalPlacesForVoteArithmetic" : "4",
+    "minimumVoteThreshold" : "0",
+    "maxSkippedRanksAllowed" : "1",
+    "maxRankingsAllowed" : "3",
+    "nonIntegerWinningThreshold" : false,
+    "hareQuota" : false,
+    "batchElimination" : true,
+    "continueUntilTwoCandidatesRemain" : false,
+    "exhaustOnDuplicateCandidate" : false,
+    "rulesDescription" : "Maine Rules",
+    "treatBlankAsUndeclaredWriteIn" : false
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/2013_minneapolis_park/2013_minneapolis_park_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/2013_minneapolis_park/2013_minneapolis_park_config.json
@@ -16,7 +16,11 @@
     "firstVoteRowIndex" : "2",
     "idColumnIndex" : "",
     "precinctColumnIndex" : "1",
-    "provider" : "ES&S"
+    "provider" : "ES&S",
+    "treatBlankAsUndeclaredWriteIn": false,
+    "overvoteLabel": "overvote",
+    "undervoteLabel": "undervote",
+    "undeclaredWriteInLabel": "UWI"
   } ],
   "candidates" : [ {
     "name" : "ANNIE YOUNG",
@@ -73,10 +77,6 @@
     "hareQuota": false,
     "batchElimination": false,
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "overvote",
-    "undervoteLabel": "undervote",
-    "undeclaredWriteInLabel": "UWI",
     "rulesDescription": "Minneapolis Rules"
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/2013_minneapolis_park_bottoms_up/2013_minneapolis_park_bottoms_up_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/2013_minneapolis_park_bottoms_up/2013_minneapolis_park_bottoms_up_config.json
@@ -16,7 +16,11 @@
     "firstVoteRowIndex" : "2",
     "idColumnIndex" : "",
     "precinctColumnIndex" : "1",
-    "provider" : "ES&S"
+    "provider" : "ES&S",
+    "treatBlankAsUndeclaredWriteIn": false,
+    "overvoteLabel": "overvote",
+    "undervoteLabel": "undervote",
+    "undeclaredWriteInLabel": "UWI"
   } ],
   "candidates" : [ {
     "name" : "ANNIE YOUNG",
@@ -73,10 +77,6 @@
     "hareQuota": false,
     "batchElimination": false,
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "overvote",
-    "undervoteLabel": "undervote",
-    "undeclaredWriteInLabel": "UWI",
     "rulesDescription": "Minneapolis Rules"
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/2013_minneapolis_park_hare/2013_minneapolis_park_hare_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/2013_minneapolis_park_hare/2013_minneapolis_park_hare_config.json
@@ -16,7 +16,11 @@
     "firstVoteRowIndex" : "2",
     "idColumnIndex" : "",
     "precinctColumnIndex" : "1",
-    "provider" : "ES&S"
+    "provider" : "ES&S",
+    "treatBlankAsUndeclaredWriteIn": false,
+    "overvoteLabel": "overvote",
+    "undervoteLabel": "undervote",
+    "undeclaredWriteInLabel": "UWI"
   } ],
   "candidates" : [ {
     "name" : "ANNIE YOUNG",
@@ -73,10 +77,6 @@
     "hareQuota": true,
     "batchElimination": false,
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "overvote",
-    "undervoteLabel": "undervote",
-    "undeclaredWriteInLabel": "UWI",
     "rulesDescription": "Minneapolis Rules"
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/2013_minneapolis_park_sequential/2013_minneapolis_park_sequential_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/2013_minneapolis_park_sequential/2013_minneapolis_park_sequential_config.json
@@ -16,7 +16,11 @@
     "firstVoteRowIndex" : "2",
     "idColumnIndex" : "",
     "precinctColumnIndex" : "1",
-    "provider" : "ES&S"
+    "provider" : "ES&S",
+    "treatBlankAsUndeclaredWriteIn": false,
+    "overvoteLabel": "overvote",
+    "undervoteLabel": "undervote",
+    "undeclaredWriteInLabel": "UWI"
   } ],
   "candidates" : [ {
     "name" : "ANNIE YOUNG",
@@ -73,10 +77,6 @@
     "hareQuota": false,
     "batchElimination": false,
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "overvote",
-    "undervoteLabel": "undervote",
-    "undeclaredWriteInLabel": "UWI",
     "rulesDescription": "Minneapolis Rules"
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/2015_portland_mayor/2015_portland_mayor_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/2015_portland_mayor/2015_portland_mayor_config.json
@@ -16,7 +16,11 @@
     "firstVoteRowIndex" : "2",
     "idColumnIndex" : "",
     "precinctColumnIndex" : "2",
-    "provider" : "ES&S"
+    "provider" : "ES&S",
+    "treatBlankAsUndeclaredWriteIn": false,
+    "overvoteLabel": "overvote",
+    "undervoteLabel": "undervote",
+    "undeclaredWriteInLabel": "UWI"
   } ],
   "candidates" : [ {
     "name" : "Brennan, Michael F.",
@@ -93,10 +97,6 @@
     "hareQuota": false,
     "batchElimination": true,
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "overvote",
-    "undervoteLabel": "undervote",
-    "undeclaredWriteInLabel": "UWI",
     "rulesDescription": "Maine Rules"
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/2015_portland_mayor_codes/2015_portland_mayor_codes_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/2015_portland_mayor_codes/2015_portland_mayor_codes_config.json
@@ -16,7 +16,11 @@
     "firstVoteRowIndex" : "2",
     "idColumnIndex" : "",
     "precinctColumnIndex" : "2",
-    "provider" : "ES&S"
+    "provider" : "ES&S",
+    "treatBlankAsUndeclaredWriteIn": false,
+    "overvoteLabel": "overvote",
+    "undervoteLabel": "undervote",
+    "undeclaredWriteInLabel": "UWI"
   } ],
   "candidates" : [ {
     "name" : "Brennan, Michael F.",
@@ -93,10 +97,6 @@
     "hareQuota": false,
     "batchElimination": true,
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "overvote",
-    "undervoteLabel": "undervote",
-    "undeclaredWriteInLabel": "UWI",
     "rulesDescription": "Maine Rules"
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/2017_minneapolis_mayor/2017_minneapolis_mayor_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/2017_minneapolis_mayor/2017_minneapolis_mayor_config.json
@@ -16,7 +16,11 @@
     "firstVoteRowIndex" : "2",
     "idColumnIndex" : "",
     "precinctColumnIndex" : "1",
-    "provider" : "ES&S"
+    "provider" : "ES&S",
+    "treatBlankAsUndeclaredWriteIn": false,
+    "overvoteLabel": "overvote",
+    "undervoteLabel": "undervote",
+    "undeclaredWriteInLabel": "UWI"
   } ],
   "candidates" : [ {
     "name" : "Jacob Frey",
@@ -105,10 +109,6 @@
     "hareQuota": false,
     "batchElimination": true,
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "overvote",
-    "undervoteLabel": "undervote",
-    "undeclaredWriteInLabel": "UWI",
     "rulesDescription": "Minneapolis Rules"
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/2018_maine_governor_primary/2018_maine_governor_primary_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/2018_maine_governor_primary/2018_maine_governor_primary_config.json
@@ -16,7 +16,11 @@
     "firstVoteRowIndex" : "2",
     "idColumnIndex" : "1",
     "precinctColumnIndex" : "2",
-    "provider" : "ES&S"
+    "provider" : "ES&S",
+    "treatBlankAsUndeclaredWriteIn": false,
+    "overvoteLabel": "overvote",
+    "undervoteLabel": "undervote",
+    "undeclaredWriteInLabel": ""
   } ],
   "candidates" : [ {
     "name" : "Mills, Janet T.",
@@ -65,10 +69,6 @@
     "hareQuota": false,
     "batchElimination": true,
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "overvote",
-    "undervoteLabel": "undervote",
-    "undeclaredWriteInLabel": "",
     "rulesDescription": "Maine Rules"
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/clear_ballot_kansas_primary/clear_ballot_kansas_primary_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/clear_ballot_kansas_primary/clear_ballot_kansas_primary_config.json
@@ -16,7 +16,11 @@
     "idColumnIndex" : "",
     "precinctColumnIndex" : "",
     "provider" : "Clear Ballot",
-    "contestId": "Democratic Primary"
+    "contestId": "Democratic Primary",
+    "treatBlankAsUndeclaredWriteIn": false,
+    "overvoteLabel": "overvote",
+    "undervoteLabel": "undervote",
+    "undeclaredWriteInLabel": "UWI"
   } ],
   "candidates" : [ {
     "name" : "Michael Bennet",
@@ -74,10 +78,6 @@
     "hareQuota": false,
     "batchElimination": true,
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "overvote",
-    "undervoteLabel": "undervote",
-    "undeclaredWriteInLabel": "UWI",
     "rulesDescription": "Kansas Primary Rules"
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/continue_tabulation_test/continue_tabulation_test_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/continue_tabulation_test/continue_tabulation_test_config.json
@@ -16,7 +16,11 @@
     "firstVoteRowIndex" : "2",
     "idColumnIndex" : "",
     "precinctColumnIndex" : "",
-    "provider" : "ES&S"
+    "provider" : "ES&S",
+    "treatBlankAsUndeclaredWriteIn": false,
+    "overvoteLabel": "overvote",
+    "undervoteLabel": "undervote",
+    "undeclaredWriteInLabel": ""
   } ],
   "candidates" : [ {
     "name" : "Carmona, Ralph C.",
@@ -47,10 +51,6 @@
     "batchElimination": false,
     "continueUntilTwoCandidatesRemain": true,
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "overvote",
-    "undervoteLabel": "undervote",
-    "undeclaredWriteInLabel": "",
     "rulesDescription": "Continue until Two Candidates Remain Test"
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/continue_until_two_with_batch_elimination_test/continue_until_two_with_batch_elimination_test_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/continue_until_two_with_batch_elimination_test/continue_until_two_with_batch_elimination_test_config.json
@@ -15,7 +15,11 @@
     "firstVoteRowIndex" : "2",
     "idColumnIndex" : "",
     "precinctColumnIndex" : "",
-    "provider": "ES&S"
+    "provider": "ES&S",
+    "treatBlankAsUndeclaredWriteIn": false,
+    "overvoteLabel": "",
+    "undervoteLabel": "",
+    "undeclaredWriteInLabel": ""
   } ],
   "candidates" : [ {
     "name" : "A",
@@ -62,10 +66,6 @@
     "batchElimination": true,
     "continueUntilTwoCandidatesRemain": true,
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "",
-    "undervoteLabel": "",
-    "undeclaredWriteInLabel": "",
     "rulesDescription": ""
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/dominion_alaska/dominion_alaska_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/dominion_alaska/dominion_alaska_config.json
@@ -13,7 +13,11 @@
     {
       "filePath": "alaska_input_data",
       "provider": "Dominion",
-      "contestId": "1"
+      "contestId": "1",
+      "treatBlankAsUndeclaredWriteIn": false,
+      "overvoteLabel": "overvote",
+      "undervoteLabel": "undervote",
+      "undeclaredWriteInLabel": "12"
     }
   ],
   "candidates": [
@@ -69,10 +73,6 @@
     "hareQuota": false,
     "batchElimination": true,
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "overvote",
-    "undervoteLabel": "undervote",
-    "undeclaredWriteInLabel": "12",
     "rulesDescription": "Alaska Rules"
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/dominion_kansas/dominion_kansas_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/dominion_kansas/dominion_kansas_config.json
@@ -13,7 +13,11 @@
     {
       "filePath": "kansas_input_data",
       "provider": "Dominion",
-      "contestId": "1"
+      "contestId": "1",
+      "treatBlankAsUndeclaredWriteIn" : false,
+      "overvoteLabel" : "overvote",
+      "undervoteLabel" : "undervote",
+      "undeclaredWriteInLabel" : "12"
     }
   ],
   "candidates": [
@@ -69,10 +73,6 @@
     "hareQuota": false,
     "batchElimination" : true,
     "exhaustOnDuplicateCandidate" : false,
-    "treatBlankAsUndeclaredWriteIn" : false,
-    "overvoteLabel" : "overvote",
-    "undervoteLabel" : "undervote",
-    "undeclaredWriteInLabel" : "12",
     "rulesDescription" : "Kansas Rules"
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/dominion_wyoming/dominion_wyoming_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/dominion_wyoming/dominion_wyoming_config.json
@@ -13,7 +13,11 @@
     {
       "filePath": "wyoming_input_data",
       "provider": "Dominion",
-      "contestId": "1"
+      "contestId": "1",
+      "treatBlankAsUndeclaredWriteIn" : false,
+      "overvoteLabel" : "overvote",
+      "undervoteLabel" : "undervote",
+      "undeclaredWriteInLabel" : "12"
     }
   ],
   "candidates": [
@@ -69,10 +73,6 @@
     "hareQuota": false,
     "batchElimination" : true,
     "exhaustOnDuplicateCandidate" : false,
-    "treatBlankAsUndeclaredWriteIn" : false,
-    "overvoteLabel" : "overvote",
-    "undervoteLabel" : "undervote",
-    "undeclaredWriteInLabel" : "12",
     "rulesDescription" : "Wyoming Rules"
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/duplicate_test/duplicate_test_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/duplicate_test/duplicate_test_config.json
@@ -16,7 +16,11 @@
     "firstVoteRowIndex" : "2",
     "idColumnIndex" : "",
     "precinctColumnIndex" : "",
-    "provider" : "ES&S"
+    "provider" : "ES&S",
+    "treatBlankAsUndeclaredWriteIn": false,
+    "overvoteLabel": "",
+    "undervoteLabel": "",
+    "undeclaredWriteInLabel": ""
   } ],
   "candidates" : [ {
     "name" : "Banana",
@@ -45,10 +49,6 @@
     "hareQuota": false,
     "batchElimination": false,
     "exhaustOnDuplicateCandidate": true,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "",
-    "undervoteLabel": "",
-    "undeclaredWriteInLabel": "",
     "rulesDescription": "Doyle Rules"
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/excluded_test/excluded_test_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/excluded_test/excluded_test_config.json
@@ -16,7 +16,11 @@
     "firstVoteRowIndex" : "2",
     "idColumnIndex" : "",
     "precinctColumnIndex" : "",
-    "provider" : "ES&S"
+    "provider" : "ES&S",
+    "treatBlankAsUndeclaredWriteIn": false,
+    "overvoteLabel": "overvote",
+    "undervoteLabel": "undervote",
+    "undeclaredWriteInLabel": ""
   } ],
   "candidates" : [ {
     "name" : "Mookie Blaylock",
@@ -49,10 +53,6 @@
     "hareQuota": false,
     "batchElimination": true,
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "overvote",
-    "undervoteLabel": "undervote",
-    "undeclaredWriteInLabel": "",
     "rulesDescription": "Doyle Rules"
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/hart_cedar_park_school_board/hart_cedar_park_school_board_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/hart_cedar_park_school_board/hart_cedar_park_school_board_config.json
@@ -16,7 +16,11 @@
     "idColumnIndex": "",
     "precinctColumnIndex": "",
     "provider": "Hart",
-    "contestId": "b651b997-417a-46d9-a676-a43d4df94ddc"
+    "contestId": "b651b997-417a-46d9-a676-a43d4df94ddc",
+    "treatBlankAsUndeclaredWriteIn": false,
+    "overvoteLabel": "",
+    "undervoteLabel": "",
+    "undeclaredWriteInLabel": "99cefa84-bad0-4d6b-a916-e606bd43f9cd"
   } ],
 
   "candidates" : [
@@ -71,10 +75,6 @@
     "hareQuota": false,
     "batchElimination": false,
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "",
-    "undervoteLabel": "",
-    "undeclaredWriteInLabel": "99cefa84-bad0-4d6b-a916-e606bd43f9cd",
     "rulesDescription": ""
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/hart_travis_county_officers/hart_travis_county_officers_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/hart_travis_county_officers/hart_travis_county_officers_config.json
@@ -16,7 +16,11 @@
     "idColumnIndex": "",
     "precinctColumnIndex": "",
     "provider": "Hart",
-    "contestId": "e9ca8235-893e-43df-93eb-3cc61eeb133c"
+    "contestId": "e9ca8235-893e-43df-93eb-3cc61eeb133c",
+    "treatBlankAsUndeclaredWriteIn": false,
+    "overvoteLabel": "",
+    "undervoteLabel": "",
+    "undeclaredWriteInLabel": ""
   } ],
   "candidates" : [
     {
@@ -60,10 +64,6 @@
     "hareQuota": false,
     "batchElimination": false,
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "",
-    "undervoteLabel": "",
-    "undeclaredWriteInLabel": "",
     "rulesDescription": ""
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/invalid_params_test/invalid_params_test_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/invalid_params_test/invalid_params_test_config.json
@@ -20,10 +20,6 @@
     "batchElimination": "True",
     "continueUntilTwoCandidatesRemain": "false",
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "overvote",
-    "undervoteLabel": "undervote",
-    "undeclaredWriteInLabel": "UWI",
     "rulesDescription": "Testing our validation logic for params"
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/invalid_sources_test/invalid_sources_test_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/invalid_sources_test/invalid_sources_test_config.json
@@ -13,22 +13,26 @@
       "firstVoteColumnIndex": 3,
       "firstVoteRowIndex": 2,
       "precinctColumnIndex": 1,
-      "provider": "ES&S"
+      "provider": "ES&S",
+      "treatBlankAsUndeclaredWriteIn": false
     },
     {
       "filePath": "test_data/nonexistent_path2",
-      "provider": "ES&S"
+      "provider": "ES&S",
+      "treatBlankAsUndeclaredWriteIn": false
     },
     {
       "firstVoteColumnIndex": 3,
       "firstVoteRowIndex": 0,
       "precinctColumnIndex": 1,
-      "provider": "ES&S"
+      "provider": "ES&S",
+      "treatBlankAsUndeclaredWriteIn": false
     },
     {
       "filePath": "invalid_sources_test_cvr.xlsx",
       "firstVoteColumnIndex": 2,
-      "provider": "ES&S"
+      "provider": "ES&S",
+      "treatBlankAsUndeclaredWriteIn": false
     }
   ],
   "candidates": [
@@ -51,7 +55,6 @@
     "batchElimination": false,
     "continueUntilTwoCandidatesRemain": false,
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
     "rulesDescription": "Testing our validation logic for sources"
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/minimum_threshold_test/minimum_threshold_test_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/minimum_threshold_test/minimum_threshold_test_config.json
@@ -16,7 +16,11 @@
     "firstVoteRowIndex" : "2",
     "idColumnIndex" : "",
     "precinctColumnIndex" : "",
-    "provider" : "ES&S"
+    "provider" : "ES&S",
+    "treatBlankAsUndeclaredWriteIn": false,
+    "overvoteLabel": "",
+    "undervoteLabel": "",
+    "undeclaredWriteInLabel": ""
   } ],
   "candidates" : [ {
     "name" : "Gargamel",
@@ -53,10 +57,6 @@
     "hareQuota": false,
     "batchElimination": false,
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "",
-    "undervoteLabel": "",
-    "undeclaredWriteInLabel": "",
     "rulesDescription": "Doyle Rules"
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/minneapolis_multi_seat_threshold/minneapolis_multi_seat_threshold_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/minneapolis_multi_seat_threshold/minneapolis_multi_seat_threshold_config.json
@@ -16,7 +16,11 @@
     "firstVoteRowIndex" : "2",
     "idColumnIndex" : "",
     "precinctColumnIndex" : "",
-    "provider": "ES&S"
+    "provider": "ES&S",
+    "treatBlankAsUndeclaredWriteIn": false,
+    "overvoteLabel": "overvote",
+    "undervoteLabel": "undervote",
+    "undeclaredWriteInLabel": ""
   } ],
   "candidates" : [ {
     "name" : "A",
@@ -57,10 +61,6 @@
     "hareQuota": false,
     "batchElimination": false,
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "overvote",
-    "undervoteLabel": "undervote",
-    "undeclaredWriteInLabel": "",
     "rulesDescription": "Multi-winner Test2"
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/missing_precinct_example/missing_precinct_example_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/missing_precinct_example/missing_precinct_example_config.json
@@ -16,7 +16,11 @@
     "firstVoteRowIndex" : "2",
     "idColumnIndex" : "",
     "precinctColumnIndex" : "1",
-    "provider" : "ES&S"
+    "provider" : "ES&S",
+    "treatBlankAsUndeclaredWriteIn": false,
+    "overvoteLabel": "overvote",
+    "undervoteLabel": "undervote",
+    "undeclaredWriteInLabel": "UWI"
   } ],
   "candidates" : [ {
     "name" : "Jacob Frey",
@@ -105,10 +109,6 @@
     "hareQuota": false,
     "batchElimination": true,
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "overvote",
-    "undervoteLabel": "undervote",
-    "undeclaredWriteInLabel": "UWI",
     "rulesDescription": "Minneapolis Rules"
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/multi_seat_bottoms_up_with_threshold/multi_seat_bottoms_up_with_threshold_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/multi_seat_bottoms_up_with_threshold/multi_seat_bottoms_up_with_threshold_config.json
@@ -16,7 +16,11 @@
     "firstVoteRowIndex" : "2",
     "idColumnIndex" : "1",
     "precinctColumnIndex" : "",
-    "provider": "ES&S"
+    "provider": "ES&S",
+    "treatBlankAsUndeclaredWriteIn": false,
+    "overvoteLabel": "",
+    "undervoteLabel": "",
+    "undeclaredWriteInLabel": ""
   } ],
   "candidates" : [ {
     "name" : "A",
@@ -66,10 +70,6 @@
     "hareQuota": false,
     "batchElimination": false,
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "",
-    "undervoteLabel": "",
-    "undeclaredWriteInLabel": "",
     "rulesDescription": ""
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/multi_seat_uwi_test/multi_seat_uwi_test_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/multi_seat_uwi_test/multi_seat_uwi_test_config.json
@@ -15,7 +15,11 @@
     "firstVoteRowIndex" : "2",
     "idColumnIndex" : "",
     "precinctColumnIndex" : "",
-    "provider": "ES&S"
+    "provider": "ES&S",
+    "treatBlankAsUndeclaredWriteIn": false,
+    "overvoteLabel": "",
+    "undervoteLabel": "",
+    "undeclaredWriteInLabel": "UWI"
   } ],
   "candidates" : [ {
     "name" : "A",
@@ -45,10 +49,6 @@
     "hareQuota": false,
     "batchElimination": false,
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "",
-    "undervoteLabel": "",
-    "undeclaredWriteInLabel": "UWI",
     "rulesDescription": ""
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/nist_xml_cdf_2/nist_xml_cdf_2_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/nist_xml_cdf_2/nist_xml_cdf_2_config.json
@@ -15,7 +15,11 @@
       "idColumnIndex": "",
       "precinctColumnIndex": "",
       "provider": "CDF",
-      "contestId": "For Governor and Lieutenant Governor"
+      "contestId": "For Governor and Lieutenant Governor",
+      "treatBlankAsUndeclaredWriteIn": false,
+      "overvoteLabel": "",
+      "undervoteLabel": "",
+      "undeclaredWriteInLabel": ""
     }
   ],
   "candidates": [
@@ -49,10 +53,6 @@
     "hareQuota": false,
     "batchElimination": false,
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "",
-    "undervoteLabel": "",
-    "undeclaredWriteInLabel": "",
     "rulesDescription": "Skiptonext_exhaustatovervote"
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/precinct_example/precinct_example_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/precinct_example/precinct_example_config.json
@@ -16,7 +16,11 @@
     "firstVoteRowIndex" : "2",
     "idColumnIndex" : "",
     "precinctColumnIndex" : "1",
-    "provider" : "ES&S"
+    "provider" : "ES&S",
+    "treatBlankAsUndeclaredWriteIn": false,
+    "overvoteLabel": "overvote",
+    "undervoteLabel": "undervote",
+    "undeclaredWriteInLabel": "UWI"
   } ],
   "candidates" : [ {
     "name" : "Jacob Frey",
@@ -105,10 +109,6 @@
     "hareQuota": false,
     "batchElimination": true,
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "overvote",
-    "undervoteLabel": "undervote",
-    "undeclaredWriteInLabel": "UWI",
     "rulesDescription": "Minneapolis Rules"
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/precinct_example/precinct_example_expected_cvr_cdf.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/precinct_example/precinct_example_expected_cvr_cdf.json
@@ -2001,7 +2001,7 @@
         "@type" : "CVR.CVRContest",
         "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-uwi",
+          "ContestSelectionId" : "cs-undeclared_write-ins",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
@@ -2020,7 +2020,7 @@
         "@type" : "CVR.CVRContest",
         "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-uwi",
+          "ContestSelectionId" : "cs-undeclared_write-ins",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
@@ -2039,7 +2039,7 @@
         "@type" : "CVR.CVRContest",
         "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-uwi",
+          "ContestSelectionId" : "cs-undeclared_write-ins",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
@@ -2058,7 +2058,7 @@
         "@type" : "CVR.CVRContest",
         "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-uwi",
+          "ContestSelectionId" : "cs-undeclared_write-ins",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
@@ -2077,7 +2077,7 @@
         "@type" : "CVR.CVRContest",
         "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-uwi",
+          "ContestSelectionId" : "cs-undeclared_write-ins",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
@@ -2096,7 +2096,7 @@
         "@type" : "CVR.CVRContest",
         "CVRContestSelection" : [ {
           "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-uwi",
+          "ContestSelectionId" : "cs-undeclared_write-ins",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
@@ -18782,7 +18782,7 @@
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-uwi",
+          "ContestSelectionId" : "cs-undeclared_write-ins",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
@@ -18821,7 +18821,7 @@
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-uwi",
+          "ContestSelectionId" : "cs-undeclared_write-ins",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
@@ -18860,7 +18860,7 @@
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-uwi",
+          "ContestSelectionId" : "cs-undeclared_write-ins",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
@@ -18899,7 +18899,7 @@
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-uwi",
+          "ContestSelectionId" : "cs-undeclared_write-ins",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
@@ -18938,7 +18938,7 @@
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-uwi",
+          "ContestSelectionId" : "cs-undeclared_write-ins",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
@@ -18977,7 +18977,7 @@
           } ]
         }, {
           "@type" : "CVR.CVRContestSelection",
-          "ContestSelectionId" : "cs-uwi",
+          "ContestSelectionId" : "cs-undeclared_write-ins",
           "SelectionPosition" : [ {
             "@type" : "CVR.SelectionPosition",
             "HasIndication" : "yes",
@@ -20571,8 +20571,8 @@
       "@id" : "c-troy_benjegerdes",
       "Name" : "Troy Benjegerdes"
     }, {
-      "@id" : "c-uwi",
-      "Name" : "UWI"
+      "@id" : "c-undeclared_write-ins",
+      "Name" : "Undeclared Write-ins"
     } ],
     "Contest" : [ {
       "@id" : "contest-001",
@@ -20650,9 +20650,9 @@
         "@type" : "CVR.ContestSelection",
         "CandidateIds" : [ "c-troy_benjegerdes" ]
       }, {
-        "@id" : "cs-uwi",
+        "@id" : "cs-undeclared_write-ins",
         "@type" : "CVR.ContestSelection",
-        "CandidateIds" : [ "c-uwi" ]
+        "CandidateIds" : [ "c-undeclared_write-ins" ]
       } ],
       "Name" : "Precinct example"
     } ],

--- a/src/test/resources/network/brightspots/rcv/test_data/sample_interactive_tiebreak/sample_interactive_tiebreak_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/sample_interactive_tiebreak/sample_interactive_tiebreak_config.json
@@ -16,7 +16,11 @@
     "firstVoteRowIndex" : "2",
     "idColumnIndex" : "",
     "precinctColumnIndex" : "",
-    "provider" : "ES&S"
+    "provider" : "ES&S",
+    "treatBlankAsUndeclaredWriteIn": false,
+    "overvoteLabel": "overvote",
+    "undervoteLabel": "undervote",
+    "undeclaredWriteInLabel": ""
   } ],
   "candidates" : [ {
     "name" : "Mookie Blaylock",
@@ -49,10 +53,6 @@
     "hareQuota": false,
     "batchElimination": true,
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "overvote",
-    "undervoteLabel": "undervote",
-    "undeclaredWriteInLabel": "",
     "rulesDescription": "Doyle Rules"
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/skip_to_next_test/skip_to_next_test_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/skip_to_next_test/skip_to_next_test_config.json
@@ -21,8 +21,7 @@
     "overvoteLabel" : "overvote",
     "undervoteLabel" : "undervote",
     "undeclaredWriteInLabel" : "",
-    "treatBlankAsUndeclaredWriteIn" : false,
-    "treatBlankAsUndeclaredWriteInEnabled" : false
+    "treatBlankAsUndeclaredWriteIn" : false
   } ],
   "candidates" : [ {
     "name" : "A",

--- a/src/test/resources/network/brightspots/rcv/test_data/skip_to_next_test/skip_to_next_test_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/skip_to_next_test/skip_to_next_test_config.json
@@ -1,22 +1,28 @@
 {
-  "tabulatorVersion": "TEST",
-  "outputSettings": {
-    "contestName": "Overvote2",
-    "outputDirectory": "output",
-    "contestDate": "2018-07-28",
-    "contestJurisdiction": "Funkytown, USA",
-    "contestOffice": "Exhausted",
-    "tabulateByPrecinct": false,
-    "generateCdfJson": false
+  "tabulatorVersion" : "TEST",
+  "outputSettings" : {
+    "contestName" : "Overvote2",
+    "outputDirectory" : "output",
+    "contestDate" : "2018-07-28",
+    "contestJurisdiction" : "Funkytown, USA",
+    "contestOffice" : "Exhausted",
+    "tabulateByPrecinct" : false,
+    "generateCdfJson" : false
   },
-  "cvrFileSources": [
-    {
+  "cvrFileSources" : [ {
     "filePath" : "skip_to_next_test_cvr.xlsx",
+    "contestId" : "",
     "firstVoteColumnIndex" : "2",
     "firstVoteRowIndex" : "2",
     "idColumnIndex" : "1",
     "precinctColumnIndex" : "",
-    "provider" : "ES&S"
+    "overvoteDelimiter" : "",
+    "provider" : "ES&S",
+    "overvoteLabel" : "overvote",
+    "undervoteLabel" : "undervote",
+    "undeclaredWriteInLabel" : "",
+    "treatBlankAsUndeclaredWriteIn" : false,
+    "treatBlankAsUndeclaredWriteInEnabled" : false
   } ],
   "candidates" : [ {
     "name" : "A",
@@ -36,23 +42,22 @@
     "excluded" : false
   } ],
   "rules" : {
-    "tiebreakMode": "Random",
-    "overvoteRule": "Always skip to next rank",
-    "winnerElectionMode": "Single-winner majority determines winner",
-    "randomSeed": "0",
-    "numberOfWinners": "1",
-    "decimalPlacesForVoteArithmetic": "4",
-    "minimumVoteThreshold": "0",
-    "maxSkippedRanksAllowed": "1",
-    "maxRankingsAllowed": "4",
-    "nonIntegerWinningThreshold": false,
-    "hareQuota": false,
-    "batchElimination": false,
-    "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "overvote",
-    "undervoteLabel": "undervote",
-    "undeclaredWriteInLabel": "",
-    "rulesDescription": "Doyle Rules"
+    "tiebreakMode" : "Random",
+    "overvoteRule" : "Always skip to next rank",
+    "winnerElectionMode" : "Single-winner majority determines winner",
+    "randomSeed" : "0",
+    "numberOfWinners" : "1",
+    "multiSeatBottomsUpPercentageThreshold" : "",
+    "decimalPlacesForVoteArithmetic" : "4",
+    "minimumVoteThreshold" : "0",
+    "maxSkippedRanksAllowed" : "1",
+    "maxRankingsAllowed" : "4",
+    "nonIntegerWinningThreshold" : false,
+    "hareQuota" : false,
+    "batchElimination" : false,
+    "continueUntilTwoCandidatesRemain" : false,
+    "exhaustOnDuplicateCandidate" : false,
+    "rulesDescription" : "Doyle Rules",
+    "treatBlankAsUndeclaredWriteIn" : false
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/test_set_0_skipped_first_choice/test_set_0_skipped_first_choice_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/test_set_0_skipped_first_choice/test_set_0_skipped_first_choice_config.json
@@ -15,7 +15,11 @@
     "idColumnIndex" : "",
     "precinctColumnIndex" : "",
     "provider" : "CDF",
-    "contestId": "Nist Test Set 0 Skipped First Choice"
+    "contestId": "Nist Test Set 0 Skipped First Choice",
+    "treatBlankAsUndeclaredWriteIn": false,
+    "overvoteLabel": "",
+    "undervoteLabel": "",
+    "undeclaredWriteInLabel": ""
   } ],
   "candidates" : [ {
     "name" : "Candidate A Name",
@@ -48,10 +52,6 @@
     "hareQuota": false,
     "batchElimination": false,
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "",
-    "undervoteLabel": "",
-    "undeclaredWriteInLabel": "",
     "rulesDescription": "Skiptonext_exhaustatovervote"
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/test_set_1_exhaust_at_overvote/test_set_1_exhaust_at_overvote_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/test_set_1_exhaust_at_overvote/test_set_1_exhaust_at_overvote_config.json
@@ -15,7 +15,11 @@
     "idColumnIndex" : "",
     "precinctColumnIndex" : "",
     "provider" : "CDF",
-    "contestId": "test set 1"
+    "contestId": "test set 1",
+    "treatBlankAsUndeclaredWriteIn": false,
+    "overvoteLabel": "",
+    "undervoteLabel": "",
+    "undeclaredWriteInLabel": ""
   } ],
   "candidates" : [ {
     "name" : "Candidate A Name",
@@ -48,10 +52,6 @@
     "hareQuota": false,
     "batchElimination": false,
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "",
-    "undervoteLabel": "",
-    "undeclaredWriteInLabel": "",
     "rulesDescription": "exhaustatovervote"
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/test_set_2_overvote_skip_to_next/test_set_2_overvote_skip_to_next_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/test_set_2_overvote_skip_to_next/test_set_2_overvote_skip_to_next_config.json
@@ -15,7 +15,11 @@
     "idColumnIndex" : "",
     "precinctColumnIndex" : "",
     "provider" : "CDF",
-    "contestId": "overvote skips to next rank"
+    "contestId": "overvote skips to next rank",
+    "treatBlankAsUndeclaredWriteIn": false,
+    "overvoteLabel": "",
+    "undervoteLabel": "",
+    "undeclaredWriteInLabel": ""
   } ],
   "candidates" : [ {
     "name" : "Candidate A Name",
@@ -48,10 +52,6 @@
     "hareQuota": false,
     "batchElimination": false,
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "",
-    "undervoteLabel": "",
-    "undeclaredWriteInLabel": "",
     "rulesDescription": "OV_skiptonext"
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/test_set_3_skipped_choice_exhaust/test_set_3_skipped_choice_exhaust_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/test_set_3_skipped_choice_exhaust/test_set_3_skipped_choice_exhaust_config.json
@@ -15,7 +15,11 @@
     "idColumnIndex" : "",
     "precinctColumnIndex" : "",
     "provider" : "CDF",
-    "contestId": "test set 3"
+    "contestId": "test set 3",
+    "treatBlankAsUndeclaredWriteIn": false,
+    "overvoteLabel": "",
+    "undervoteLabel": "",
+    "undeclaredWriteInLabel": ""
   } ],
   "candidates" : [ {
     "name" : "Candidate A Name",
@@ -48,10 +52,6 @@
     "hareQuota": false,
     "batchElimination": false,
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "",
-    "undervoteLabel": "",
-    "undeclaredWriteInLabel": "",
     "rulesDescription": ""
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/test_set_4_skipped_choice_next/test_set_4_skipped_choice_next_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/test_set_4_skipped_choice_next/test_set_4_skipped_choice_next_config.json
@@ -15,7 +15,11 @@
     "idColumnIndex" : "",
     "precinctColumnIndex" : "",
     "provider" : "CDF",
-    "contestId": "test set 4"
+    "contestId": "test set 4",
+    "treatBlankAsUndeclaredWriteIn": false,
+    "overvoteLabel": "",
+    "undervoteLabel": "",
+    "undeclaredWriteInLabel": ""
   } ],
   "candidates" : [ {
     "name" : "Candidate A Name",
@@ -48,10 +52,6 @@
     "hareQuota": false,
     "batchElimination": false,
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "",
-    "undervoteLabel": "",
-    "undeclaredWriteInLabel": "",
     "rulesDescription": "Skipped choice_skip to next"
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/test_set_5_two_skipped_choice_exhaust/test_set_5_two_skipped_choice_exhaust_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/test_set_5_two_skipped_choice_exhaust/test_set_5_two_skipped_choice_exhaust_config.json
@@ -15,7 +15,11 @@
     "idColumnIndex" : "",
     "precinctColumnIndex" : "",
     "provider" : "CDF",
-    "contestId": "test set 5"
+    "contestId": "test set 5",
+    "treatBlankAsUndeclaredWriteIn": false,
+    "overvoteLabel": "",
+    "undervoteLabel": "",
+    "undeclaredWriteInLabel": ""
   } ],
   "candidates" : [ {
     "name" : "Candidate A Name",
@@ -48,10 +52,6 @@
     "hareQuota": false,
     "batchElimination": false,
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "",
-    "undervoteLabel": "",
-    "undeclaredWriteInLabel": "",
     "rulesDescription": "Skipped choice allowed 1"
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/test_set_6_duplicate_exhaust/test_set_6_duplicate_exhaust_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/test_set_6_duplicate_exhaust/test_set_6_duplicate_exhaust_config.json
@@ -15,7 +15,11 @@
     "idColumnIndex" : "",
     "precinctColumnIndex" : "",
     "provider" : "CDF",
-    "contestId": "test set 6"
+    "contestId": "test set 6",
+    "treatBlankAsUndeclaredWriteIn": false,
+    "overvoteLabel": "",
+    "undervoteLabel": "",
+    "undeclaredWriteInLabel": ""
   } ],
   "candidates" : [ {
     "name" : "Candidate A Name",
@@ -48,10 +52,6 @@
     "hareQuota": false,
     "batchElimination": false,
     "exhaustOnDuplicateCandidate": true,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "",
-    "undervoteLabel": "",
-    "undeclaredWriteInLabel": "",
     "rulesDescription": "Duplicate choice exhaust"
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/test_set_7_duplicate_skip_to_next/test_set_7_duplicate_skip_to_next_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/test_set_7_duplicate_skip_to_next/test_set_7_duplicate_skip_to_next_config.json
@@ -15,7 +15,11 @@
     "idColumnIndex" : "",
     "precinctColumnIndex" : "",
     "provider" : "CDF",
-    "contestId": "test set 7"
+    "contestId": "test set 7",
+    "treatBlankAsUndeclaredWriteIn": false,
+    "overvoteLabel": "",
+    "undervoteLabel": "",
+    "undeclaredWriteInLabel": ""
   } ],
   "candidates" : [ {
     "name" : "Candidate A Name",
@@ -48,10 +52,6 @@
     "hareQuota": false,
     "batchElimination": false,
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "",
-    "undervoteLabel": "",
-    "undeclaredWriteInLabel": "",
     "rulesDescription": "Duplicate choice skip"
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/test_set_allow_only_one_winner_per_round/test_set_allow_only_one_winner_per_round_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/test_set_allow_only_one_winner_per_round/test_set_allow_only_one_winner_per_round_config.json
@@ -16,7 +16,11 @@
     "firstVoteRowIndex" : "2",
     "idColumnIndex" : "1",
     "precinctColumnIndex" : "",
-    "provider": "ES&S"
+    "provider": "ES&S",
+    "treatBlankAsUndeclaredWriteIn": false,
+    "overvoteLabel": "",
+    "undervoteLabel": "undervote",
+    "undeclaredWriteInLabel": ""
   } ],
   "candidates" : [ {
     "name" : "A",
@@ -49,10 +53,6 @@
     "hareQuota": false,
     "batchElimination": false,
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "",
-    "undervoteLabel": "undervote",
-    "undeclaredWriteInLabel": "",
     "rulesDescription": "Allow Only One Winner per Round Test"
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/test_set_multi_winner_fractional_threshold/test_set_multi_winner_fractional_threshold_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/test_set_multi_winner_fractional_threshold/test_set_multi_winner_fractional_threshold_config.json
@@ -15,7 +15,11 @@
     "idColumnIndex" : "",
     "precinctColumnIndex" : "",
     "provider" : "CDF",
-    "contestId": "test set multi winner fractional"
+    "contestId": "test set multi winner fractional",
+    "treatBlankAsUndeclaredWriteIn": false,
+    "overvoteLabel": "",
+    "undervoteLabel": "",
+    "undeclaredWriteInLabel": ""
   } ],
   "candidates" : [ {
     "name" : "Candidate A Name",
@@ -56,10 +60,6 @@
     "hareQuota": false,
     "batchElimination": false,
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "",
-    "undervoteLabel": "",
-    "undeclaredWriteInLabel": "",
     "rulesDescription": "Multi-winner Test 3"
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/test_set_multi_winner_whole_threshold/test_set_multi_winner_whole_threshold_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/test_set_multi_winner_whole_threshold/test_set_multi_winner_whole_threshold_config.json
@@ -15,7 +15,11 @@
     "idColumnIndex" : "",
     "precinctColumnIndex" : "",
     "provider" : "CDF",
-    "contestId": "test set multi winner whole"
+    "contestId": "test set multi winner whole",
+    "treatBlankAsUndeclaredWriteIn": false,
+    "overvoteLabel": "",
+    "undervoteLabel": "",
+    "undeclaredWriteInLabel": ""
   } ],
   "candidates" : [ {
     "name" : "Candidate A Name",
@@ -56,10 +60,6 @@
     "hareQuota": false,
     "batchElimination": false,
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "",
-    "undervoteLabel": "",
-    "undeclaredWriteInLabel": "",
     "rulesDescription": "Multi-winner Test 3"
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/test_set_overvote_delimiter/test_set_overvote_delimiter_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/test_set_overvote_delimiter/test_set_overvote_delimiter_config.json
@@ -17,7 +17,11 @@
     "idColumnIndex" : "1",
     "precinctColumnIndex" : "",
     "overvoteDelimiter" : "/",
-    "provider" : "ES&S"
+    "provider" : "ES&S",
+    "treatBlankAsUndeclaredWriteIn" : false,
+    "overvoteLabel" : "",
+    "undervoteLabel" : "",
+    "undeclaredWriteInLabel" : ""
   } ],
   "candidates" : [ {
     "name" : "A",
@@ -52,10 +56,6 @@
     "batchElimination" : false,
     "continueUntilTwoCandidatesRemain" : false,
     "exhaustOnDuplicateCandidate" : false,
-    "treatBlankAsUndeclaredWriteIn" : false,
-    "overvoteLabel" : "",
-    "undervoteLabel" : "",
-    "undeclaredWriteInLabel" : "",
     "rulesDescription" : ""
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/test_set_treat_blank_as_undeclared_write_in/test_set_treat_blank_as_undeclared_write_in_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/test_set_treat_blank_as_undeclared_write_in/test_set_treat_blank_as_undeclared_write_in_config.json
@@ -16,7 +16,11 @@
     "firstVoteRowIndex" : "2",
     "idColumnIndex" : "1",
     "precinctColumnIndex" : "",
-    "provider": "ES&S"
+    "provider": "ES&S",
+    "treatBlankAsUndeclaredWriteIn": true,
+    "overvoteLabel": "overvote",
+    "undervoteLabel": "undervote",
+    "undeclaredWriteInLabel": "UWI"
   } ],
   "candidates" : [ {
     "name" : "A",
@@ -49,10 +53,6 @@
     "hareQuota": false,
     "batchElimination": false,
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": true,
-    "overvoteLabel": "overvote",
-    "undervoteLabel": "undervote",
-    "undeclaredWriteInLabel": "UWI",
     "rulesDescription": "test"
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/tiebreak_generate_permutation_test/tiebreak_generate_permutation_test_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/tiebreak_generate_permutation_test/tiebreak_generate_permutation_test_config.json
@@ -16,7 +16,11 @@
     "firstVoteRowIndex" : "2",
     "idColumnIndex" : "",
     "precinctColumnIndex" : "",
-    "provider" : "ES&S"
+    "provider" : "ES&S",
+    "treatBlankAsUndeclaredWriteIn": false,
+    "overvoteLabel": "overvote",
+    "undervoteLabel": "undervote",
+    "undeclaredWriteInLabel": ""
   } ],
   "candidates" : [ {
     "name" : "Mookie Blaylock",
@@ -49,10 +53,6 @@
     "hareQuota": false,
     "batchElimination": true,
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "overvote",
-    "undervoteLabel": "undervote",
-    "undeclaredWriteInLabel": "",
     "rulesDescription": "Doyle Rules"
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/tiebreak_previous_round_counts_then_random_test/tiebreak_previous_round_counts_then_random_test_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/tiebreak_previous_round_counts_then_random_test/tiebreak_previous_round_counts_then_random_test_config.json
@@ -16,7 +16,11 @@
     "firstVoteRowIndex" : "2",
     "idColumnIndex" : "1",
     "precinctColumnIndex" : "",
-    "provider": "ES&S"
+    "provider": "ES&S",
+    "treatBlankAsUndeclaredWriteIn": false,
+    "overvoteLabel": "overvote",
+    "undervoteLabel": "undervote",
+    "undeclaredWriteInLabel": ""
   } ],
   "candidates" : [ {
     "name" : "Happy",
@@ -49,10 +53,6 @@
     "hareQuota": false,
     "batchElimination": false,
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "overvote",
-    "undervoteLabel": "undervote",
-    "undeclaredWriteInLabel": "",
     "rulesDescription": "Doyle Rules"
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/tiebreak_seed_test/tiebreak_seed_test_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/tiebreak_seed_test/tiebreak_seed_test_config.json
@@ -16,7 +16,11 @@
     "firstVoteRowIndex" : "2",
     "idColumnIndex" : "1",
     "precinctColumnIndex" : "",
-    "provider" : "ES&S"
+    "provider" : "ES&S",
+    "treatBlankAsUndeclaredWriteIn": false,
+    "overvoteLabel": "overvote",
+    "undervoteLabel": "undervote",
+    "undeclaredWriteInLabel": ""
   } ],
   "candidates" : [ {
     "name" : "Mookie Blaylock",
@@ -45,10 +49,6 @@
     "hareQuota": false,
     "batchElimination": true,
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "overvote",
-    "undervoteLabel": "undervote",
-    "undeclaredWriteInLabel": "",
     "rulesDescription": "Doyle Rules"
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/tiebreak_use_permutation_in_config_test/tiebreak_use_permutation_in_config_test_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/tiebreak_use_permutation_in_config_test/tiebreak_use_permutation_in_config_test_config.json
@@ -16,7 +16,11 @@
     "firstVoteRowIndex" : 2,
     "idColumnIndex" : "",
     "precinctColumnIndex" : "",
-    "provider" : "ES&S"
+    "provider" : "ES&S",
+    "treatBlankAsUndeclaredWriteIn": false,
+    "overvoteLabel": "overvote",
+    "undervoteLabel": "undervote",
+    "undeclaredWriteInLabel": ""
   } ],
   "candidates" : [ {
     "name" : "Mookie Blaylock",
@@ -48,10 +52,6 @@
     "hareQuota": false,
     "batchElimination": true,
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "overvote",
-    "undervoteLabel": "undervote",
-    "undeclaredWriteInLabel": "",
     "rulesDescription": "Doyle Rules"
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/unisyn_xml_cdf_city_chief_of_police/unisyn_xml_cdf_city_chief_of_police_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/unisyn_xml_cdf_city_chief_of_police/unisyn_xml_cdf_city_chief_of_police_config.json
@@ -15,7 +15,11 @@
       "idColumnIndex": "",
       "precinctColumnIndex": "",
       "provider": "CDF",
-      "contestId": "For City C Chief of Police (1/3)"
+      "contestId": "For City C Chief of Police (1/3)",
+      "treatBlankAsUndeclaredWriteIn": false,
+      "overvoteLabel": "",
+      "undervoteLabel": "",
+      "undeclaredWriteInLabel": "UWI"
     }
   ],
   "candidates": [
@@ -69,10 +73,6 @@
     "hareQuota": false,
     "batchElimination": false,
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "",
-    "undervoteLabel": "",
-    "undeclaredWriteInLabel": "UWI",
     "rulesDescription": "Skiptonext_exhaustatovervote"
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/unisyn_xml_cdf_city_coroner/unisyn_xml_cdf_city_coroner_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/unisyn_xml_cdf_city_coroner/unisyn_xml_cdf_city_coroner_config.json
@@ -15,7 +15,11 @@
       "idColumnIndex": "",
       "precinctColumnIndex": "",
       "provider": "CDF",
-      "contestId": "For City C Coroner (1/3)"
+      "contestId": "For City C Coroner (1/3)",
+      "treatBlankAsUndeclaredWriteIn": false,
+      "overvoteLabel": "",
+      "undervoteLabel": "",
+      "undeclaredWriteInLabel": "UWI"
     }
   ],
   "candidates": [
@@ -64,10 +68,6 @@
     "hareQuota": false,
     "batchElimination": false,
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "",
-    "undervoteLabel": "",
-    "undeclaredWriteInLabel": "UWI",
     "rulesDescription": "Skiptonext_exhaustatovervote"
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/unisyn_xml_cdf_city_council_member/unisyn_xml_cdf_city_council_member_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/unisyn_xml_cdf_city_council_member/unisyn_xml_cdf_city_council_member_config.json
@@ -15,7 +15,11 @@
       "idColumnIndex": "",
       "precinctColumnIndex": "",
       "provider": "CDF",
-      "contestId": "For City C Council Member (1/3)"
+      "contestId": "For City C Council Member (1/3)",
+      "treatBlankAsUndeclaredWriteIn": false,
+      "overvoteLabel": "",
+      "undervoteLabel": "",
+      "undeclaredWriteInLabel": "UWI"
     }
   ],
   "candidates": [
@@ -75,10 +79,6 @@
     "hareQuota": false,
     "batchElimination": false,
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "",
-    "undervoteLabel": "",
-    "undeclaredWriteInLabel": "UWI",
     "rulesDescription": "Skiptonext_exhaustatovervote"
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/unisyn_xml_cdf_city_mayor/unisyn_xml_cdf_city_mayor_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/unisyn_xml_cdf_city_mayor/unisyn_xml_cdf_city_mayor_config.json
@@ -15,7 +15,11 @@
       "idColumnIndex": "",
       "precinctColumnIndex": "",
       "provider": "CDF",
-      "contestId": "For City C Mayor (1/3)"
+      "contestId": "For City C Mayor (1/3)",
+      "treatBlankAsUndeclaredWriteIn": false,
+      "overvoteLabel": "",
+      "undervoteLabel": "",
+      "undeclaredWriteInLabel": "UWI"
     }
   ],
   "candidates": [
@@ -94,10 +98,6 @@
     "hareQuota": false,
     "batchElimination": false,
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "",
-    "undervoteLabel": "",
-    "undeclaredWriteInLabel": "UWI",
     "rulesDescription": "Skiptonext_exhaustatovervote"
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/unisyn_xml_cdf_city_tax_collector/unisyn_xml_cdf_city_tax_collector_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/unisyn_xml_cdf_city_tax_collector/unisyn_xml_cdf_city_tax_collector_config.json
@@ -15,7 +15,11 @@
       "idColumnIndex": "",
       "precinctColumnIndex": "",
       "provider": "CDF",
-      "contestId": "For County Tax Collector (1/3)"
+      "contestId": "For County Tax Collector (1/3)",
+      "treatBlankAsUndeclaredWriteIn": false,
+      "overvoteLabel": "",
+      "undervoteLabel": "",
+      "undeclaredWriteInLabel": "UWI"
     }
   ],
   "candidates": [
@@ -74,10 +78,6 @@
     "hareQuota": false,
     "batchElimination": false,
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "",
-    "undervoteLabel": "",
-    "undeclaredWriteInLabel": "UWI",
     "rulesDescription": "Skiptonext_exhaustatovervote"
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/unisyn_xml_cdf_county_coroner/unisyn_xml_cdf_county_coroner_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/unisyn_xml_cdf_county_coroner/unisyn_xml_cdf_county_coroner_config.json
@@ -15,7 +15,11 @@
       "idColumnIndex": "",
       "precinctColumnIndex": "",
       "provider": "CDF",
-      "contestId": "For County Coroner (1/2)"
+      "contestId": "For County Coroner (1/2)",
+      "treatBlankAsUndeclaredWriteIn": false,
+      "overvoteLabel": "",
+      "undervoteLabel": "",
+      "undeclaredWriteInLabel": "UWI"
     }
   ],
   "candidates": [
@@ -74,10 +78,6 @@
     "hareQuota": false,
     "batchElimination": false,
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "",
-    "undervoteLabel": "",
-    "undeclaredWriteInLabel": "UWI",
     "rulesDescription": "Skiptonext_exhaustatovervote"
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/unisyn_xml_cdf_county_sheriff/unisyn_xml_cdf_county_sheriff_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/unisyn_xml_cdf_county_sheriff/unisyn_xml_cdf_county_sheriff_config.json
@@ -15,7 +15,11 @@
       "idColumnIndex": "",
       "precinctColumnIndex": "",
       "provider": "CDF",
-      "contestId": "For County Sheriff (1/3)"
+      "contestId": "For County Sheriff (1/3)",
+      "treatBlankAsUndeclaredWriteIn": false,
+      "overvoteLabel": "",
+      "undervoteLabel": "",
+      "undeclaredWriteInLabel": "UWI"
     }
   ],
   "candidates": [
@@ -69,10 +73,6 @@
     "hareQuota": false,
     "batchElimination": false,
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "",
-    "undervoteLabel": "",
-    "undeclaredWriteInLabel": "UWI",
     "rulesDescription": "Skiptonext_exhaustatovervote"
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/uwi_cannot_win_test/uwi_cannot_win_test_config.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/uwi_cannot_win_test/uwi_cannot_win_test_config.json
@@ -15,7 +15,11 @@
     "firstVoteRowIndex" : "2",
     "idColumnIndex" : "",
     "precinctColumnIndex" : "",
-    "provider": "ES&S"
+    "provider": "ES&S",
+    "treatBlankAsUndeclaredWriteIn": false,
+    "overvoteLabel": "",
+    "undervoteLabel": "",
+    "undeclaredWriteInLabel": "UWI"
   } ],
   "candidates" : [ {
     "name" : "A",
@@ -41,10 +45,6 @@
     "hareQuota": false,
     "batchElimination": false,
     "exhaustOnDuplicateCandidate": false,
-    "treatBlankAsUndeclaredWriteIn": false,
-    "overvoteLabel": "",
-    "undervoteLabel": "",
-    "undeclaredWriteInLabel": "UWI",
     "rulesDescription": ""
   }
 }


### PR DESCRIPTION
This address #507 and #508.

OK, I was a fool when I said that moving these fields would be easy. But I just plowed through it for the last ~3 hours and I think it's at least mostly working.

This PR also includes changes to move the migration logic to a separate class, to refuse to migrate if the config file is newer than the app, and to provide helpful messages if you have a version mismatch when running from the CLI.

I just updated one test to prove that the per-source fields work. I'll have to go back and deal with all of the other tests one by one. :(

Moving overvoteLabel, undervoteLabel, and treatBlankAsUndeclaredWriteIn was fairly straightforward (except for some validation fun in ContestConfig). But undeclaredWriteInLabel was trickier, because we also use that string in other places in a way that definitely can't be per-source. I resolved that by replacing all of those uses with a new constant... which I believe should work fine.

In general I've barely tested this and my attention to detail in my coding was far looser than usual because it was such a massive tedious change. If you have time to try to break it, please go for it. I'll spend more time reviewing my work and cleaning it up tomorrow.