### PR TITLE
Add floorWinningThreshold option

### DIFF
--- a/config_file_documentation.txt
+++ b/config_file_documentation.txt
@@ -241,6 +241,13 @@ Config file must be valid JSON format. Examples can be found in the test_data fo
         text description of this rules configuration for organizing your config files -- not used by the tabulator
         Example "Maine Rules"
         value: string of length [1..1000]
+        
+      "floorWinningThreshold" optional
+        if true, threshold = floor(V/(S+1)) + 1
+        if false, threshold = (V/(S+1)) + 1
+        makes no difference if nonIntegerWinningThreshold is true
+        value: true | false
+        if not supplied: true
 
       "nonIntegerWinningThreshold" optional
         the vote threshold used to determine winners can be a non-integer

--- a/src/main/java/network/brightspots/rcv/ContestConfig.java
+++ b/src/main/java/network/brightspots/rcv/ContestConfig.java
@@ -850,7 +850,11 @@ class ContestConfig {
   boolean isMultiSeatSequentialWinnerTakesAllEnabled() {
     return getWinnerElectionMode() == WinnerElectionMode.MULTI_SEAT_SEQUENTIAL_WINNER_TAKES_ALL;
   }
-
+  
+  boolean isFloorWinningThresholdEnabled() {
+    return rawConfig.rules.floorWinningThreshold
+  }
+  
   boolean isNonIntegerWinningThresholdEnabled() {
     return rawConfig.rules.nonIntegerWinningThreshold;
   }

--- a/src/main/java/network/brightspots/rcv/RawContestConfig.java
+++ b/src/main/java/network/brightspots/rcv/RawContestConfig.java
@@ -259,6 +259,7 @@ public class RawContestConfig {
     public String minimumVoteThreshold;
     public String maxSkippedRanksAllowed;
     public String maxRankingsAllowed;
+    public boolean floorWinningThreshold;
     public boolean nonIntegerWinningThreshold;
     public boolean hareQuota;
     public boolean batchElimination;

--- a/src/main/java/network/brightspots/rcv/Tabulator.java
+++ b/src/main/java/network/brightspots/rcv/Tabulator.java
@@ -365,22 +365,22 @@ class Tabulator {
               config.isHareQuotaEnabled()
                   ? config.getNumberOfWinners()
                   : config.getNumberOfWinners() + 1);
-      if (config.isNonIntegerWinningThresholdEnabled()) {
+      if (config.isHareQuotaEnabled()) {
+        winningThreshold = config.divide(currentRoundTotalVotes, divisor)
+      } else if (config.isNonIntegerWinningThresholdEnabled()) {
         // threshold = (votes / (num_winners + 1)) + 10^(-1 * decimalPlacesForVoteArithmetic)
         BigDecimal augend =
             config.divide(
                 BigDecimal.ONE, BigDecimal.TEN.pow(config.getDecimalPlacesForVoteArithmetic()));
         winningThreshold = config.divide(currentRoundTotalVotes, divisor).add(augend);
+      } else if (config.isFloorWinningThresholdEnabled()) {
+        // threshold = floor(votes / (num_winners + 1)) + 1
+        winningThreshold =
+            currentRoundTotalVotes.divideToIntegralValue(divisor).add(BigDecimal.ONE);
       } else {
-        if (config.isFloorWinningThresholdEnabled()) {
-          // threshold = floor(votes / (num_winners + 1)) + 1
-          winningThreshold =
-              currentRoundTotalVotes.divideToIntegralValue(divisor).add(BigDecimal.ONE);
-        } else {
-          // threshold = (votes / (num_winners + 1)) + 1
-          winningThreshold =
-              config.divide(currentRoundTotalVotes, divisor).add(BigDecimal.ONE);
-        }
+        // threshold = (votes / (num_winners + 1)) + 1
+        winningThreshold =
+            config.divide(currentRoundTotalVotes, divisor).add(BigDecimal.ONE);
       }
     }
     Logger.info("Winning threshold set to %s.", winningThreshold);

--- a/src/main/java/network/brightspots/rcv/Tabulator.java
+++ b/src/main/java/network/brightspots/rcv/Tabulator.java
@@ -372,9 +372,15 @@ class Tabulator {
                 BigDecimal.ONE, BigDecimal.TEN.pow(config.getDecimalPlacesForVoteArithmetic()));
         winningThreshold = config.divide(currentRoundTotalVotes, divisor).add(augend);
       } else {
-        // threshold = floor(votes / (num_winners + 1)) + 1
-        winningThreshold =
-            currentRoundTotalVotes.divideToIntegralValue(divisor).add(BigDecimal.ONE);
+        if (config.isFloorWinningThresholdEnabled()) {
+          // threshold = floor(votes / (num_winners + 1)) + 1
+          winningThreshold =
+              currentRoundTotalVotes.divideToIntegralValue(divisor).add(BigDecimal.ONE);
+        } else {
+          // threshold = (votes / (num_winners + 1)) + 1
+          winningThreshold =
+              config.divide(currentRoundTotalVotes, divisor).add(BigDecimal.ONE);
+        }
       }
     }
     Logger.info("Winning threshold set to %s.", winningThreshold);


### PR DESCRIPTION
Some jurisdictions, such as Portland, define "majority" as >= 1/2 + 1, and analogously for multi-winner threshold. This can be accommodated by configuring floorWinningThreshold to false.

As of writing, I haven't tested this with Gradle so it probably doesn't work correctly.