### PR TITLE
Specify JDK 14 or 15 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The Tabulator produces the following as output:
 
 #### Method 2 (Less Easy): Compile and Run Using Gradle
 
-1. Install [JDK 14 or higher](https://jdk.java.net/), and make sure your Java path is picking it up properly by verifying that the following command returns the expected version:
+1. Install [JDK 14 or 15](https://jdk.java.net/), and make sure your Java path is picking it up properly by verifying that the following command returns the expected version:
     
     `$ java -version`
     


### PR DESCRIPTION
Currently, the Tabulator cannot be built with JDK 16 or higher, so it makes sense to say "14 or 15" rather than "14 or higher".

See issue #565.