### PR TITLE
downgrade bouncycastle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.13.3'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
-    implementation 'org.bouncycastle:bc-fips:1.0.2.4'
+    implementation 'org.bouncycastle:bc-fips:1.0.2.3'
 }
 
 // ### Application plugin settings


### PR DESCRIPTION
A bug, possibly in bouncycastle, prevents 1.0.2.4 from working:

When using bc-fips 1.0.2.4 on a jpackage'd package on Windows 10, I get the following error:
`java.lang.NoClassDefFoundError: Could not initialize class org.bouncycastle.crypto.CryptoServicesRegistrar`

This error does not occur when running from source (via IntelliJ), or when using 1.0.2.3. Somehow, bouncycastle is being packaged incorrectly. We have reached out to bouncycastle developers to dig deeper, but for now, let's proceed with 1.0.2.3.

closes #772 