### PR TITLE
support multiple candidate IDs in CDF

### DIFF
--- a/src/test/resources/network/brightspots/rcv/test_data/aliases_cdf_json/aliases_cdf_json_file1_cvr.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/aliases_cdf_json/aliases_cdf_json_file1_cvr.json
@@ -800,7 +800,7 @@
       "ContestSelection" : [ {
         "@id" : "cs-a",
         "@type" : "CandidateSelection",
-        "CandidateIds" : [ "candidate-a" ]
+        "CandidateIds" : [ "candidate-A", "candidate-a" ]
       }, {
         "@id" : "cs-b",
         "@type" : "CandidateSelection",


### PR DESCRIPTION
The CDF format can have multiple candidate IDs to support party ticket voting options. A comment says "in practice this is always a single candidate ID".

I'm not sure we actually want to do this -- I thought the candidate IDs were aliases, but they're not quite the same.

This PR looks for the first-found candidate ID, which is a reasonable thing to do, but also adds potentially-unnecessary complexity since we'd never encounter this situation (right?).

Thoughts on ignoring this ticket entirely vs merging this PR?