### PR TITLE
Minor cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Or, again, if you're compiling and running using Gradle:
 
 `$ gradlew run --args="-cli path/to/config  convert-to-cdf"`
 
-Note: if you convert a source to CDF and that source uses an overvoteLabel or an undeclaredWriteInLabel, the label will be represented differently in the generated CDF source file than it was in the original CVR source. When you create a new config using this generated CDF source file and you need to set overvoteLabel, you should use "overvote". If you need to set undeclaredWriteInLabel, you should use "undeclared_write-ins".
+Note: if you convert a source to CDF and that source uses an overvoteLabel or an undeclaredWriteInLabel, the label will be represented differently in the generated CDF source file than it was in the original CVR source. When you create a new config using this generated CDF source file and you need to set overvoteLabel, you should use "overvote". If you need to set undeclaredWriteInLabel, you should use "Undeclared Write-ins".
 
 ## Viewing Tabulator Output
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Or, again, if you're compiling and running using Gradle:
 
 `$ gradlew run --args="-cli path/to/config  convert-to-cdf"`
 
-Note: if you convert a source to CDF and that source uses an overvoteLabel or an undeclaredWriteInLabel, the label will be represented differently in the generated CDF source file than it was in the original CVR source. When you create a new config using this generated CDF source file and you need to set overvoteLabel, you should use "cs-overvote". If you need to set undeclaredWriteInLabel, you should use "cs-undeclared_write-ins".
+Note: if you convert a source to CDF and that source uses an overvoteLabel or an undeclaredWriteInLabel, the label will be represented differently in the generated CDF source file than it was in the original CVR source. When you create a new config using this generated CDF source file and you need to set overvoteLabel, you should use "overvote". If you need to set undeclaredWriteInLabel, you should use "undeclared_write-ins".
 
 ## Viewing Tabulator Output
 

--- a/src/main/java/network/brightspots/rcv/CommonDataFormatReader.java
+++ b/src/main/java/network/brightspots/rcv/CommonDataFormatReader.java
@@ -363,6 +363,10 @@ class CommonDataFormatReader {
       for (Object cvrContestSelectionObject : cvrContestSelections) {
         HashMap cvrContestSelection = (HashMap) cvrContestSelectionObject;
         String contestSelectionId = (String) cvrContestSelection.get("ContestSelectionId");
+        if (!contestSelections.containsKey(contestSelectionId)) {
+          Logger.severe("ContestSelection \"%s\" from CVR not found!", contestSelectionId);
+          throw new CvrParseException();
+        }
         HashMap contestSelection = (HashMap) contestSelections.get(contestSelectionId);
         String candidateId;
         if (contestSelection.containsKey("IsWriteIn")

--- a/src/main/java/network/brightspots/rcv/ResultsWriter.java
+++ b/src/main/java/network/brightspots/rcv/ResultsWriter.java
@@ -644,7 +644,7 @@ class ResultsWriter {
             entry("Type", "other"),
             entry("OtherType", "Election Scope Jurisdiction"),
             entry("Name", config.getContestJurisdiction()),
-            entry("@type", "CVR.GpUnit")));
+            entry("@type", "GpUnit")));
 
     // generate GpUnit entries
     for (Entry<String, String> entry : gpUnitIds.entrySet()) {
@@ -653,7 +653,7 @@ class ResultsWriter {
               entry("@id", entry.getValue()),
               entry("Type", "precinct"),
               entry("Name", entry.getKey()),
-              entry("@type", "CVR.GpUnit")));
+              entry("@type", "GpUnit")));
     }
     return gpUnitMaps;
   }
@@ -690,7 +690,7 @@ class ResultsWriter {
       cvrMap.put("CurrentSnapshotId", generateCvrSnapshotId(sanitizedId, numRounds));
       cvrMap.put("CVRSnapshot", cvrSnapshots);
       cvrMap.put("ElectionId", CDF_ELECTION_ID);
-      cvrMap.put("@type", "CVR.CVR");
+      cvrMap.put("@type", "CVR");
       // if using precincts add GpUnitId for cvr precinct
       if (config.isTabulateByPrecinctEnabled()) {
         String gpUnitId = gpUnitIds.get(cvr.getPrecinct());
@@ -807,7 +807,7 @@ class ResultsWriter {
       contestSelections.add(
           Map.ofEntries(
               entry("@id", getCdfContestSelectionIdForCandidateCode(candidateCode)),
-              entry("@type", "CVR.ContestSelection"),
+              entry("@type", "ContestSelection"),
               entry(
                   "CandidateIds",
                   new String[]{getCdfCandidateIdForCandidateCode(candidateCode)})));
@@ -816,7 +816,7 @@ class ResultsWriter {
     Map<String, Object> contestJson =
         Map.ofEntries(
             entry("@id", CDF_CONTEST_ID),
-            entry("@type", "CVR.CandidateContest"),
+            entry("@type", "CandidateContest"),
             entry("ContestSelection", contestSelections),
             entry("Name", config.getContestName()));
 
@@ -825,7 +825,7 @@ class ResultsWriter {
     electionMap.put("Candidate", candidates);
     electionMap.put("Contest", new Map[]{contestJson});
     electionMap.put("ElectionScopeId", CDF_GPU_ID);
-    electionMap.put("@type", "CVR.Election");
+    electionMap.put("@type", "Election");
 
     return electionMap;
   }

--- a/src/test/resources/network/brightspots/rcv/test_data/precinct_example/precinct_example_expected_cvr_cdf.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/precinct_example/precinct_example_expected_cvr_cdf.json
@@ -1,7 +1,7 @@
 {
   "@type" : "CVR.CastVoteRecordReport",
   "CVR" : [ {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-1",
     "BallotStyleUnitId" : "gpu-21",
     "CVRSnapshot" : [ {
@@ -242,7 +242,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-1-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-2",
     "BallotStyleUnitId" : "gpu-35",
     "CVRSnapshot" : [ {
@@ -483,7 +483,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-2-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-3",
     "BallotStyleUnitId" : "gpu-51",
     "CVRSnapshot" : [ {
@@ -604,7 +604,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-3-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-4",
     "BallotStyleUnitId" : "gpu-58",
     "CVRSnapshot" : [ {
@@ -845,7 +845,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-4-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-5",
     "BallotStyleUnitId" : "gpu-54",
     "CVRSnapshot" : [ {
@@ -966,7 +966,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-5-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-6",
     "BallotStyleUnitId" : "gpu-45",
     "CVRSnapshot" : [ {
@@ -1207,7 +1207,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-6-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-7",
     "BallotStyleUnitId" : "gpu-51",
     "CVRSnapshot" : [ {
@@ -1328,7 +1328,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-7-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-8",
     "BallotStyleUnitId" : "gpu-24",
     "CVRSnapshot" : [ {
@@ -1569,7 +1569,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-8-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-9",
     "BallotStyleUnitId" : "gpu-49",
     "CVRSnapshot" : [ {
@@ -1750,7 +1750,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-9-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-10",
     "BallotStyleUnitId" : "gpu-8",
     "CVRSnapshot" : [ {
@@ -1991,7 +1991,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-10-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-11",
     "BallotStyleUnitId" : "gpu-51",
     "CVRSnapshot" : [ {
@@ -2112,7 +2112,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-11-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-12",
     "BallotStyleUnitId" : "gpu-38",
     "CVRSnapshot" : [ {
@@ -2353,7 +2353,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-12-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-13",
     "BallotStyleUnitId" : "gpu-6",
     "CVRSnapshot" : [ {
@@ -2594,7 +2594,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-13-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-14",
     "BallotStyleUnitId" : "gpu-48",
     "CVRSnapshot" : [ {
@@ -2835,7 +2835,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-14-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-15",
     "BallotStyleUnitId" : "gpu-31",
     "CVRSnapshot" : [ {
@@ -3076,7 +3076,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-15-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-16",
     "BallotStyleUnitId" : "gpu-32",
     "CVRSnapshot" : [ {
@@ -3197,7 +3197,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-16-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-17",
     "BallotStyleUnitId" : "gpu-19",
     "CVRSnapshot" : [ {
@@ -3438,7 +3438,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-17-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-18",
     "BallotStyleUnitId" : "gpu-56",
     "CVRSnapshot" : [ {
@@ -3619,7 +3619,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-18-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-19",
     "BallotStyleUnitId" : "gpu-37",
     "CVRSnapshot" : [ {
@@ -3860,7 +3860,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-19-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-20",
     "BallotStyleUnitId" : "gpu-7",
     "CVRSnapshot" : [ {
@@ -4101,7 +4101,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-20-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-21",
     "BallotStyleUnitId" : "gpu-43",
     "CVRSnapshot" : [ {
@@ -4342,7 +4342,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-21-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-22",
     "BallotStyleUnitId" : "gpu-39",
     "CVRSnapshot" : [ {
@@ -4583,7 +4583,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-22-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-23",
     "BallotStyleUnitId" : "gpu-46",
     "CVRSnapshot" : [ {
@@ -4704,7 +4704,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-23-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-24",
     "BallotStyleUnitId" : "gpu-20",
     "CVRSnapshot" : [ {
@@ -4945,7 +4945,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-24-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-25",
     "BallotStyleUnitId" : "gpu-35",
     "CVRSnapshot" : [ {
@@ -5186,7 +5186,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-25-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-26",
     "BallotStyleUnitId" : "gpu-44",
     "CVRSnapshot" : [ {
@@ -5367,7 +5367,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-26-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-27",
     "BallotStyleUnitId" : "gpu-10",
     "CVRSnapshot" : [ {
@@ -5608,7 +5608,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-27-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-28",
     "BallotStyleUnitId" : "gpu-36",
     "CVRSnapshot" : [ {
@@ -5849,7 +5849,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-28-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-29",
     "BallotStyleUnitId" : "gpu-42",
     "CVRSnapshot" : [ {
@@ -6090,7 +6090,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-29-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-30",
     "BallotStyleUnitId" : "gpu-6",
     "CVRSnapshot" : [ {
@@ -6271,7 +6271,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-30-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-31",
     "BallotStyleUnitId" : "gpu-55",
     "CVRSnapshot" : [ {
@@ -6512,7 +6512,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-31-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-32",
     "BallotStyleUnitId" : "gpu-2",
     "CVRSnapshot" : [ {
@@ -6693,7 +6693,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-32-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-33",
     "BallotStyleUnitId" : "gpu-31",
     "CVRSnapshot" : [ {
@@ -6814,7 +6814,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-33-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-34",
     "BallotStyleUnitId" : "gpu-52",
     "CVRSnapshot" : [ {
@@ -6995,7 +6995,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-34-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-35",
     "BallotStyleUnitId" : "gpu-36",
     "CVRSnapshot" : [ {
@@ -7236,7 +7236,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-35-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-36",
     "BallotStyleUnitId" : "gpu-1",
     "CVRSnapshot" : [ {
@@ -7417,7 +7417,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-36-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-37",
     "BallotStyleUnitId" : "gpu-53",
     "CVRSnapshot" : [ {
@@ -7598,7 +7598,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-37-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-38",
     "BallotStyleUnitId" : "gpu-22",
     "CVRSnapshot" : [ {
@@ -7719,7 +7719,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-38-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-39",
     "BallotStyleUnitId" : "gpu-42",
     "CVRSnapshot" : [ {
@@ -7960,7 +7960,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-39-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-40",
     "BallotStyleUnitId" : "gpu-17",
     "CVRSnapshot" : [ {
@@ -8201,7 +8201,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-40-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-41",
     "BallotStyleUnitId" : "gpu-51",
     "CVRSnapshot" : [ {
@@ -8322,7 +8322,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-41-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-42",
     "BallotStyleUnitId" : "gpu-55",
     "CVRSnapshot" : [ {
@@ -8563,7 +8563,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-42-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-43",
     "BallotStyleUnitId" : "gpu-26",
     "CVRSnapshot" : [ {
@@ -8804,7 +8804,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-43-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-44",
     "BallotStyleUnitId" : "gpu-25",
     "CVRSnapshot" : [ {
@@ -9045,7 +9045,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-44-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-45",
     "BallotStyleUnitId" : "gpu-18",
     "CVRSnapshot" : [ {
@@ -9286,7 +9286,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-45-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-46",
     "BallotStyleUnitId" : "gpu-21",
     "CVRSnapshot" : [ {
@@ -9527,7 +9527,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-46-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-47",
     "BallotStyleUnitId" : "gpu-31",
     "CVRSnapshot" : [ {
@@ -9768,7 +9768,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-47-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-48",
     "BallotStyleUnitId" : "gpu-49",
     "CVRSnapshot" : [ {
@@ -10009,7 +10009,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-48-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-49",
     "BallotStyleUnitId" : "gpu-15",
     "CVRSnapshot" : [ {
@@ -10250,7 +10250,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-49-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-50",
     "BallotStyleUnitId" : "gpu-50",
     "CVRSnapshot" : [ {
@@ -10371,7 +10371,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-50-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-51",
     "BallotStyleUnitId" : "gpu-4",
     "CVRSnapshot" : [ {
@@ -10492,7 +10492,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-51-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-52",
     "BallotStyleUnitId" : "gpu-31",
     "CVRSnapshot" : [ {
@@ -10733,7 +10733,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-52-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-53",
     "BallotStyleUnitId" : "gpu-30",
     "CVRSnapshot" : [ {
@@ -10914,7 +10914,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-53-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-54",
     "BallotStyleUnitId" : "gpu-34",
     "CVRSnapshot" : [ {
@@ -11155,7 +11155,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-54-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-55",
     "BallotStyleUnitId" : "gpu-40",
     "CVRSnapshot" : [ {
@@ -11396,7 +11396,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-55-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-56",
     "BallotStyleUnitId" : "gpu-36",
     "CVRSnapshot" : [ {
@@ -11637,7 +11637,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-56-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-57",
     "BallotStyleUnitId" : "gpu-42",
     "CVRSnapshot" : [ {
@@ -11878,7 +11878,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-57-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-58",
     "BallotStyleUnitId" : "gpu-1",
     "CVRSnapshot" : [ {
@@ -12119,7 +12119,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-58-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-59",
     "BallotStyleUnitId" : "gpu-44",
     "CVRSnapshot" : [ {
@@ -12300,7 +12300,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-59-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-60",
     "BallotStyleUnitId" : "gpu-58",
     "CVRSnapshot" : [ {
@@ -12541,7 +12541,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-60-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-61",
     "BallotStyleUnitId" : "gpu-3",
     "CVRSnapshot" : [ {
@@ -12782,7 +12782,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-61-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-62",
     "BallotStyleUnitId" : "gpu-44",
     "CVRSnapshot" : [ {
@@ -12963,7 +12963,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-62-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-63",
     "BallotStyleUnitId" : "gpu-50",
     "CVRSnapshot" : [ {
@@ -13084,7 +13084,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-63-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-64",
     "BallotStyleUnitId" : "gpu-49",
     "CVRSnapshot" : [ {
@@ -13325,7 +13325,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-64-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-65",
     "BallotStyleUnitId" : "gpu-51",
     "CVRSnapshot" : [ {
@@ -13446,7 +13446,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-65-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-66",
     "BallotStyleUnitId" : "gpu-57",
     "CVRSnapshot" : [ {
@@ -13687,7 +13687,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-66-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-67",
     "BallotStyleUnitId" : "gpu-23",
     "CVRSnapshot" : [ {
@@ -13880,7 +13880,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-67-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-68",
     "BallotStyleUnitId" : "gpu-12",
     "CVRSnapshot" : [ {
@@ -14121,7 +14121,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-68-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-69",
     "BallotStyleUnitId" : "gpu-28",
     "CVRSnapshot" : [ {
@@ -14362,7 +14362,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-69-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-70",
     "BallotStyleUnitId" : "gpu-9",
     "CVRSnapshot" : [ {
@@ -14603,7 +14603,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-70-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-71",
     "BallotStyleUnitId" : "gpu-31",
     "CVRSnapshot" : [ {
@@ -14844,7 +14844,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-71-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-72",
     "BallotStyleUnitId" : "gpu-51",
     "CVRSnapshot" : [ {
@@ -14965,7 +14965,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-72-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-73",
     "BallotStyleUnitId" : "gpu-45",
     "CVRSnapshot" : [ {
@@ -15086,7 +15086,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-73-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-74",
     "BallotStyleUnitId" : "gpu-34",
     "CVRSnapshot" : [ {
@@ -15327,7 +15327,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-74-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-75",
     "BallotStyleUnitId" : "gpu-45",
     "CVRSnapshot" : [ {
@@ -15448,7 +15448,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-75-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-76",
     "BallotStyleUnitId" : "gpu-18",
     "CVRSnapshot" : [ {
@@ -15689,7 +15689,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-76-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-77",
     "BallotStyleUnitId" : "gpu-16",
     "CVRSnapshot" : [ {
@@ -15930,7 +15930,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-77-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-78",
     "BallotStyleUnitId" : "gpu-55",
     "CVRSnapshot" : [ {
@@ -16171,7 +16171,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-78-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-79",
     "BallotStyleUnitId" : "gpu-14",
     "CVRSnapshot" : [ {
@@ -16412,7 +16412,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-79-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-80",
     "BallotStyleUnitId" : "gpu-33",
     "CVRSnapshot" : [ {
@@ -16533,7 +16533,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-80-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-81",
     "BallotStyleUnitId" : "gpu-52",
     "CVRSnapshot" : [ {
@@ -16774,7 +16774,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-81-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-82",
     "BallotStyleUnitId" : "gpu-5",
     "CVRSnapshot" : [ {
@@ -16991,7 +16991,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-82-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-83",
     "BallotStyleUnitId" : "gpu-11",
     "CVRSnapshot" : [ {
@@ -17232,7 +17232,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-83-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-84",
     "BallotStyleUnitId" : "gpu-33",
     "CVRSnapshot" : [ {
@@ -17353,7 +17353,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-84-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-85",
     "BallotStyleUnitId" : "gpu-27",
     "CVRSnapshot" : [ {
@@ -17594,7 +17594,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-85-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-86",
     "BallotStyleUnitId" : "gpu-30",
     "CVRSnapshot" : [ {
@@ -17835,7 +17835,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-86-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-87",
     "BallotStyleUnitId" : "gpu-22",
     "CVRSnapshot" : [ {
@@ -18016,7 +18016,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-87-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-88",
     "BallotStyleUnitId" : "gpu-51",
     "CVRSnapshot" : [ {
@@ -18137,7 +18137,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-88-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-89",
     "BallotStyleUnitId" : "gpu-27",
     "CVRSnapshot" : [ {
@@ -18318,7 +18318,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-89-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-90",
     "BallotStyleUnitId" : "gpu-47",
     "CVRSnapshot" : [ {
@@ -18559,7 +18559,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-90-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-91",
     "BallotStyleUnitId" : "gpu-51",
     "CVRSnapshot" : [ {
@@ -18752,7 +18752,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-91-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-92",
     "BallotStyleUnitId" : "gpu-37",
     "CVRSnapshot" : [ {
@@ -18993,7 +18993,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-92-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-93",
     "BallotStyleUnitId" : "gpu-37",
     "CVRSnapshot" : [ {
@@ -19174,7 +19174,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-93-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-94",
     "BallotStyleUnitId" : "gpu-17",
     "CVRSnapshot" : [ {
@@ -19367,7 +19367,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-94-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-95",
     "BallotStyleUnitId" : "gpu-13",
     "CVRSnapshot" : [ {
@@ -19608,7 +19608,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-95-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-96",
     "BallotStyleUnitId" : "gpu-38",
     "CVRSnapshot" : [ {
@@ -19729,7 +19729,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-96-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-97",
     "BallotStyleUnitId" : "gpu-49",
     "CVRSnapshot" : [ {
@@ -19790,7 +19790,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-97-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-98",
     "BallotStyleUnitId" : "gpu-33",
     "CVRSnapshot" : [ {
@@ -20031,7 +20031,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-98-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-99",
     "BallotStyleUnitId" : "gpu-29",
     "CVRSnapshot" : [ {
@@ -20272,7 +20272,7 @@
     "CurrentSnapshotId" : "ballot-precinct_example_cvr.xlsx-99-round-5",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "precinct_example_cvr.xlsx-100",
     "BallotStyleUnitId" : "gpu-41",
     "CVRSnapshot" : [ {
@@ -20515,7 +20515,7 @@
   } ],
   "Election" : [ {
     "@id" : "election-001",
-    "@type" : "CVR.Election",
+    "@type" : "Election",
     "Candidate" : [ {
       "@id" : "c-al_flowers",
       "Name" : "Al Flowers"
@@ -20576,383 +20576,383 @@
     } ],
     "Contest" : [ {
       "@id" : "contest-001",
-      "@type" : "CVR.CandidateContest",
+      "@type" : "CandidateContest",
       "ContestSelection" : [ {
         "@id" : "cs-al_flowers",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-al_flowers" ]
       }, {
         "@id" : "cs-aswar_rahman",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-aswar_rahman" ]
       }, {
         "@id" : "cs-betsy_hodges",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-betsy_hodges" ]
       }, {
         "@id" : "cs-captain_jack_sparrow",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-captain_jack_sparrow" ]
       }, {
         "@id" : "cs-charlie_gers",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-charlie_gers" ]
       }, {
         "@id" : "cs-christopher_zimmerman",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-christopher_zimmerman" ]
       }, {
         "@id" : "cs-david_john_wilson",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-david_john_wilson" ]
       }, {
         "@id" : "cs-david_rosenfeld",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-david_rosenfeld" ]
       }, {
         "@id" : "cs-gregg_a._iverson",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-gregg_a._iverson" ]
       }, {
         "@id" : "cs-ian_simpson",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-ian_simpson" ]
       }, {
         "@id" : "cs-jacob_frey",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-jacob_frey" ]
       }, {
         "@id" : "cs-l.a._nik",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-l.a._nik" ]
       }, {
         "@id" : "cs-nekima_levy-pounds",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-nekima_levy-pounds" ]
       }, {
         "@id" : "cs-raymond_dehn",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-raymond_dehn" ]
       }, {
         "@id" : "cs-ronald_lischeid",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-ronald_lischeid" ]
       }, {
         "@id" : "cs-theron_preston_washington",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-theron_preston_washington" ]
       }, {
         "@id" : "cs-tom_hoch",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-tom_hoch" ]
       }, {
         "@id" : "cs-troy_benjegerdes",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-troy_benjegerdes" ]
       }, {
         "@id" : "cs-undeclared_write-ins",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-undeclared_write-ins" ]
       } ],
       "Name" : "Precinct example"
     } ],
     "ElectionScopeId" : "gpu-election"
   } ],
-  "GeneratedDate" : "2020-09-13T15:19:21-07:00",
+  "GeneratedDate" : "2020-10-03T12:36:59-07:00",
   "GpUnit" : [ {
     "@id" : "gpu-election",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "Minneapolis, MN",
     "OtherType" : "Election Scope Jurisdiction",
     "Type" : "other"
   }, {
     "@id" : "gpu-1",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-9 P-02",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-2",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-7 P-02D",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-3",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-9 P-01",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-4",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-9 P-03",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-5",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-4 P-05",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-6",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-8 P-02",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-7",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-8 P-03",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-8",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-2 P-05",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-9",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-5 P-05",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-10",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-2 P-02",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-11",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-2 P-01",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-12",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-8 P-05",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-13",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-7 P-01C",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-14",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-8 P-06",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-15",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-5 P-03",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-16",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-8 P-07",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-17",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-5 P-09",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-18",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-2 P-08",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-19",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-10 P-04",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-20",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-13 P-07",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-21",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-10 P-02",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-22",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-13 P-05",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-23",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-10 P-01",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-24",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-10 P-08",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-25",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-10 P-07",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-26",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-10 P-06",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-27",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-13 P-09",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-28",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-11 P-04",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-29",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-11 P-06",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-30",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-2 P-11",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-31",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-7 P-08",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-32",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-7 P-07",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-33",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-7 P-06",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-34",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-7 P-05",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-35",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-13 P-13",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-36",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-1 P-03",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-37",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-1 P-04",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-38",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-13 P-11",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-39",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-1 P-02",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-40",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-1 P-07",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-41",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-3 P-11",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-42",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-3 P-12",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-43",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-3 P-08",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-44",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-3 P-09",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-45",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-6 P-04",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-46",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-9 P-06",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-47",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-3 P-03",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-48",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-6 P-05",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-49",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-3 P-05",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-50",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-6 P-02",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-51",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-6 P-03",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-52",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-3 P-06",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-53",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-12 P-12",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-54",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-6 P-08",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-55",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-6 P-09",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-56",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-6 P-06",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-57",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-10 P-05A",
     "Type" : "precinct"
   }, {
     "@id" : "gpu-58",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "MINNEAPOLIS W-3 P-02",
     "Type" : "precinct"
   } ],

--- a/src/test/resources/network/brightspots/rcv/test_data/test_set_0_skipped_first_choice/test_set_0_skipped_first_choice_expected_cvr_cdf.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/test_set_0_skipped_first_choice/test_set_0_skipped_first_choice_expected_cvr_cdf.json
@@ -1,7 +1,7 @@
 {
   "@type" : "CVR.CastVoteRecordReport",
   "CVR" : [ {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "1",
     "CVRSnapshot" : [ {
       "@id" : "ballot-1",
@@ -203,7 +203,7 @@
     "CurrentSnapshotId" : "ballot-1-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "2",
     "CVRSnapshot" : [ {
       "@id" : "ballot-2",
@@ -405,7 +405,7 @@
     "CurrentSnapshotId" : "ballot-2-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "3",
     "CVRSnapshot" : [ {
       "@id" : "ballot-3",
@@ -607,7 +607,7 @@
     "CurrentSnapshotId" : "ballot-3-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "4",
     "CVRSnapshot" : [ {
       "@id" : "ballot-4",
@@ -809,7 +809,7 @@
     "CurrentSnapshotId" : "ballot-4-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "5",
     "CVRSnapshot" : [ {
       "@id" : "ballot-5",
@@ -1011,7 +1011,7 @@
     "CurrentSnapshotId" : "ballot-5-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "6",
     "CVRSnapshot" : [ {
       "@id" : "ballot-6",
@@ -1173,7 +1173,7 @@
     "CurrentSnapshotId" : "ballot-6-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "7",
     "CVRSnapshot" : [ {
       "@id" : "ballot-7",
@@ -1375,7 +1375,7 @@
     "CurrentSnapshotId" : "ballot-7-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "8",
     "CVRSnapshot" : [ {
       "@id" : "ballot-8",
@@ -1577,7 +1577,7 @@
     "CurrentSnapshotId" : "ballot-8-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "9",
     "CVRSnapshot" : [ {
       "@id" : "ballot-9",
@@ -1779,7 +1779,7 @@
     "CurrentSnapshotId" : "ballot-9-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "10",
     "CVRSnapshot" : [ {
       "@id" : "ballot-10",
@@ -1981,7 +1981,7 @@
     "CurrentSnapshotId" : "ballot-10-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "11",
     "CVRSnapshot" : [ {
       "@id" : "ballot-11",
@@ -2183,7 +2183,7 @@
     "CurrentSnapshotId" : "ballot-11-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "12",
     "CVRSnapshot" : [ {
       "@id" : "ballot-12",
@@ -2371,7 +2371,7 @@
   } ],
   "Election" : [ {
     "@id" : "election-001",
-    "@type" : "CVR.Election",
+    "@type" : "Election",
     "Candidate" : [ {
       "@id" : "c-candidate_a_name",
       "Name" : "Candidate A Name"
@@ -2387,32 +2387,32 @@
     } ],
     "Contest" : [ {
       "@id" : "contest-001",
-      "@type" : "CVR.CandidateContest",
+      "@type" : "CandidateContest",
       "ContestSelection" : [ {
         "@id" : "cs-candidate_a_name",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-candidate_a_name" ]
       }, {
         "@id" : "cs-candidate_b_name",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-candidate_b_name" ]
       }, {
         "@id" : "cs-candidate_c_name",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-candidate_c_name" ]
       }, {
         "@id" : "cs-candidate_d_name",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-candidate_d_name" ]
       } ],
       "Name" : "Test Set 0"
     } ],
     "ElectionScopeId" : "gpu-election"
   } ],
-  "GeneratedDate" : "2020-09-13T09:12:30-07:00",
+  "GeneratedDate" : "2020-10-03T14:33:56-07:00",
   "GpUnit" : [ {
     "@id" : "gpu-election",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "TestSets_Single_winner",
     "OtherType" : "Election Scope Jurisdiction",
     "Type" : "other"

--- a/src/test/resources/network/brightspots/rcv/test_data/test_set_1_exhaust_at_overvote/test_set_1_exhaust_at_overvote_expected_cvr_cdf.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/test_set_1_exhaust_at_overvote/test_set_1_exhaust_at_overvote_expected_cvr_cdf.json
@@ -1,7 +1,7 @@
 {
   "@type" : "CVR.CastVoteRecordReport",
   "CVR" : [ {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "1",
     "CVRSnapshot" : [ {
       "@id" : "ballot-1",
@@ -203,7 +203,7 @@
     "CurrentSnapshotId" : "ballot-1-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "2",
     "CVRSnapshot" : [ {
       "@id" : "ballot-2",
@@ -405,7 +405,7 @@
     "CurrentSnapshotId" : "ballot-2-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "3",
     "CVRSnapshot" : [ {
       "@id" : "ballot-3",
@@ -607,7 +607,7 @@
     "CurrentSnapshotId" : "ballot-3-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "4",
     "CVRSnapshot" : [ {
       "@id" : "ballot-4",
@@ -809,7 +809,7 @@
     "CurrentSnapshotId" : "ballot-4-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "5",
     "CVRSnapshot" : [ {
       "@id" : "ballot-5",
@@ -1011,7 +1011,7 @@
     "CurrentSnapshotId" : "ballot-5-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "6",
     "CVRSnapshot" : [ {
       "@id" : "ballot-6",
@@ -1213,7 +1213,7 @@
     "CurrentSnapshotId" : "ballot-6-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "7",
     "CVRSnapshot" : [ {
       "@id" : "ballot-7",
@@ -1415,7 +1415,7 @@
     "CurrentSnapshotId" : "ballot-7-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "8",
     "CVRSnapshot" : [ {
       "@id" : "ballot-8",
@@ -1617,7 +1617,7 @@
     "CurrentSnapshotId" : "ballot-8-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "9",
     "CVRSnapshot" : [ {
       "@id" : "ballot-9",
@@ -1819,7 +1819,7 @@
     "CurrentSnapshotId" : "ballot-9-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "10",
     "CVRSnapshot" : [ {
       "@id" : "ballot-10",
@@ -2021,7 +2021,7 @@
     "CurrentSnapshotId" : "ballot-10-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "11",
     "CVRSnapshot" : [ {
       "@id" : "ballot-11",
@@ -2223,7 +2223,7 @@
     "CurrentSnapshotId" : "ballot-11-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "12",
     "CVRSnapshot" : [ {
       "@id" : "ballot-12",
@@ -2425,7 +2425,7 @@
     "CurrentSnapshotId" : "ballot-12-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "13",
     "CVRSnapshot" : [ {
       "@id" : "ballot-13",
@@ -2547,7 +2547,7 @@
     "CurrentSnapshotId" : "ballot-13-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "14",
     "CVRSnapshot" : [ {
       "@id" : "ballot-14",
@@ -2709,7 +2709,7 @@
     "CurrentSnapshotId" : "ballot-14-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "15",
     "CVRSnapshot" : [ {
       "@id" : "ballot-15",
@@ -2913,7 +2913,7 @@
   } ],
   "Election" : [ {
     "@id" : "election-001",
-    "@type" : "CVR.Election",
+    "@type" : "Election",
     "Candidate" : [ {
       "@id" : "c-candidate_a_name",
       "Name" : "Candidate A Name"
@@ -2929,32 +2929,32 @@
     } ],
     "Contest" : [ {
       "@id" : "contest-001",
-      "@type" : "CVR.CandidateContest",
+      "@type" : "CandidateContest",
       "ContestSelection" : [ {
         "@id" : "cs-candidate_a_name",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-candidate_a_name" ]
       }, {
         "@id" : "cs-candidate_b_name",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-candidate_b_name" ]
       }, {
         "@id" : "cs-candidate_c_name",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-candidate_c_name" ]
       }, {
         "@id" : "cs-candidate_d_name",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-candidate_d_name" ]
       } ],
       "Name" : "test set 1"
     } ],
     "ElectionScopeId" : "gpu-election"
   } ],
-  "GeneratedDate" : "2020-09-13T14:45:45-07:00",
+  "GeneratedDate" : "2020-10-03T14:33:16-07:00",
   "GpUnit" : [ {
     "@id" : "gpu-election",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "TestSets_Single_winner",
     "OtherType" : "Election Scope Jurisdiction",
     "Type" : "other"

--- a/src/test/resources/network/brightspots/rcv/test_data/test_set_2_overvote_skip_to_next/test_set_2_overvote_skip_to_next_expected_cvr_cdf.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/test_set_2_overvote_skip_to_next/test_set_2_overvote_skip_to_next_expected_cvr_cdf.json
@@ -1,7 +1,7 @@
 {
   "@type" : "CVR.CastVoteRecordReport",
   "CVR" : [ {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "1",
     "CVRSnapshot" : [ {
       "@id" : "ballot-1",
@@ -203,7 +203,7 @@
     "CurrentSnapshotId" : "ballot-1-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "2",
     "CVRSnapshot" : [ {
       "@id" : "ballot-2",
@@ -405,7 +405,7 @@
     "CurrentSnapshotId" : "ballot-2-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "3",
     "CVRSnapshot" : [ {
       "@id" : "ballot-3",
@@ -607,7 +607,7 @@
     "CurrentSnapshotId" : "ballot-3-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "4",
     "CVRSnapshot" : [ {
       "@id" : "ballot-4",
@@ -809,7 +809,7 @@
     "CurrentSnapshotId" : "ballot-4-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "5",
     "CVRSnapshot" : [ {
       "@id" : "ballot-5",
@@ -1011,7 +1011,7 @@
     "CurrentSnapshotId" : "ballot-5-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "6",
     "CVRSnapshot" : [ {
       "@id" : "ballot-6",
@@ -1213,7 +1213,7 @@
     "CurrentSnapshotId" : "ballot-6-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "7",
     "CVRSnapshot" : [ {
       "@id" : "ballot-7",
@@ -1415,7 +1415,7 @@
     "CurrentSnapshotId" : "ballot-7-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "8",
     "CVRSnapshot" : [ {
       "@id" : "ballot-8",
@@ -1617,7 +1617,7 @@
     "CurrentSnapshotId" : "ballot-8-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "9",
     "CVRSnapshot" : [ {
       "@id" : "ballot-9",
@@ -1819,7 +1819,7 @@
     "CurrentSnapshotId" : "ballot-9-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "10",
     "CVRSnapshot" : [ {
       "@id" : "ballot-10",
@@ -2021,7 +2021,7 @@
     "CurrentSnapshotId" : "ballot-10-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "11",
     "CVRSnapshot" : [ {
       "@id" : "ballot-11",
@@ -2223,7 +2223,7 @@
     "CurrentSnapshotId" : "ballot-11-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "12",
     "CVRSnapshot" : [ {
       "@id" : "ballot-12",
@@ -2425,7 +2425,7 @@
     "CurrentSnapshotId" : "ballot-12-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "13",
     "CVRSnapshot" : [ {
       "@id" : "ballot-13",
@@ -2547,7 +2547,7 @@
     "CurrentSnapshotId" : "ballot-13-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "14",
     "CVRSnapshot" : [ {
       "@id" : "ballot-14",
@@ -2709,7 +2709,7 @@
     "CurrentSnapshotId" : "ballot-14-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "15",
     "CVRSnapshot" : [ {
       "@id" : "ballot-15",
@@ -2913,7 +2913,7 @@
   } ],
   "Election" : [ {
     "@id" : "election-001",
-    "@type" : "CVR.Election",
+    "@type" : "Election",
     "Candidate" : [ {
       "@id" : "c-candidate_a_name",
       "Name" : "Candidate A Name"
@@ -2929,32 +2929,32 @@
     } ],
     "Contest" : [ {
       "@id" : "contest-001",
-      "@type" : "CVR.CandidateContest",
+      "@type" : "CandidateContest",
       "ContestSelection" : [ {
         "@id" : "cs-candidate_a_name",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-candidate_a_name" ]
       }, {
         "@id" : "cs-candidate_b_name",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-candidate_b_name" ]
       }, {
         "@id" : "cs-candidate_c_name",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-candidate_c_name" ]
       }, {
         "@id" : "cs-candidate_d_name",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-candidate_d_name" ]
       } ],
       "Name" : "overvote skips to next rank"
     } ],
     "ElectionScopeId" : "gpu-election"
   } ],
-  "GeneratedDate" : "2020-09-13T11:02:06-07:00",
+  "GeneratedDate" : "2020-10-03T12:36:29-07:00",
   "GpUnit" : [ {
     "@id" : "gpu-election",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "TestSets_Single_winner",
     "OtherType" : "Election Scope Jurisdiction",
     "Type" : "other"

--- a/src/test/resources/network/brightspots/rcv/test_data/test_set_3_skipped_choice_exhaust/test_set_3_skipped_choice_exhaust_expected_cvr_cdf.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/test_set_3_skipped_choice_exhaust/test_set_3_skipped_choice_exhaust_expected_cvr_cdf.json
@@ -1,7 +1,7 @@
 {
   "@type" : "CVR.CastVoteRecordReport",
   "CVR" : [ {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "1",
     "CVRSnapshot" : [ {
       "@id" : "ballot-1",
@@ -123,7 +123,7 @@
     "CurrentSnapshotId" : "ballot-1-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "2",
     "CVRSnapshot" : [ {
       "@id" : "ballot-2",
@@ -325,7 +325,7 @@
     "CurrentSnapshotId" : "ballot-2-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "3",
     "CVRSnapshot" : [ {
       "@id" : "ballot-3",
@@ -527,7 +527,7 @@
     "CurrentSnapshotId" : "ballot-3-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "4",
     "CVRSnapshot" : [ {
       "@id" : "ballot-4",
@@ -729,7 +729,7 @@
     "CurrentSnapshotId" : "ballot-4-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "5",
     "CVRSnapshot" : [ {
       "@id" : "ballot-5",
@@ -931,7 +931,7 @@
     "CurrentSnapshotId" : "ballot-5-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "6",
     "CVRSnapshot" : [ {
       "@id" : "ballot-6",
@@ -1133,7 +1133,7 @@
     "CurrentSnapshotId" : "ballot-6-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "7",
     "CVRSnapshot" : [ {
       "@id" : "ballot-7",
@@ -1335,7 +1335,7 @@
     "CurrentSnapshotId" : "ballot-7-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "8",
     "CVRSnapshot" : [ {
       "@id" : "ballot-8",
@@ -1497,7 +1497,7 @@
     "CurrentSnapshotId" : "ballot-8-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "9",
     "CVRSnapshot" : [ {
       "@id" : "ballot-9",
@@ -1699,7 +1699,7 @@
     "CurrentSnapshotId" : "ballot-9-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "10",
     "CVRSnapshot" : [ {
       "@id" : "ballot-10",
@@ -1901,7 +1901,7 @@
     "CurrentSnapshotId" : "ballot-10-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "11",
     "CVRSnapshot" : [ {
       "@id" : "ballot-11",
@@ -2103,7 +2103,7 @@
     "CurrentSnapshotId" : "ballot-11-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "12",
     "CVRSnapshot" : [ {
       "@id" : "ballot-12",
@@ -2305,7 +2305,7 @@
     "CurrentSnapshotId" : "ballot-12-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "13",
     "CVRSnapshot" : [ {
       "@id" : "ballot-13",
@@ -2427,7 +2427,7 @@
     "CurrentSnapshotId" : "ballot-13-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "14",
     "CVRSnapshot" : [ {
       "@id" : "ballot-14",
@@ -2589,7 +2589,7 @@
     "CurrentSnapshotId" : "ballot-14-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "15",
     "CVRSnapshot" : [ {
       "@id" : "ballot-15",
@@ -2793,7 +2793,7 @@
   } ],
   "Election" : [ {
     "@id" : "election-001",
-    "@type" : "CVR.Election",
+    "@type" : "Election",
     "Candidate" : [ {
       "@id" : "c-candidate_a_name",
       "Name" : "Candidate A Name"
@@ -2809,32 +2809,32 @@
     } ],
     "Contest" : [ {
       "@id" : "contest-001",
-      "@type" : "CVR.CandidateContest",
+      "@type" : "CandidateContest",
       "ContestSelection" : [ {
         "@id" : "cs-candidate_a_name",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-candidate_a_name" ]
       }, {
         "@id" : "cs-candidate_b_name",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-candidate_b_name" ]
       }, {
         "@id" : "cs-candidate_c_name",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-candidate_c_name" ]
       }, {
         "@id" : "cs-candidate_d_name",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-candidate_d_name" ]
       } ],
       "Name" : "test set 3"
     } ],
     "ElectionScopeId" : "gpu-election"
   } ],
-  "GeneratedDate" : "2020-09-13T14:47:03-07:00",
+  "GeneratedDate" : "2020-10-03T12:36:29-07:00",
   "GpUnit" : [ {
     "@id" : "gpu-election",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "Funkytown, USA",
     "OtherType" : "Election Scope Jurisdiction",
     "Type" : "other"

--- a/src/test/resources/network/brightspots/rcv/test_data/test_set_4_skipped_choice_next/test_set_4_skipped_choice_next_expected_cvr_cdf.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/test_set_4_skipped_choice_next/test_set_4_skipped_choice_next_expected_cvr_cdf.json
@@ -1,7 +1,7 @@
 {
   "@type" : "CVR.CastVoteRecordReport",
   "CVR" : [ {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "1",
     "CVRSnapshot" : [ {
       "@id" : "ballot-1",
@@ -123,7 +123,7 @@
     "CurrentSnapshotId" : "ballot-1-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "2",
     "CVRSnapshot" : [ {
       "@id" : "ballot-2",
@@ -325,7 +325,7 @@
     "CurrentSnapshotId" : "ballot-2-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "3",
     "CVRSnapshot" : [ {
       "@id" : "ballot-3",
@@ -527,7 +527,7 @@
     "CurrentSnapshotId" : "ballot-3-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "4",
     "CVRSnapshot" : [ {
       "@id" : "ballot-4",
@@ -729,7 +729,7 @@
     "CurrentSnapshotId" : "ballot-4-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "5",
     "CVRSnapshot" : [ {
       "@id" : "ballot-5",
@@ -931,7 +931,7 @@
     "CurrentSnapshotId" : "ballot-5-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "6",
     "CVRSnapshot" : [ {
       "@id" : "ballot-6",
@@ -1133,7 +1133,7 @@
     "CurrentSnapshotId" : "ballot-6-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "7",
     "CVRSnapshot" : [ {
       "@id" : "ballot-7",
@@ -1335,7 +1335,7 @@
     "CurrentSnapshotId" : "ballot-7-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "8",
     "CVRSnapshot" : [ {
       "@id" : "ballot-8",
@@ -1497,7 +1497,7 @@
     "CurrentSnapshotId" : "ballot-8-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "9",
     "CVRSnapshot" : [ {
       "@id" : "ballot-9",
@@ -1699,7 +1699,7 @@
     "CurrentSnapshotId" : "ballot-9-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "10",
     "CVRSnapshot" : [ {
       "@id" : "ballot-10",
@@ -1901,7 +1901,7 @@
     "CurrentSnapshotId" : "ballot-10-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "11",
     "CVRSnapshot" : [ {
       "@id" : "ballot-11",
@@ -2103,7 +2103,7 @@
     "CurrentSnapshotId" : "ballot-11-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "12",
     "CVRSnapshot" : [ {
       "@id" : "ballot-12",
@@ -2305,7 +2305,7 @@
     "CurrentSnapshotId" : "ballot-12-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "13",
     "CVRSnapshot" : [ {
       "@id" : "ballot-13",
@@ -2427,7 +2427,7 @@
     "CurrentSnapshotId" : "ballot-13-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "14",
     "CVRSnapshot" : [ {
       "@id" : "ballot-14",
@@ -2589,7 +2589,7 @@
     "CurrentSnapshotId" : "ballot-14-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "15",
     "CVRSnapshot" : [ {
       "@id" : "ballot-15",
@@ -2793,7 +2793,7 @@
   } ],
   "Election" : [ {
     "@id" : "election-001",
-    "@type" : "CVR.Election",
+    "@type" : "Election",
     "Candidate" : [ {
       "@id" : "c-candidate_a_name",
       "Name" : "Candidate A Name"
@@ -2809,32 +2809,32 @@
     } ],
     "Contest" : [ {
       "@id" : "contest-001",
-      "@type" : "CVR.CandidateContest",
+      "@type" : "CandidateContest",
       "ContestSelection" : [ {
         "@id" : "cs-candidate_a_name",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-candidate_a_name" ]
       }, {
         "@id" : "cs-candidate_b_name",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-candidate_b_name" ]
       }, {
         "@id" : "cs-candidate_c_name",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-candidate_c_name" ]
       }, {
         "@id" : "cs-candidate_d_name",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-candidate_d_name" ]
       } ],
       "Name" : "test set 4"
     } ],
     "ElectionScopeId" : "gpu-election"
   } ],
-  "GeneratedDate" : "2020-09-13T14:51:06-07:00",
+  "GeneratedDate" : "2020-10-03T14:31:30-07:00",
   "GpUnit" : [ {
     "@id" : "gpu-election",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "TestSets_Single_winner",
     "OtherType" : "Election Scope Jurisdiction",
     "Type" : "other"

--- a/src/test/resources/network/brightspots/rcv/test_data/test_set_5_two_skipped_choice_exhaust/test_set_5_two_skipped_choice_exhaust_expected_cvr_cdf.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/test_set_5_two_skipped_choice_exhaust/test_set_5_two_skipped_choice_exhaust_expected_cvr_cdf.json
@@ -1,7 +1,7 @@
 {
   "@type" : "CVR.CastVoteRecordReport",
   "CVR" : [ {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "1",
     "CVRSnapshot" : [ {
       "@id" : "ballot-1",
@@ -123,7 +123,7 @@
     "CurrentSnapshotId" : "ballot-1-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "2",
     "CVRSnapshot" : [ {
       "@id" : "ballot-2",
@@ -325,7 +325,7 @@
     "CurrentSnapshotId" : "ballot-2-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "3",
     "CVRSnapshot" : [ {
       "@id" : "ballot-3",
@@ -527,7 +527,7 @@
     "CurrentSnapshotId" : "ballot-3-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "4",
     "CVRSnapshot" : [ {
       "@id" : "ballot-4",
@@ -729,7 +729,7 @@
     "CurrentSnapshotId" : "ballot-4-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "5",
     "CVRSnapshot" : [ {
       "@id" : "ballot-5",
@@ -931,7 +931,7 @@
     "CurrentSnapshotId" : "ballot-5-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "6",
     "CVRSnapshot" : [ {
       "@id" : "ballot-6",
@@ -1133,7 +1133,7 @@
     "CurrentSnapshotId" : "ballot-6-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "7",
     "CVRSnapshot" : [ {
       "@id" : "ballot-7",
@@ -1335,7 +1335,7 @@
     "CurrentSnapshotId" : "ballot-7-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "8",
     "CVRSnapshot" : [ {
       "@id" : "ballot-8",
@@ -1497,7 +1497,7 @@
     "CurrentSnapshotId" : "ballot-8-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "9",
     "CVRSnapshot" : [ {
       "@id" : "ballot-9",
@@ -1699,7 +1699,7 @@
     "CurrentSnapshotId" : "ballot-9-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "10",
     "CVRSnapshot" : [ {
       "@id" : "ballot-10",
@@ -1901,7 +1901,7 @@
     "CurrentSnapshotId" : "ballot-10-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "11",
     "CVRSnapshot" : [ {
       "@id" : "ballot-11",
@@ -2103,7 +2103,7 @@
     "CurrentSnapshotId" : "ballot-11-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "12",
     "CVRSnapshot" : [ {
       "@id" : "ballot-12",
@@ -2305,7 +2305,7 @@
     "CurrentSnapshotId" : "ballot-12-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "13",
     "CVRSnapshot" : [ {
       "@id" : "ballot-13",
@@ -2427,7 +2427,7 @@
     "CurrentSnapshotId" : "ballot-13-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "14",
     "CVRSnapshot" : [ {
       "@id" : "ballot-14",
@@ -2589,7 +2589,7 @@
     "CurrentSnapshotId" : "ballot-14-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "15",
     "CVRSnapshot" : [ {
       "@id" : "ballot-15",
@@ -2793,7 +2793,7 @@
   } ],
   "Election" : [ {
     "@id" : "election-001",
-    "@type" : "CVR.Election",
+    "@type" : "Election",
     "Candidate" : [ {
       "@id" : "c-candidate_a_name",
       "Name" : "Candidate A Name"
@@ -2809,32 +2809,32 @@
     } ],
     "Contest" : [ {
       "@id" : "contest-001",
-      "@type" : "CVR.CandidateContest",
+      "@type" : "CandidateContest",
       "ContestSelection" : [ {
         "@id" : "cs-candidate_a_name",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-candidate_a_name" ]
       }, {
         "@id" : "cs-candidate_b_name",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-candidate_b_name" ]
       }, {
         "@id" : "cs-candidate_c_name",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-candidate_c_name" ]
       }, {
         "@id" : "cs-candidate_d_name",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-candidate_d_name" ]
       } ],
       "Name" : "Test Set 5"
     } ],
     "ElectionScopeId" : "gpu-election"
   } ],
-  "GeneratedDate" : "2020-09-13T14:48:19-07:00",
+  "GeneratedDate" : "2020-10-03T14:30:21-07:00",
   "GpUnit" : [ {
     "@id" : "gpu-election",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "TestSets_Single_winner",
     "OtherType" : "Election Scope Jurisdiction",
     "Type" : "other"

--- a/src/test/resources/network/brightspots/rcv/test_data/test_set_6_duplicate_exhaust/test_set_6_duplicate_exhaust_expected_cvr_cdf.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/test_set_6_duplicate_exhaust/test_set_6_duplicate_exhaust_expected_cvr_cdf.json
@@ -1,7 +1,7 @@
 {
   "@type" : "CVR.CastVoteRecordReport",
   "CVR" : [ {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "1",
     "CVRSnapshot" : [ {
       "@id" : "ballot-1",
@@ -147,7 +147,7 @@
     "CurrentSnapshotId" : "ballot-1-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "2",
     "CVRSnapshot" : [ {
       "@id" : "ballot-2",
@@ -333,7 +333,7 @@
     "CurrentSnapshotId" : "ballot-2-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "3",
     "CVRSnapshot" : [ {
       "@id" : "ballot-3",
@@ -535,7 +535,7 @@
     "CurrentSnapshotId" : "ballot-3-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "4",
     "CVRSnapshot" : [ {
       "@id" : "ballot-4",
@@ -737,7 +737,7 @@
     "CurrentSnapshotId" : "ballot-4-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "5",
     "CVRSnapshot" : [ {
       "@id" : "ballot-5",
@@ -939,7 +939,7 @@
     "CurrentSnapshotId" : "ballot-5-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "6",
     "CVRSnapshot" : [ {
       "@id" : "ballot-6",
@@ -1141,7 +1141,7 @@
     "CurrentSnapshotId" : "ballot-6-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "7",
     "CVRSnapshot" : [ {
       "@id" : "ballot-7",
@@ -1343,7 +1343,7 @@
     "CurrentSnapshotId" : "ballot-7-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "8",
     "CVRSnapshot" : [ {
       "@id" : "ballot-8",
@@ -1505,7 +1505,7 @@
     "CurrentSnapshotId" : "ballot-8-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "9",
     "CVRSnapshot" : [ {
       "@id" : "ballot-9",
@@ -1707,7 +1707,7 @@
     "CurrentSnapshotId" : "ballot-9-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "10",
     "CVRSnapshot" : [ {
       "@id" : "ballot-10",
@@ -1909,7 +1909,7 @@
     "CurrentSnapshotId" : "ballot-10-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "11",
     "CVRSnapshot" : [ {
       "@id" : "ballot-11",
@@ -2095,7 +2095,7 @@
     "CurrentSnapshotId" : "ballot-11-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "12",
     "CVRSnapshot" : [ {
       "@id" : "ballot-12",
@@ -2297,7 +2297,7 @@
     "CurrentSnapshotId" : "ballot-12-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "13",
     "CVRSnapshot" : [ {
       "@id" : "ballot-13",
@@ -2419,7 +2419,7 @@
     "CurrentSnapshotId" : "ballot-13-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "14",
     "CVRSnapshot" : [ {
       "@id" : "ballot-14",
@@ -2581,7 +2581,7 @@
     "CurrentSnapshotId" : "ballot-14-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "15",
     "CVRSnapshot" : [ {
       "@id" : "ballot-15",
@@ -2785,7 +2785,7 @@
   } ],
   "Election" : [ {
     "@id" : "election-001",
-    "@type" : "CVR.Election",
+    "@type" : "Election",
     "Candidate" : [ {
       "@id" : "c-candidate_a_name",
       "Name" : "Candidate A Name"
@@ -2801,32 +2801,32 @@
     } ],
     "Contest" : [ {
       "@id" : "contest-001",
-      "@type" : "CVR.CandidateContest",
+      "@type" : "CandidateContest",
       "ContestSelection" : [ {
         "@id" : "cs-candidate_a_name",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-candidate_a_name" ]
       }, {
         "@id" : "cs-candidate_b_name",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-candidate_b_name" ]
       }, {
         "@id" : "cs-candidate_c_name",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-candidate_c_name" ]
       }, {
         "@id" : "cs-candidate_d_name",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-candidate_d_name" ]
       } ],
       "Name" : "test set 6"
     } ],
     "ElectionScopeId" : "gpu-election"
   } ],
-  "GeneratedDate" : "2020-09-13T14:48:35-07:00",
+  "GeneratedDate" : "2020-10-03T14:20:55-07:00",
   "GpUnit" : [ {
     "@id" : "gpu-election",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "TestSets_Single_winner",
     "OtherType" : "Election Scope Jurisdiction",
     "Type" : "other"

--- a/src/test/resources/network/brightspots/rcv/test_data/test_set_7_duplicate_skip_to_next/test_set_7_duplicate_skip_to_next_expected_cvr_cdf.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/test_set_7_duplicate_skip_to_next/test_set_7_duplicate_skip_to_next_expected_cvr_cdf.json
@@ -1,7 +1,7 @@
 {
   "@type" : "CVR.CastVoteRecordReport",
   "CVR" : [ {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "1",
     "CVRSnapshot" : [ {
       "@id" : "ballot-1",
@@ -147,7 +147,7 @@
     "CurrentSnapshotId" : "ballot-1-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "2",
     "CVRSnapshot" : [ {
       "@id" : "ballot-2",
@@ -349,7 +349,7 @@
     "CurrentSnapshotId" : "ballot-2-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "3",
     "CVRSnapshot" : [ {
       "@id" : "ballot-3",
@@ -551,7 +551,7 @@
     "CurrentSnapshotId" : "ballot-3-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "4",
     "CVRSnapshot" : [ {
       "@id" : "ballot-4",
@@ -753,7 +753,7 @@
     "CurrentSnapshotId" : "ballot-4-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "5",
     "CVRSnapshot" : [ {
       "@id" : "ballot-5",
@@ -955,7 +955,7 @@
     "CurrentSnapshotId" : "ballot-5-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "6",
     "CVRSnapshot" : [ {
       "@id" : "ballot-6",
@@ -1157,7 +1157,7 @@
     "CurrentSnapshotId" : "ballot-6-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "7",
     "CVRSnapshot" : [ {
       "@id" : "ballot-7",
@@ -1359,7 +1359,7 @@
     "CurrentSnapshotId" : "ballot-7-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "8",
     "CVRSnapshot" : [ {
       "@id" : "ballot-8",
@@ -1521,7 +1521,7 @@
     "CurrentSnapshotId" : "ballot-8-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "9",
     "CVRSnapshot" : [ {
       "@id" : "ballot-9",
@@ -1723,7 +1723,7 @@
     "CurrentSnapshotId" : "ballot-9-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "10",
     "CVRSnapshot" : [ {
       "@id" : "ballot-10",
@@ -1925,7 +1925,7 @@
     "CurrentSnapshotId" : "ballot-10-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "11",
     "CVRSnapshot" : [ {
       "@id" : "ballot-11",
@@ -2127,7 +2127,7 @@
     "CurrentSnapshotId" : "ballot-11-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "12",
     "CVRSnapshot" : [ {
       "@id" : "ballot-12",
@@ -2329,7 +2329,7 @@
     "CurrentSnapshotId" : "ballot-12-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "13",
     "CVRSnapshot" : [ {
       "@id" : "ballot-13",
@@ -2451,7 +2451,7 @@
     "CurrentSnapshotId" : "ballot-13-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "14",
     "CVRSnapshot" : [ {
       "@id" : "ballot-14",
@@ -2613,7 +2613,7 @@
     "CurrentSnapshotId" : "ballot-14-round-3",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "15",
     "CVRSnapshot" : [ {
       "@id" : "ballot-15",
@@ -2817,7 +2817,7 @@
   } ],
   "Election" : [ {
     "@id" : "election-001",
-    "@type" : "CVR.Election",
+    "@type" : "Election",
     "Candidate" : [ {
       "@id" : "c-candidate_a_name",
       "Name" : "Candidate A Name"
@@ -2833,32 +2833,32 @@
     } ],
     "Contest" : [ {
       "@id" : "contest-001",
-      "@type" : "CVR.CandidateContest",
+      "@type" : "CandidateContest",
       "ContestSelection" : [ {
         "@id" : "cs-candidate_a_name",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-candidate_a_name" ]
       }, {
         "@id" : "cs-candidate_b_name",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-candidate_b_name" ]
       }, {
         "@id" : "cs-candidate_c_name",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-candidate_c_name" ]
       }, {
         "@id" : "cs-candidate_d_name",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-candidate_d_name" ]
       } ],
       "Name" : "Test Set 6"
     } ],
     "ElectionScopeId" : "gpu-election"
   } ],
-  "GeneratedDate" : "2020-09-13T14:48:50-07:00",
+  "GeneratedDate" : "2020-10-03T14:25:09-07:00",
   "GpUnit" : [ {
     "@id" : "gpu-election",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "TestSets_Single_winner",
     "OtherType" : "Election Scope Jurisdiction",
     "Type" : "other"

--- a/src/test/resources/network/brightspots/rcv/test_data/test_set_multi_winner_fractional_threshold/test_set_multi_winner_fractional_threshold_expected_cvr_cdf.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/test_set_multi_winner_fractional_threshold/test_set_multi_winner_fractional_threshold_expected_cvr_cdf.json
@@ -1,7 +1,7 @@
 {
   "@type" : "CVR.CastVoteRecordReport",
   "CVR" : [ {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "1",
     "CVRSnapshot" : [ {
       "@id" : "ballot-1",
@@ -428,7 +428,7 @@
     "CurrentSnapshotId" : "ballot-1-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "2",
     "CVRSnapshot" : [ {
       "@id" : "ballot-2",
@@ -918,7 +918,7 @@
     "CurrentSnapshotId" : "ballot-2-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "3",
     "CVRSnapshot" : [ {
       "@id" : "ballot-3",
@@ -1415,7 +1415,7 @@
     "CurrentSnapshotId" : "ballot-3-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "4",
     "CVRSnapshot" : [ {
       "@id" : "ballot-4",
@@ -1765,7 +1765,7 @@
     "CurrentSnapshotId" : "ballot-4-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "5",
     "CVRSnapshot" : [ {
       "@id" : "ballot-5",
@@ -1975,7 +1975,7 @@
     "CurrentSnapshotId" : "ballot-5-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "6",
     "CVRSnapshot" : [ {
       "@id" : "ballot-6",
@@ -2465,7 +2465,7 @@
     "CurrentSnapshotId" : "ballot-6-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "7",
     "CVRSnapshot" : [ {
       "@id" : "ballot-7",
@@ -2815,7 +2815,7 @@
     "CurrentSnapshotId" : "ballot-7-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "8",
     "CVRSnapshot" : [ {
       "@id" : "ballot-8",
@@ -3235,7 +3235,7 @@
     "CurrentSnapshotId" : "ballot-8-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "9",
     "CVRSnapshot" : [ {
       "@id" : "ballot-9",
@@ -3662,7 +3662,7 @@
     "CurrentSnapshotId" : "ballot-9-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "10",
     "CVRSnapshot" : [ {
       "@id" : "ballot-10",
@@ -3801,7 +3801,7 @@
     "CurrentSnapshotId" : "ballot-10-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "11",
     "CVRSnapshot" : [ {
       "@id" : "ballot-11",
@@ -4086,7 +4086,7 @@
     "CurrentSnapshotId" : "ballot-11-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "12",
     "CVRSnapshot" : [ {
       "@id" : "ballot-12",
@@ -4548,7 +4548,7 @@
     "CurrentSnapshotId" : "ballot-12-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "13",
     "CVRSnapshot" : [ {
       "@id" : "ballot-13",
@@ -4903,7 +4903,7 @@
     "CurrentSnapshotId" : "ballot-13-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "14",
     "CVRSnapshot" : [ {
       "@id" : "ballot-14",
@@ -5323,7 +5323,7 @@
     "CurrentSnapshotId" : "ballot-14-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "15",
     "CVRSnapshot" : [ {
       "@id" : "ballot-15",
@@ -5813,7 +5813,7 @@
     "CurrentSnapshotId" : "ballot-15-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "16",
     "CVRSnapshot" : [ {
       "@id" : "ballot-16",
@@ -6162,7 +6162,7 @@
     "CurrentSnapshotId" : "ballot-16-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "17",
     "CVRSnapshot" : [ {
       "@id" : "ballot-17",
@@ -6652,7 +6652,7 @@
     "CurrentSnapshotId" : "ballot-17-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "18",
     "CVRSnapshot" : [ {
       "@id" : "ballot-18",
@@ -7149,7 +7149,7 @@
     "CurrentSnapshotId" : "ballot-18-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "19",
     "CVRSnapshot" : [ {
       "@id" : "ballot-19",
@@ -7499,7 +7499,7 @@
     "CurrentSnapshotId" : "ballot-19-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "20",
     "CVRSnapshot" : [ {
       "@id" : "ballot-20",
@@ -7709,7 +7709,7 @@
     "CurrentSnapshotId" : "ballot-20-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "21",
     "CVRSnapshot" : [ {
       "@id" : "ballot-21",
@@ -8199,7 +8199,7 @@
     "CurrentSnapshotId" : "ballot-21-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "22",
     "CVRSnapshot" : [ {
       "@id" : "ballot-22",
@@ -8549,7 +8549,7 @@
     "CurrentSnapshotId" : "ballot-22-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "23",
     "CVRSnapshot" : [ {
       "@id" : "ballot-23",
@@ -8969,7 +8969,7 @@
     "CurrentSnapshotId" : "ballot-23-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "24",
     "CVRSnapshot" : [ {
       "@id" : "ballot-24",
@@ -9459,7 +9459,7 @@
     "CurrentSnapshotId" : "ballot-24-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "25",
     "CVRSnapshot" : [ {
       "@id" : "ballot-25",
@@ -9669,7 +9669,7 @@
     "CurrentSnapshotId" : "ballot-25-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "26",
     "CVRSnapshot" : [ {
       "@id" : "ballot-26",
@@ -9954,7 +9954,7 @@
     "CurrentSnapshotId" : "ballot-26-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "27",
     "CVRSnapshot" : [ {
       "@id" : "ballot-27",
@@ -10444,7 +10444,7 @@
     "CurrentSnapshotId" : "ballot-27-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "28",
     "CVRSnapshot" : [ {
       "@id" : "ballot-28",
@@ -10799,7 +10799,7 @@
     "CurrentSnapshotId" : "ballot-28-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "29",
     "CVRSnapshot" : [ {
       "@id" : "ballot-29",
@@ -11219,7 +11219,7 @@
     "CurrentSnapshotId" : "ballot-29-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "30",
     "CVRSnapshot" : [ {
       "@id" : "ballot-30",
@@ -11711,7 +11711,7 @@
   } ],
   "Election" : [ {
     "@id" : "election-001",
-    "@type" : "CVR.Election",
+    "@type" : "Election",
     "Candidate" : [ {
       "@id" : "c-candidate_a_name",
       "Name" : "Candidate A Name"
@@ -11733,40 +11733,40 @@
     } ],
     "Contest" : [ {
       "@id" : "contest-001",
-      "@type" : "CVR.CandidateContest",
+      "@type" : "CandidateContest",
       "ContestSelection" : [ {
         "@id" : "cs-candidate_a_name",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-candidate_a_name" ]
       }, {
         "@id" : "cs-candidate_b_name",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-candidate_b_name" ]
       }, {
         "@id" : "cs-candidate_c_name",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-candidate_c_name" ]
       }, {
         "@id" : "cs-candidate_d_name",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-candidate_d_name" ]
       }, {
         "@id" : "cs-candidate_e_name",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-candidate_e_name" ]
       }, {
         "@id" : "cs-candidate_f_name",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-candidate_f_name" ]
       } ],
       "Name" : "test set multi winner fractional"
     } ],
     "ElectionScopeId" : "gpu-election"
   } ],
-  "GeneratedDate" : "2020-09-13T15:13:47-07:00",
+  "GeneratedDate" : "2020-10-03T14:34:33-07:00",
   "GpUnit" : [ {
     "@id" : "gpu-election",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "Multi-winner",
     "OtherType" : "Election Scope Jurisdiction",
     "Type" : "other"

--- a/src/test/resources/network/brightspots/rcv/test_data/test_set_multi_winner_whole_threshold/test_set_multi_winner_whole_threshold_expected_cvr_cdf.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/test_set_multi_winner_whole_threshold/test_set_multi_winner_whole_threshold_expected_cvr_cdf.json
@@ -1,7 +1,7 @@
 {
   "@type" : "CVR.CastVoteRecordReport",
   "CVR" : [ {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "1",
     "CVRSnapshot" : [ {
       "@id" : "ballot-1",
@@ -421,7 +421,7 @@
     "CurrentSnapshotId" : "ballot-1-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "2",
     "CVRSnapshot" : [ {
       "@id" : "ballot-2",
@@ -920,7 +920,7 @@
     "CurrentSnapshotId" : "ballot-2-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "3",
     "CVRSnapshot" : [ {
       "@id" : "ballot-3",
@@ -1419,7 +1419,7 @@
     "CurrentSnapshotId" : "ballot-3-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "4",
     "CVRSnapshot" : [ {
       "@id" : "ballot-4",
@@ -1769,7 +1769,7 @@
     "CurrentSnapshotId" : "ballot-4-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "5",
     "CVRSnapshot" : [ {
       "@id" : "ballot-5",
@@ -1979,7 +1979,7 @@
     "CurrentSnapshotId" : "ballot-5-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "6",
     "CVRSnapshot" : [ {
       "@id" : "ballot-6",
@@ -2469,7 +2469,7 @@
     "CurrentSnapshotId" : "ballot-6-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "7",
     "CVRSnapshot" : [ {
       "@id" : "ballot-7",
@@ -2819,7 +2819,7 @@
     "CurrentSnapshotId" : "ballot-7-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "8",
     "CVRSnapshot" : [ {
       "@id" : "ballot-8",
@@ -3239,7 +3239,7 @@
     "CurrentSnapshotId" : "ballot-8-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "9",
     "CVRSnapshot" : [ {
       "@id" : "ballot-9",
@@ -3668,7 +3668,7 @@
     "CurrentSnapshotId" : "ballot-9-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "10",
     "CVRSnapshot" : [ {
       "@id" : "ballot-10",
@@ -3807,7 +3807,7 @@
     "CurrentSnapshotId" : "ballot-10-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "11",
     "CVRSnapshot" : [ {
       "@id" : "ballot-11",
@@ -4094,7 +4094,7 @@
     "CurrentSnapshotId" : "ballot-11-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "12",
     "CVRSnapshot" : [ {
       "@id" : "ballot-12",
@@ -4556,7 +4556,7 @@
     "CurrentSnapshotId" : "ballot-12-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "13",
     "CVRSnapshot" : [ {
       "@id" : "ballot-13",
@@ -4913,7 +4913,7 @@
     "CurrentSnapshotId" : "ballot-13-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "14",
     "CVRSnapshot" : [ {
       "@id" : "ballot-14",
@@ -5342,7 +5342,7 @@
     "CurrentSnapshotId" : "ballot-14-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "15",
     "CVRSnapshot" : [ {
       "@id" : "ballot-15",
@@ -5832,7 +5832,7 @@
     "CurrentSnapshotId" : "ballot-15-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "16",
     "CVRSnapshot" : [ {
       "@id" : "ballot-16",
@@ -6181,7 +6181,7 @@
     "CurrentSnapshotId" : "ballot-16-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "17",
     "CVRSnapshot" : [ {
       "@id" : "ballot-17",
@@ -6671,7 +6671,7 @@
     "CurrentSnapshotId" : "ballot-17-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "18",
     "CVRSnapshot" : [ {
       "@id" : "ballot-18",
@@ -7170,7 +7170,7 @@
     "CurrentSnapshotId" : "ballot-18-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "19",
     "CVRSnapshot" : [ {
       "@id" : "ballot-19",
@@ -7520,7 +7520,7 @@
     "CurrentSnapshotId" : "ballot-19-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "20",
     "CVRSnapshot" : [ {
       "@id" : "ballot-20",
@@ -7730,7 +7730,7 @@
     "CurrentSnapshotId" : "ballot-20-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "21",
     "CVRSnapshot" : [ {
       "@id" : "ballot-21",
@@ -8220,7 +8220,7 @@
     "CurrentSnapshotId" : "ballot-21-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "22",
     "CVRSnapshot" : [ {
       "@id" : "ballot-22",
@@ -8570,7 +8570,7 @@
     "CurrentSnapshotId" : "ballot-22-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "23",
     "CVRSnapshot" : [ {
       "@id" : "ballot-23",
@@ -8990,7 +8990,7 @@
     "CurrentSnapshotId" : "ballot-23-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "24",
     "CVRSnapshot" : [ {
       "@id" : "ballot-24",
@@ -9480,7 +9480,7 @@
     "CurrentSnapshotId" : "ballot-24-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "25",
     "CVRSnapshot" : [ {
       "@id" : "ballot-25",
@@ -9690,7 +9690,7 @@
     "CurrentSnapshotId" : "ballot-25-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "26",
     "CVRSnapshot" : [ {
       "@id" : "ballot-26",
@@ -9977,7 +9977,7 @@
     "CurrentSnapshotId" : "ballot-26-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "27",
     "CVRSnapshot" : [ {
       "@id" : "ballot-27",
@@ -10467,7 +10467,7 @@
     "CurrentSnapshotId" : "ballot-27-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "28",
     "CVRSnapshot" : [ {
       "@id" : "ballot-28",
@@ -10824,7 +10824,7 @@
     "CurrentSnapshotId" : "ballot-28-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "29",
     "CVRSnapshot" : [ {
       "@id" : "ballot-29",
@@ -11244,7 +11244,7 @@
     "CurrentSnapshotId" : "ballot-29-round-6",
     "ElectionId" : "election-001"
   }, {
-    "@type" : "CVR.CVR",
+    "@type" : "CVR",
     "BallotPrePrintedId" : "30",
     "CVRSnapshot" : [ {
       "@id" : "ballot-30",
@@ -11736,7 +11736,7 @@
   } ],
   "Election" : [ {
     "@id" : "election-001",
-    "@type" : "CVR.Election",
+    "@type" : "Election",
     "Candidate" : [ {
       "@id" : "c-candidate_a_name",
       "Name" : "Candidate A Name"
@@ -11758,40 +11758,40 @@
     } ],
     "Contest" : [ {
       "@id" : "contest-001",
-      "@type" : "CVR.CandidateContest",
+      "@type" : "CandidateContest",
       "ContestSelection" : [ {
         "@id" : "cs-candidate_a_name",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-candidate_a_name" ]
       }, {
         "@id" : "cs-candidate_b_name",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-candidate_b_name" ]
       }, {
         "@id" : "cs-candidate_c_name",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-candidate_c_name" ]
       }, {
         "@id" : "cs-candidate_d_name",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-candidate_d_name" ]
       }, {
         "@id" : "cs-candidate_e_name",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-candidate_e_name" ]
       }, {
         "@id" : "cs-candidate_f_name",
-        "@type" : "CVR.ContestSelection",
+        "@type" : "ContestSelection",
         "CandidateIds" : [ "c-candidate_f_name" ]
       } ],
       "Name" : "test set multi winner whole"
     } ],
     "ElectionScopeId" : "gpu-election"
   } ],
-  "GeneratedDate" : "2020-09-13T15:16:49-07:00",
+  "GeneratedDate" : "2020-10-03T14:38:02-07:00",
   "GpUnit" : [ {
     "@id" : "gpu-election",
-    "@type" : "CVR.GpUnit",
+    "@type" : "GpUnit",
     "Name" : "Multi-winner",
     "OtherType" : "Election Scope Jurisdiction",
     "Type" : "other"


### PR DESCRIPTION
A few small things here:
Correct Readme.md regarding usage of overvote and uwi strings.
Throw if a candidate object can't be found during CVR parsing (this caused a NPE when parsing a CDF file which had been exported before (#523) was fixed.  @gngilbert encountered this problem
Finally, the CDF class (type) names have been fixed.  I verified and updated regressions tests impacted by this.  I just noticed this was wrong.