### PR TITLE
include SHA256 for output files

### DIFF
--- a/src/main/java/network/brightspots/rcv/AuditableFile.java
+++ b/src/main/java/network/brightspots/rcv/AuditableFile.java
@@ -32,8 +32,8 @@ final class AuditableFile extends File {
     Logger.info("File %s written with hash %s".formatted(getAbsolutePath(), hash));
 
     // Write hash to hash file
-    File hashFile = new File(getAbsolutePath() + ".sha");
-    writeStringToFile(hashFile, hash);
+    File hashFile = new File(getAbsolutePath() + ".hash");
+    writeStringToFile(hashFile, "sha512: " + hash);
 
     // Make both file and its hash file read-only
     makeReadOnlyOrLogWarning(this);

--- a/src/main/java/network/brightspots/rcv/AuditableFile.java
+++ b/src/main/java/network/brightspots/rcv/AuditableFile.java
@@ -1,0 +1,35 @@
+/*
+ * RCTab
+ * Copyright (c) 2017-2023 Bright Spots Developers.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Purpose: Create a file that, on close, is read-only and has its hash added to the audit log.
+ * Design: Overrides the File class
+ * Conditions: Always.
+ * Version history: see https://github.com/BrightSpots/rcv.
+ */
+
+package network.brightspots.rcv;
+
+import java.io.File;
+
+final class AuditableFile extends File {
+  public AuditableFile(String pathname) {
+    super(pathname);
+  }
+
+  public void finalizeAndHash() {
+    boolean readOnlySucceeded = setReadOnly();
+    if (!readOnlySucceeded) {
+      Logger.warning("Failed to set file to read-only: %s", getAbsolutePath());
+    }
+
+    String hash = Utils.getHash(this);
+    Logger.info("File %s written with hash %s".formatted(getAbsolutePath(), hash));
+  }
+}

--- a/src/main/java/network/brightspots/rcv/AuditableFile.java
+++ b/src/main/java/network/brightspots/rcv/AuditableFile.java
@@ -29,7 +29,7 @@ final class AuditableFile extends File {
       Logger.warning("Failed to set file to read-only: %s", getAbsolutePath());
     }
 
-    String hash = Utils.getHash(this);
+    String hash = FileUtils.getHash(this);
     Logger.info("File %s written with hash %s".formatted(getAbsolutePath(), hash));
   }
 }

--- a/src/main/java/network/brightspots/rcv/FileUtils.java
+++ b/src/main/java/network/brightspots/rcv/FileUtils.java
@@ -59,9 +59,9 @@ final class FileUtils {
   static String getHash(File file) {
     MessageDigest digest;
     try {
-      digest = MessageDigest.getInstance("SHA-256");
+      digest = MessageDigest.getInstance("SHA-512");
     } catch (NoSuchAlgorithmException e) {
-      Logger.severe("Failed to get SHA-256 algorithm");
+      Logger.severe("Failed to get SHA-512 algorithm");
       return "[hash not available]";
     }
 

--- a/src/main/java/network/brightspots/rcv/FileUtils.java
+++ b/src/main/java/network/brightspots/rcv/FileUtils.java
@@ -20,6 +20,12 @@ package network.brightspots.rcv;
 import static network.brightspots.rcv.Utils.isNullOrBlank;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 
 final class FileUtils {
 
@@ -48,6 +54,29 @@ final class FileUtils {
         throw new UnableToCreateDirectoryException("Unable to create output directory: " + dir);
       }
     }
+  }
+
+  static String getHash(File file) {
+    MessageDigest digest;
+    try {
+      digest = MessageDigest.getInstance("SHA-256");
+    } catch (NoSuchAlgorithmException e) {
+      Logger.severe("Failed to get SHA-256 algorithm");
+      return "[hash not available]";
+    }
+
+    try (InputStream is = Files.newInputStream(file.toPath())) {
+      try (DigestInputStream hashingStream = new DigestInputStream(is, digest)) {
+        while (hashingStream.readNBytes(1024).length > 0) {
+          // Read in 1kb chunks -- don't need to do anything in the body here
+        }
+      }
+    } catch (IOException e) {
+      Logger.severe("Failed to read file: %s", file.getAbsolutePath());
+      return "[hash not available]";
+    }
+
+    return Utils.bytesToHex(digest.digest());
   }
 
   static class UnableToCreateDirectoryException extends Exception {

--- a/src/main/java/network/brightspots/rcv/Logger.java
+++ b/src/main/java/network/brightspots/rcv/Logger.java
@@ -95,8 +95,8 @@ class Logger {
   // adds file logging for a tabulation run
   static void addTabulationFileLogging(String outputFolder, String timestampString)
       throws IOException {
-    // log file name is: outputFolder + timestamp + log index + hash + .log
-    // FileHandler requires % to be encoded as %%. %g is the log index.
+    // log file name is: outputFolder + timestamp + log index
+    // FileHandler requires % to be encoded as %%.  %g is the log index
     tabulationLogPattern =
         Paths.get(
                 outputFolder.replace("%", "%%"),

--- a/src/main/java/network/brightspots/rcv/Logger.java
+++ b/src/main/java/network/brightspots/rcv/Logger.java
@@ -134,7 +134,7 @@ class Logger {
       }
 
       // Rename file to include hash
-      String hash = Utils.getHash(fileWithoutHash);
+      String hash = FileUtils.getHash(fileWithoutHash);
       File fileWithHash = new File(tabulationLogPattern
               .replace("%g", String.valueOf(index))
               .replace("%h", hash));

--- a/src/main/java/network/brightspots/rcv/Utils.java
+++ b/src/main/java/network/brightspots/rcv/Utils.java
@@ -94,17 +94,6 @@ final class Utils {
     return s.trim().split("\\s*\\r?\\n\\s*");
   }
 
-  static byte[] readFileToByteArray(File file) {
-    byte[] fileBytes = null;
-    try {
-      fileBytes = Files.readAllBytes(file.toPath());
-    } catch (IOException e) {
-      Logger.severe("Failed to read file: %s", file.getAbsolutePath());
-    }
-
-    return fileBytes;
-  }
-
   static String bytesToHex(byte[] hash) {
     StringBuilder hexString = new StringBuilder(2 * hash.length);
     for (byte b : hash) {

--- a/src/main/java/network/brightspots/rcv/Utils.java
+++ b/src/main/java/network/brightspots/rcv/Utils.java
@@ -16,7 +16,12 @@
 
 package network.brightspots.rcv;
 
+import java.io.File;
+import java.io.IOException;
 import java.net.UnknownHostException;
+import java.nio.file.Files;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.List;
 import java.util.Map;
 
@@ -85,5 +90,42 @@ final class Utils {
 
   static String[] splitByNewline(String s) {
     return s.trim().split("\\s*\\r?\\n\\s*");
+  }
+
+  static byte[] readFileToByteArray(File file) {
+    byte[] fileBytes = null;
+    try {
+      fileBytes = Files.readAllBytes(file.toPath());
+    } catch (IOException e) {
+      Logger.severe("Failed to read file: %s", file.getAbsolutePath());
+    }
+
+    return fileBytes;
+  }
+
+  static String bytesToHex(byte[] hash) {
+    StringBuilder hexString = new StringBuilder(2 * hash.length);
+    for (byte b : hash) {
+      String hex = Integer.toHexString(0xff & b);
+      if (hex.length() == 1) {
+        hexString.append('0');
+      }
+      hexString.append(hex);
+    }
+    return hexString.toString();
+  }
+
+  static String getHash(File file) {
+    MessageDigest digest;
+    try {
+      digest = MessageDigest.getInstance("SHA-256");
+    } catch (NoSuchAlgorithmException e) {
+      Logger.severe("Failed to get SHA-256 algorithm");
+      return "[hash not available]";
+    }
+
+    // Read file as byte-array for hashing
+    byte[] fileBytes = readFileToByteArray(file);
+    return bytesToHex(digest.digest(fileBytes));
   }
 }

--- a/src/main/java/network/brightspots/rcv/Utils.java
+++ b/src/main/java/network/brightspots/rcv/Utils.java
@@ -18,8 +18,10 @@ package network.brightspots.rcv;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.UnknownHostException;
 import java.nio.file.Files;
+import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.List;
@@ -113,19 +115,5 @@ final class Utils {
       hexString.append(hex);
     }
     return hexString.toString();
-  }
-
-  static String getHash(File file) {
-    MessageDigest digest;
-    try {
-      digest = MessageDigest.getInstance("SHA-256");
-    } catch (NoSuchAlgorithmException e) {
-      Logger.severe("Failed to get SHA-256 algorithm");
-      return "[hash not available]";
-    }
-
-    // Read file as byte-array for hashing
-    byte[] fileBytes = readFileToByteArray(file);
-    return bytesToHex(digest.digest(fileBytes));
   }
 }

--- a/src/test/java/network/brightspots/rcv/TabulatorTests.java
+++ b/src/test/java/network/brightspots/rcv/TabulatorTests.java
@@ -254,6 +254,9 @@ class TabulatorTests {
     File[] files = outputFolder.listFiles();
     if (files != null) {
       for (File file : files) {
+        if (file.getName().equals(".DS_Store")) {
+          continue;
+        }
         if (!file.isDirectory()) {
           try {
             // Every ephemeral file must be set to read-only on close, including audit logs


### PR DESCRIPTION
1. Every file that's written should now use AuditableFile, instead of File. When the file writing is complete, you should call `finalizeAndHash` on it. That will mark it as read-only and add its hash to the audit log.
2. An exception is made for files in the Logger to avoid a circular dependency: how can you write your own hash to your file contents? In this case, we add the hash to the filename.

Alternatively, you could:
```
String hash;
do {
   hash = getHash(logFilePath);
   ReplaceLastLineOfFileWith("The hash of this file is %s".formatted(hash));
} while (getHash(logFilePath) != lastSeenHash)
```
But that will take around 10^60 years to complete by my math.

Resolves #746 