### PR TITLE
make all output files read-only (#687)

### DIFF
--- a/src/main/java/network/brightspots/rcv/Logger.java
+++ b/src/main/java/network/brightspots/rcv/Logger.java
@@ -32,6 +32,7 @@
 
 package network.brightspots.rcv;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -59,6 +60,7 @@ class Logger {
   private static final java.util.logging.Formatter formatter = new LogFormatter();
   private static java.util.logging.Logger logger;
   private static java.util.logging.FileHandler tabulationHandler;
+  private static String tabulationLogPattern;
 
   static void setup() {
     logger = java.util.logging.Logger.getLogger("");
@@ -95,7 +97,7 @@ class Logger {
       throws IOException {
     // log file name is: outputFolder + timestamp + log index
     // FileHandler requires % to be encoded as %%.  %g is the log index
-    String tabulationLogPattern =
+    tabulationLogPattern =
             Paths.get(outputFolder.replace("%", "%%"),
                     String.format("%s_audit_%%g.log", timestampString))
                     .toAbsolutePath()
@@ -116,6 +118,19 @@ class Logger {
     tabulationHandler.flush();
     tabulationHandler.close();
     logger.removeHandler(tabulationHandler);
+
+    int index = 0;
+    while (true) {
+      File file = new File(tabulationLogPattern.replace("%g", String.valueOf(index)));
+      if (!file.exists()) {
+        break;
+      }
+      boolean readOnlySucceeded = file.setReadOnly();
+      if (!readOnlySucceeded) {
+        warning("Failed to set file to read-only: %s", file.getAbsolutePath());
+      }
+      index++;
+    }
   }
 
   static void fine(String message, Object... obj) {

--- a/src/main/java/network/brightspots/rcv/ResultsWriter.java
+++ b/src/main/java/network/brightspots/rcv/ResultsWriter.java
@@ -116,6 +116,10 @@ class ResultsWriter {
 
     try {
       jsonWriter.writeValue(outFile, json);
+      boolean readOnlySucceeded = outFile.setReadOnly();
+      if (!readOnlySucceeded) {
+        Logger.warning("Failed to set file to read-only: %s", outFile.getAbsolutePath());
+      }
     } catch (IOException exception) {
       Logger.severe(
           "Error writing to JSON file: %s\n%s\nPlease check the file path and permissions!",
@@ -379,6 +383,12 @@ class ResultsWriter {
     try {
       csvPrinter.flush();
       csvPrinter.close();
+
+      File file = new File(csvPath);
+      boolean readOnlySucceeded = file.setReadOnly();
+      if (!readOnlySucceeded) {
+        Logger.warning("Failed to set file to read-only: %s", file.getAbsolutePath());
+      }
     } catch (IOException exception) {
       Logger.severe("Error saving file: %s\n%s", outputPath, exception);
       throw exception;
@@ -547,6 +557,12 @@ class ResultsWriter {
         csvPrinter.close();
         filesWritten.add(outputPath.toString());
         Logger.info("Successfully wrote: %s", outputPath.toString());
+
+        File file = new File(outputPath.toString());
+        boolean readOnlySucceeded = file.setReadOnly();
+        if (!readOnlySucceeded) {
+          Logger.warning("Failed to set file to read-only: %s", file.getAbsolutePath());
+        }
       }
     } catch (IOException exception) {
       Logger.severe(

--- a/src/test/java/network/brightspots/rcv/TabulatorTests.java
+++ b/src/test/java/network/brightspots/rcv/TabulatorTests.java
@@ -145,6 +145,15 @@ class TabulatorTests {
       for (File file : files) {
         if (!file.isDirectory()) {
           try {
+            // Every ephemeral file must be set to read-only on close, including audit logs
+            assertFalse(
+                file.canWrite(),
+                "File must be set to read-only: %s".formatted(file.getAbsolutePath()));
+            // Then set it writeable so it can be deleted
+            boolean writeableSucceeded = file.setWritable(true);
+            if (!writeableSucceeded) {
+              Logger.warning("Failed to set file to writeable: %s", file.getAbsolutePath());
+            }
             Files.delete(file.toPath());
           } catch (IOException exception) {
             Logger.severe("Error deleting file: %s\n%s", file.getAbsolutePath(), exception);


### PR DESCRIPTION
closes #748 

cherry-picked the commit from https://github.com/BrightSpots/rcv/pull/687

created branch hotfix/1.3.2 as the release branch for 1.3.2