### PR TITLE
allow aliases to start and end with non-word characters

### DIFF
--- a/src/main/java/network/brightspots/rcv/RawContestConfig.java
+++ b/src/main/java/network/brightspots/rcv/RawContestConfig.java
@@ -226,7 +226,7 @@ public class RawContestConfig {
 
       if (newlineSeparatedAliases != null) {
         // Split by newline, and also trim whitespace
-        this.aliases = Arrays.asList(newlineSeparatedAliases.split("\\W*\\r?\\n\\W*"));
+        this.aliases = Arrays.asList(newlineSeparatedAliases.split("\\s*\\r?\\n\\s*"));
       }
     }
 


### PR DESCRIPTION
Regex was eating all non-word characters instead of all non-space characters, so while the first alias could start and end with `.;,` etc, the second alias could not.