### PR TITLE
fix Auto-Loading candidates fails when 'Maximum Number of Candidate... (#766)

### DIFF
--- a/src/main/java/network/brightspots/rcv/ClearBallotCvrReader.java
+++ b/src/main/java/network/brightspots/rcv/ClearBallotCvrReader.java
@@ -82,11 +82,14 @@ class ClearBallotCvrReader extends BaseCvrReader {
           choiceName = Tabulator.UNDECLARED_WRITE_IN_OUTPUT_LABEL;
         }
         Integer rank = Integer.parseInt(choiceFields[RcvChoiceHeaderField.RANK.ordinal()]);
-        if (rank > this.config.getMaxRankingsAllowed()) {
-          Logger.severe(
-              "Rank: %d exceeds max rankings allowed in config: %d",
-              rank, this.config.getMaxRankingsAllowed());
-          throw new CvrParseException();
+        if (!this.config.getRawConfig().rules.maxRankingsAllowed.equals("max")) {
+          if (this.config.getMaxRankingsAllowed() != null
+                  && rank > this.config.getMaxRankingsAllowed()) {
+            Logger.severe(
+                    "Rank: %d exceeds max rankings allowed in config: %d",
+                    rank, this.config.getMaxRankingsAllowed());
+            throw new CvrParseException();
+          }
         }
         columnIndexToRanking.put(columnIndex, new Pair<>(rank, choiceName));
       }


### PR DESCRIPTION
…That Can Be Ranked' setting is set to 'Maximum' #766 

- ContestConfig.getMaxRankingsAllowed() returns '0' when Maximum option is checked, so i checked it from RawConfig
- A null check has been added to inner condition because the same method returns null when maximum option was checked but the input left blank
