### PR TITLE
Auto-build releases (#282)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,12 @@
 name: Build Releases
 
-on: [push]
-# TODO: eventually, only build on master, and add a step to deploy when a Release is created.
+on:
+  release:
+    types: [published]
+  push:
+    branches:
+      - 'master'
+      - 'develop'
 
 jobs:
   release:
@@ -10,41 +15,38 @@ jobs:
         matrix:
             os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      #- name: Create filename
-      #  id: fn
-      #  run: echo "FILENAME=build/rctab_${{ github.ref_name }}_${{ runner.os }}.zip" >> $GITHUB_OUTPUT
-      - name: Create filename
+      - name: "Create filename"
         id: fn
         shell: bash
-        run: echo "FILENAME=build/rctab_v1.3.1_${{ runner.os }}.zip" >> $GITHUB_OUTPUT
+        run: echo "FILENAME=build/rctab_${{ github.ref_name }}_${{ runner.os }}.zip" >> $GITHUB_OUTPUT
           
-
       - uses: actions/checkout@v3
-      - name: Set up JDK 17.0.2
+
+      - name: "Set up JDK 17.0.2"
         uses: actions/setup-java@v3
         with:
           java-version: '17.0.2'
           distribution: 'temurin'
 
-      - name: Validate Gradle wrapper
+      - name: "Validate Gradle wrapper"
         uses: gradle/wrapper-validation-action@ccb4328a959376b642e027874838f60f8e596de3
 
-      - name: Create zip with Gradle
+      - name: "Create zip with Gradle"
         uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
         with:
           arguments: jlinkZip
 
-      - name: "Copy zip file"
+      - name: "Rename zip file"
         run: cp build/rcv.zip ${{ steps.fn.outputs.FILENAME }}
 
-      - name: Linux SHA512
+      - name: "Generate SHA512 for Linux"
         if: runner.os == 'Linux'
         run: sha512sum ${{ steps.fn.outputs.FILENAME }} > ${{ steps.fn.outputs.FILENAME }}.sha512
-      - name: Windows SHA512
+      - name: "Generate SHA512 for Windows"
         if: runner.os == 'Windows'
         shell: bash
         run: certutil -hashfile ${{ steps.fn.outputs.FILENAME }} SHA512 >> ${{ steps.fn.outputs.FILENAME }}.sha512
-      - name: OSX SHA512
+      - name: "Generate SHA512 for OSX"
         if: runner.os == 'macOS'
         run: openssl dgst -sha512 > ${{ steps.fn.outputs.FILENAME }}.sha512
 
@@ -55,3 +57,14 @@ jobs:
           path: |
             ${{ github.workspace }}/${{ steps.fn.outputs.FILENAME }}
             ${{ github.workspace }}/${{ steps.fn.outputs.FILENAME }}.sha512
+          retention-days: 90
+
+      - name: "Upload binaries to release"
+        uses: svenstaro/upload-release-action@v2
+        if: ${{ github.event_name }} == 'release'
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{ github.workspace }}/${{ steps.fn.outputs.FILENAME }}*
+          tag: ${{ github.ref_name }}
+          overwrite: true
+          file_glob: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: Build Releases
+
+on: [push]
+# TODO: eventually, only build on master, and add a step to deploy when a Release is created.
+
+jobs:
+  release:
+    runs-on: ${{ matrix.os }}
+    strategy:
+        matrix:
+            os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      #- name: Create filename
+      #  id: fn
+      #  run: echo "FILENAME=build/rctab_${{ github.ref_name }}_${{ runner.os }}.zip" >> $GITHUB_OUTPUT
+      - name: Create filename
+        id: fn
+        shell: bash
+        run: echo "FILENAME=build/rctab_v1.3.1_${{ runner.os }}.zip" >> $GITHUB_OUTPUT
+          
+
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17.0.2
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17.0.2'
+          distribution: 'temurin'
+
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@ccb4328a959376b642e027874838f60f8e596de3
+
+      - name: Create zip with Gradle
+        uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+        with:
+          arguments: jlinkZip
+
+      - name: "Copy zip file"
+        run: cp build/rcv.zip ${{ steps.fn.outputs.FILENAME }}
+
+      - name: Linux SHA512
+        if: runner.os == 'Linux'
+        run: sha512sum ${{ steps.fn.outputs.FILENAME }} > ${{ steps.fn.outputs.FILENAME }}.sha512
+      - name: Windows SHA512
+        if: runner.os == 'Windows'
+        shell: bash
+        run: certutil -hashfile ${{ steps.fn.outputs.FILENAME }} SHA512 >> ${{ steps.fn.outputs.FILENAME }}.sha512
+      - name: OSX SHA512
+        if: runner.os == 'macOS'
+        run: openssl dgst -sha512 > ${{ steps.fn.outputs.FILENAME }}.sha512
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Package
+          if-no-files-found: error
+          path: |
+            ${{ github.workspace }}/${{ steps.fn.outputs.FILENAME }}
+            ${{ github.workspace }}/${{ steps.fn.outputs.FILENAME }}.sha512

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,6 @@ name: Build Releases
 on:
   release:
     types: [published]
-  push:
-    branches:
-      - 'master'
-      - 'develop'
 
 jobs:
   release:


### PR DESCRIPTION
Github action to:
1. Build assets on every merge into develop and master
2. Automatically add assets to every prerelease and release

Where assets include the zip files for windows, mac, and linux, built with jdk 17.0.2, along with their SHA512s.

The zips go in two places:
1. On every push to master or develop, they will show up [in the "artifacts" section](https://github.com/BrightSpots/rcv/actions/runs/4773447699) in the Action linked from the PR.
2. On every prerelease and release, they will show up [in the Releases section](https://github.com/BrightSpots/rcv/releases)