### PR TITLE
make Convert to CDF filenames more likely to be unique

### DIFF
--- a/src/main/java/network/brightspots/rcv/ResultsWriter.java
+++ b/src/main/java/network/brightspots/rcv/ResultsWriter.java
@@ -553,17 +553,28 @@ class ResultsWriter {
       List<CastVoteRecord> castVoteRecords,
       Integer numRanks,
       String csvOutputFolder,
+      String inputFilepath,
       String contestId,
       String undeclaredWriteInLabel)
       throws IOException {
     String fileWritten;
+    // Get input filename with extension
+    String inputFileBaseName = new File(inputFilepath).getName();
+    // Remove the extension if it exists
+    int lastIndex = inputFileBaseName.lastIndexOf('.');
+    if (lastIndex != -1) {
+      inputFileBaseName = inputFileBaseName.substring(0, lastIndex);
+    }
+    // Put the input filename in the output filename in case contestId isn't unique --
+    // knowing that it's possible that if both the filename AND the contestId isn't unique,
+    // this will fail.
     Path outputPath =
             Paths.get(
                     getOutputFilePath(
                             csvOutputFolder,
                             "dominion_conversion_contest",
                             timestampString,
-                            sanitizeStringForOutput(contestId))
+                            inputFileBaseName + "-" + sanitizeStringForOutput(contestId))
                             + ".csv");
     try {
       Logger.info("Writing cast vote records in generic format to file: %s...", outputPath);

--- a/src/main/java/network/brightspots/rcv/TabulatorSession.java
+++ b/src/main/java/network/brightspots/rcv/TabulatorSession.java
@@ -308,6 +308,7 @@ class TabulatorSession {
                   castVoteRecords,
                   reader.getMaxRankingsAllowed(source.getContestId()),
                   config.getOutputDirectory(),
+                  source.getFilePath(),
                   source.getContestId(),
                   source.getUndeclaredWriteInLabel());
         } catch (IOException exception) {


### PR DESCRIPTION
closes #734 

not all contests have contest IDs, so relying on them for uniqueness causes files to be overwritten. Don't do that anymore.

It's still possible for this bug to pop up if all CVR files have the same filename and there is no contest ID. Do you think that's acceptable? Alternatively, I could (a) force a Contest ID; or (b) increment until a unique filename is found -- but I think this is fine?

After merging into develop, I will cherry-pick onto 1.3.2.