### PR TITLE
Allow bouncycastle to build on non-Oracle JDKs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,7 +106,7 @@ jlink {
     imageDir = file(JLINK_DIR)
     imageZip = file(JLINK_DIR + ".zip")
     addOptions '--add-modules', MODULES_TO_ADD, '--strip-debug', '--compress', '2',
-            '--no-header-files', '--no-man-pages'
+            '--no-header-files', '--no-man-pages', '--ignore-signing-information'
     mergedModule {
         requires "java.xml"
     }


### PR DESCRIPTION
See: https://stackoverflow.com/questions/50597926/signed-modular-jar-with-crypto-provider-cannot-be-linked-into-run-time-image/68295740#68295740 for the error we were getting on openjdk