### PR TITLE
fix Adding candidates manually through the UI… (#774)

### DIFF
--- a/src/main/java/network/brightspots/rcv/RawContestConfig.java
+++ b/src/main/java/network/brightspots/rcv/RawContestConfig.java
@@ -288,7 +288,7 @@ public class RawContestConfig {
       this.name.setValue(name);
       this.excluded.setValue(excluded);
 
-      if (newlineSeparatedAliases != null) {
+      if (newlineSeparatedAliases != null && !newlineSeparatedAliases.isEmpty()) {
         // Split by newline, and also trim whitespace
         this.aliases.setAll(Utils.splitByNewline(newlineSeparatedAliases));
       }


### PR DESCRIPTION
Adding candidates manually through the UI was also adding an empty string alias which was causing a duplication error on config validation (#774) 