### PR TITLE
track session count to avoid race conditions in tests

### DIFF
--- a/src/main/java/network/brightspots/rcv/TabulatorSession.java
+++ b/src/main/java/network/brightspots/rcv/TabulatorSession.java
@@ -42,6 +42,9 @@ import network.brightspots.rcv.Tabulator.TabulationAbortedException;
 
 @SuppressWarnings("RedundantSuppression")
 class TabulatorSession {
+  // In order to allow multiple tests to write to the same output file at the same millisecond,
+  // we track the session count and append it to the timestamp string.
+  private static int sessionCount = 0;
 
   private final String configPath;
   private final String timestampString;
@@ -51,7 +54,8 @@ class TabulatorSession {
   TabulatorSession(String configPath) {
     this.configPath = configPath;
     // current date-time formatted as a string used for creating unique output files names
-    timestampString = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss-SSS").format(new Date());
+    String dateString = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss-SSS").format(new Date());
+    timestampString = "%s_%03d".format(dateString, sessionCount++);
   }
 
   // validation will catch a mismatch and abort anyway, but let's log helpful errors for the CLI


### PR DESCRIPTION
While this hasn't happened with milliseconds appended to the output filenames, it's theoretically possible:

1. Output files now go into the `_shared` directory for some tests
2. If two tests that output the same file run within the same millisecond, they'll have the same output filename, and one will overwrite the other
3. This could lead to flaky tests in the future

I seems exceedingly rare for two tests to run at the same millisecond unless we're running on multiple threads -- and in that case, this code won't work anyway, since `sessionCount` isn't thread-safe. Still, wanted to open this PR to start a discussion: is this something we should handle?