### PR TITLE
Generate precinct ID where it makes sense and reduce clutter

### DIFF
--- a/src/main/java/network/brightspots/rcv/BaseCvrReader.java
+++ b/src/main/java/network/brightspots/rcv/BaseCvrReader.java
@@ -18,7 +18,6 @@ package network.brightspots.rcv;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Set;
 import network.brightspots.rcv.RawContestConfig.CvrSource;
 
 abstract class BaseCvrReader {
@@ -34,7 +33,7 @@ abstract class BaseCvrReader {
 
   // parse CVR for records matching the specified contestId into CastVoteRecord objects and add
   // them to the input list
-  abstract void readCastVoteRecords(List<CastVoteRecord> castVoteRecords, Set<String> precinctIds)
+  abstract void readCastVoteRecords(List<CastVoteRecord> castVoteRecords)
       throws CastVoteRecord.CvrParseException,
           TabulatorSession.UnrecognizedCandidatesException,
           IOException;

--- a/src/main/java/network/brightspots/rcv/ClearBallotCvrReader.java
+++ b/src/main/java/network/brightspots/rcv/ClearBallotCvrReader.java
@@ -44,7 +44,7 @@ class ClearBallotCvrReader extends BaseCvrReader {
   // parse Cvr json into CastVoteRecord objects and append them to the input castVoteRecords list
   // see Clear Ballot 2.1 RCV Format Specification for details
   @Override
-  void readCastVoteRecords(List<CastVoteRecord> castVoteRecords, Set<String> precinctIds)
+  void readCastVoteRecords(List<CastVoteRecord> castVoteRecords)
       throws CvrParseException, UnrecognizedCandidatesException, IOException {
     BufferedReader csvReader;
     // map for tracking unrecognized candidates during parsing

--- a/src/main/java/network/brightspots/rcv/CommonDataFormatReader.java
+++ b/src/main/java/network/brightspots/rcv/CommonDataFormatReader.java
@@ -100,7 +100,7 @@ class CommonDataFormatReader extends BaseCvrReader {
   }
 
   @Override
-  void readCastVoteRecords(List<CastVoteRecord> castVoteRecords, Set<String> precinctIds)
+  void readCastVoteRecords(List<CastVoteRecord> castVoteRecords)
       throws UnrecognizedCandidatesException, CvrParseException {
     try {
       if (cvrPath.endsWith(".xml")) {

--- a/src/main/java/network/brightspots/rcv/CsvCvrReader.java
+++ b/src/main/java/network/brightspots/rcv/CsvCvrReader.java
@@ -53,7 +53,7 @@ class CsvCvrReader extends BaseCvrReader {
 
   // parse CVR CSV file into CastVoteRecord objects and add them to the input List<CastVoteRecord>
   @Override
-  void readCastVoteRecords(List<CastVoteRecord> castVoteRecords, Set<String> precinctIds)
+  void readCastVoteRecords(List<CastVoteRecord> castVoteRecords)
       throws CastVoteRecord.CvrParseException, IOException, UnrecognizedCandidatesException {
     try (FileInputStream inputStream = new FileInputStream(Path.of(cvrPath).toFile())) {
       CSVParser parser =

--- a/src/main/java/network/brightspots/rcv/DominionCvrReader.java
+++ b/src/main/java/network/brightspots/rcv/DominionCvrReader.java
@@ -135,7 +135,7 @@ class DominionCvrReader extends BaseCvrReader {
   // parse CVR JSON for records matching the specified contestId into CastVoteRecord objects and add
   // them to the input list
   @Override
-  void readCastVoteRecords(List<CastVoteRecord> castVoteRecords, Set<String> precinctIds)
+  void readCastVoteRecords(List<CastVoteRecord> castVoteRecords)
       throws CvrParseException, UnrecognizedCandidatesException {
     // read metadata files for precincts, precinct portions, contest, and candidates
 

--- a/src/main/java/network/brightspots/rcv/GuiConfigController.java
+++ b/src/main/java/network/brightspots/rcv/GuiConfigController.java
@@ -1403,7 +1403,7 @@ public class GuiConfigController implements Initializable {
                 try {
                   List<CastVoteRecord> castVoteRecords = new ArrayList<>();
                   BaseCvrReader reader = provider.constructReader(config, source);
-                  reader.readCastVoteRecords(castVoteRecords, new HashSet<>());
+                  reader.readCastVoteRecords(castVoteRecords);
                   unloadedNames.addAll(reader.gatherUnknownCandidates(castVoteRecords).keySet());
                 } catch (ContestConfig.UnrecognizedProviderException e) {
                   Logger.severe(

--- a/src/main/java/network/brightspots/rcv/HartCvrReader.java
+++ b/src/main/java/network/brightspots/rcv/HartCvrReader.java
@@ -45,7 +45,7 @@ class HartCvrReader extends BaseCvrReader {
 
   // iterate all xml files in the source input folder
   @Override
-  void readCastVoteRecords(List<CastVoteRecord> castVoteRecords, Set<String> precinctIds)
+  void readCastVoteRecords(List<CastVoteRecord> castVoteRecords)
       throws CastVoteRecord.CvrParseException,
           TabulatorSession.UnrecognizedCandidatesException,
           IOException {

--- a/src/main/java/network/brightspots/rcv/StreamingCvrReader.java
+++ b/src/main/java/network/brightspots/rcv/StreamingCvrReader.java
@@ -80,8 +80,6 @@ class StreamingCvrReader extends BaseCvrReader {
   private String currentPrecinct;
   // place to store input CVR list (new CVRs will be appended as we parse)
   private List<CastVoteRecord> cvrList;
-  // store precinct IDs (new IDs will be added as we parse)
-  private Set<String> precinctIds;
   // last rankings cell observed for CVR in progress
   private int lastRankSeen;
   // flag indicating data issues during parsing
@@ -186,7 +184,6 @@ class StreamingCvrReader extends BaseCvrReader {
             "Precinct identifier not found for cast vote record: %s", computedCastVoteRecordId);
         currentPrecinct = MISSING_PRECINCT_ID;
       }
-      precinctIds.add(currentPrecinct);
     }
 
     if (idColumnIndex != null && currentSuppliedCvrId == null) {
@@ -266,10 +263,10 @@ class StreamingCvrReader extends BaseCvrReader {
   }
 
   @Override
-  void readCastVoteRecords(List<CastVoteRecord> castVoteRecords, Set<String> precinctIds)
+  void readCastVoteRecords(List<CastVoteRecord> castVoteRecords)
       throws UnrecognizedCandidatesException, CastVoteRecord.CvrParseException, IOException {
     try {
-      parseCvrFileInternal(castVoteRecords, precinctIds);
+      parseCvrFileInternal(castVoteRecords);
     } catch (OpenXML4JException | SAXException | ParserConfigurationException e) {
       Logger.severe("Error parsing source file %s", cvrPath);
       Logger.info(
@@ -286,7 +283,7 @@ class StreamingCvrReader extends BaseCvrReader {
   // parse the given file into a List of CastVoteRecords for tabulation
   // param: castVoteRecords existing list to append new CastVoteRecords to
   // param: precinctIDs existing set of precinctIDs discovered during CVR parsing
-  private void parseCvrFileInternal(List<CastVoteRecord> castVoteRecords, Set<String> precinctIds)
+  private void parseCvrFileInternal(List<CastVoteRecord> castVoteRecords)
       throws UnrecognizedCandidatesException,
           OpenXML4JException,
           SAXException,
@@ -295,7 +292,6 @@ class StreamingCvrReader extends BaseCvrReader {
           CvrDataFormatException {
 
     cvrList = castVoteRecords;
-    this.precinctIds = precinctIds;
 
     // open the zip package
     OPCPackage pkg = OPCPackage.open(cvrPath);

--- a/src/main/java/network/brightspots/rcv/Tabulator.java
+++ b/src/main/java/network/brightspots/rcv/Tabulator.java
@@ -72,7 +72,7 @@ class Tabulator {
   // tracks residual surplus from multi-seat contest vote transfers
   private final Map<Integer, BigDecimal> roundToResidualSurplus = new HashMap<>();
   // precincts which may appear in the cast vote records
-  private final Set<String> precinctNames = new HashSet<>();
+  private final Set<String> precinctIds = new HashSet<>();
   // tracks the current round (and when tabulation is completed, the total number of rounds)
   private int currentRound = 0;
   // tracks required winning threshold
@@ -84,9 +84,9 @@ class Tabulator {
     this.config = config;
 
     for (CastVoteRecord cvr : castVoteRecords) {
-      String precinctName = cvr.getPrecinct();
-      if (precinctName != null) {
-        precinctNames.add(precinctName);
+      String precinctId = cvr.getPrecinct();
+      if (precinctId != null) {
+        precinctIds.add(precinctId);
       }
     }
 
@@ -685,7 +685,7 @@ class Tabulator {
             .setContestConfig(config)
             .setTimestampString(timestamp)
             .setWinningThreshold(winningThreshold)
-            .setPrecinctIds(precinctNames)
+            .setPrecinctIds(precinctIds)
             .setRoundToResidualSurplus(roundToResidualSurplus);
 
     writer.generateOverallSummaryFiles(roundTallies, tallyTransfers, castVoteRecords.size());
@@ -1071,10 +1071,10 @@ class Tabulator {
   }
 
   private void initPrecinctRoundTallies() {
-    for (String precinctName : precinctNames) {
-      precinctRoundTallies.put(precinctName, new HashMap<>());
-      precinctTallyTransfers.put(precinctName, new TallyTransfers());
-      assert !isNullOrBlank(precinctName);
+    for (String precinctId : precinctIds) {
+      precinctRoundTallies.put(precinctId, new HashMap<>());
+      precinctTallyTransfers.put(precinctId, new TallyTransfers());
+      assert !isNullOrBlank(precinctId);
     }
   }
 

--- a/src/main/java/network/brightspots/rcv/Tabulator.java
+++ b/src/main/java/network/brightspots/rcv/Tabulator.java
@@ -72,17 +72,24 @@ class Tabulator {
   // tracks residual surplus from multi-seat contest vote transfers
   private final Map<Integer, BigDecimal> roundToResidualSurplus = new HashMap<>();
   // precincts which may appear in the cast vote records
-  private final Set<String> precinctNames;
+  private final Set<String> precinctNames = new HashSet<>();
   // tracks the current round (and when tabulation is completed, the total number of rounds)
   private int currentRound = 0;
   // tracks required winning threshold
   private BigDecimal winningThreshold;
 
-  Tabulator(List<CastVoteRecord> castVoteRecords, ContestConfig config, Set<String> precinctNames) {
+  Tabulator(List<CastVoteRecord> castVoteRecords, ContestConfig config) {
     this.castVoteRecords = castVoteRecords;
     this.candidateNames = config.getCandidateNames();
     this.config = config;
-    this.precinctNames = precinctNames;
+
+    for (CastVoteRecord cvr : castVoteRecords) {
+      String precinctName = cvr.getPrecinct();
+      if (precinctName != null) {
+        precinctNames.add(precinctName);
+      }
+    }
+
     if (config.isTabulateByPrecinctEnabled()) {
       initPrecinctRoundTallies();
     }

--- a/src/main/java/network/brightspots/rcv/TabulatorSession.java
+++ b/src/main/java/network/brightspots/rcv/TabulatorSession.java
@@ -45,8 +45,6 @@ import network.brightspots.rcv.Tabulator.TabulationAbortedException;
 class TabulatorSession {
 
   private final String configPath;
-  // precinct IDs discovered during CVR parsing to support testing
-  private final Set<String> precinctIds = new HashSet<>();
   private final String timestampString;
   private String outputPath;
   private List<String> convertedFilesWritten;
@@ -102,7 +100,7 @@ class TabulatorSession {
       checkConfigVersionMatchesApp(config);
       try {
         FileUtils.createOutputDirectory(config.getOutputDirectory());
-        List<CastVoteRecord> castVoteRecords = parseCastVoteRecords(config, precinctIds);
+        List<CastVoteRecord> castVoteRecords = parseCastVoteRecords(config);
         if (castVoteRecords == null) {
           Logger.severe("Aborting conversion due to cast vote record errors!");
         } else {
@@ -110,8 +108,7 @@ class TabulatorSession {
               new ResultsWriter()
                   .setNumRounds(0)
                   .setContestConfig(config)
-                  .setTimestampString(timestampString)
-                  .setPrecinctIds(precinctIds);
+                  .setTimestampString(timestampString);
           try {
             writer.generateCdfJson(castVoteRecords);
           } catch (RoundSnapshotDataMissingException exception) {
@@ -164,7 +161,7 @@ class TabulatorSession {
           Logger.info(
               "Beginning tabulation for seat #%d...", config.getSequentialWinners().size() + 1);
           // Read cast vote records and precinct IDs from CVR files
-          List<CastVoteRecord> castVoteRecords = parseCastVoteRecords(config, precinctIds);
+          List<CastVoteRecord> castVoteRecords = parseCastVoteRecords(config);
           if (castVoteRecords == null) {
             Logger.severe("Aborting tabulation due to cast vote record errors!");
             break;
@@ -195,7 +192,7 @@ class TabulatorSession {
       } else {
         // normal operation (not multi-pass IRV, a.k.a. sequential multi-seat)
         // Read cast vote records and precinct IDs from CVR files
-        List<CastVoteRecord> castVoteRecords = parseCastVoteRecords(config, precinctIds);
+        List<CastVoteRecord> castVoteRecords = parseCastVoteRecords(config);
         if (castVoteRecords == null) {
           Logger.severe("Aborting tabulation due to cast vote record errors!");
         } else {
@@ -240,7 +237,7 @@ class TabulatorSession {
       ContestConfig config, List<CastVoteRecord> castVoteRecords)
       throws TabulationAbortedException {
     Set<String> winners;
-    Tabulator tabulator = new Tabulator(castVoteRecords, config, precinctIds);
+    Tabulator tabulator = new Tabulator(castVoteRecords, config);
     winners = tabulator.tabulate();
     try {
       tabulator.generateSummaryFiles(timestampString);
@@ -252,9 +249,8 @@ class TabulatorSession {
 
   // parse CVR files referenced in the ContestConfig object into a list of CastVoteRecords
   // param: config object containing CVR file paths to parse
-  // param: precinctIds a set of precinct IDs which will be populated during cvr parsing
   // returns: list of parsed CVRs or null if an error was encountered
-  private List<CastVoteRecord> parseCastVoteRecords(ContestConfig config, Set<String> precinctIds) {
+  private List<CastVoteRecord> parseCastVoteRecords(ContestConfig config) {
     Logger.info("Parsing cast vote records...");
     List<CastVoteRecord> castVoteRecords = new ArrayList<>();
     boolean encounteredSourceProblem = false;
@@ -266,7 +262,7 @@ class TabulatorSession {
       try {
         BaseCvrReader reader = provider.constructReader(config, source);
         Logger.info("Reading %s cast vote records from: %s...", reader.readerName(), cvrPath);
-        reader.readCastVoteRecords(castVoteRecords, precinctIds);
+        reader.readCastVoteRecords(castVoteRecords);
 
         if (reader.getClass() == DominionCvrReader.class) {
           // Before we tabulate, we output a converted generic CSV for the CVRs.


### PR DESCRIPTION
Based on https://github.com/BrightSpots/rcv/pull/651#discussion_r1209623094

`precinctIds` was being passed everywhere to populate as we read CVRs, but it can just as easily be generated after all CVRs are read. This will add a tiny amount of processing & memory to non-ES&S tabulation, since only ES&S used it previously, but it is negligible.