### PR TITLE
Adds note in UI that names must match exactly

### DIFF
--- a/src/main/resources/network/brightspots/rcv/GuiConfigLayout.fxml
+++ b/src/main/resources/network/brightspots/rcv/GuiConfigLayout.fxml
@@ -322,8 +322,12 @@
                     </padding>
                     <Label text="Manually Add Candidate" style="-fx-font-weight: bold"/>
                     <Text
-                      text="You can manually add candidates if auto-loading fails to produce acceptable results."
-                      wrappingWidth="350"
+                            text="You can manually add candidates if auto-loading fails to produce acceptable results."
+                            wrappingWidth="350"
+                    />
+                    <Text
+                            text="NOTE: Candidate names must match names in CVR files exactly!"
+                            wrappingWidth="350"
                     />
                   </VBox>
                   <Separator>

--- a/src/main/resources/network/brightspots/rcv/GuiConfigLayout.fxml
+++ b/src/main/resources/network/brightspots/rcv/GuiConfigLayout.fxml
@@ -325,10 +325,15 @@
                             text="You can manually add candidates if auto-loading fails to produce acceptable results."
                             wrappingWidth="350"
                     />
-                    <Text
-                            text="NOTE: Candidate names must match names in CVR files exactly!"
+                    <VBox>
+                      <Text text="NOTE: Candidate names are case-sensitive and must match the CVR exactly, including any HTML tags or other special characters!"
                             wrappingWidth="350"
-                    />
+                            style="-fx-font-weight: bold; -fx-font-style: italic; -fx-font-size: 11">
+                      </Text>
+                      <padding>
+                        <Insets left="8.0" right="8.0" top="8.0"/>
+                      </padding>
+                    </VBox>
                   </VBox>
                   <Separator>
                     <padding>


### PR DESCRIPTION
Fixes #677.

![image](https://github.com/BrightSpots/rcv/assets/8259446/d1c4d0d4-be92-4ba0-80f1-de4679e22b7d)
