### PR TITLE
FIPS Compliance

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.13.3'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
+    implementation 'org.bouncycastle:bc-fips:1.0.2.4'
 }
 
 // ### Application plugin settings

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -12,6 +12,7 @@ module network.brightspots.rcv {
   requires java.xml;
   requires org.apache.poi.ooxml;
   requires java.xml.crypto;
+  requires org.bouncycastle.fips.core;
   // enable reflexive calls from network.brightspots.rcv into javafx.fxml
   opens network.brightspots.rcv;
   // our main module

--- a/src/main/java/network/brightspots/rcv/HartCvrReader.java
+++ b/src/main/java/network/brightspots/rcv/HartCvrReader.java
@@ -55,6 +55,10 @@ class HartCvrReader {
     boolean isHashVerified = false;
 
     if (SecurityConfig.isIsHartSignatureValidationEnabled()) {
+      if (!SecurityConfig.haveProvidersBeenCulled()) {
+        Logger.severe("RCTab security error. Could not meet FIPS compliance.");
+      }
+
       File signatureXml = new File(cvrXml.getAbsolutePath() + ".sig.xml");
       if (signatureXml.exists()) {
         try {

--- a/src/main/java/network/brightspots/rcv/SecurityXmlParsers.java
+++ b/src/main/java/network/brightspots/rcv/SecurityXmlParsers.java
@@ -66,8 +66,6 @@ class SecurityXmlParsers {
 
     @JacksonXmlProperty(localName = "DigestValue")
     String digestValue;
-
-    // Getters and setters
   }
 
   static class DigestMethod {

--- a/src/test/java/network/brightspots/rcv/SecurityTests.java
+++ b/src/test/java/network/brightspots/rcv/SecurityTests.java
@@ -137,4 +137,16 @@ class SecurityTests {
             DEFAULT_DATA_FILE)
     );
   }
+
+  @Test
+  @DisplayName("Ensure FIPS Compliance check is run")
+  void testFipsComplianceWasCorrectlySetUp() {
+    Assertions.assertTrue(SecurityConfig.haveProvidersBeenCulled());
+
+    java.security.Provider[] providers = java.security.Security.getProviders();
+    Assertions.assertEquals(3, providers.length);
+    Assertions.assertEquals("BCFIPS", providers[0].getName());
+    Assertions.assertEquals("SUN", providers[1].getName());
+    Assertions.assertEquals("XMLDSig", providers[2].getName());
+  }
 }


### PR DESCRIPTION
Our RSA validation algorithm needs to be [FIPS Compliant](https://www.nist.gov/publications/security-requirements-cryptographic-modules-includes-change-notices-1232002). Bouncycastle is compliant ([certificate #4616](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4616)) but only up to Java 17.

Luckily 1.3.2 uses Java 17, but 1.4.x will not, so we'll need to figure something out then.

In the meantime, there are two methods that are not FIPS compliant:
1. The psuedo-random number generator
2. The XML canonicalization library

(2) is not directly related to cryptography, and is likely a non-issue. We will need to determine if (1) is an issue. In the meantime, this is ready for review @tarheel @HEdingfield.