### PR TITLE
fix CVR Overvotes show up as blank in simple_cvr (#777)

### DIFF
--- a/src/main/java/network/brightspots/rcv/ContestConfig.java
+++ b/src/main/java/network/brightspots/rcv/ContestConfig.java
@@ -1129,6 +1129,11 @@ class ContestConfig {
       candidateAliasesToNameMap.put(
           Tabulator.UNDECLARED_WRITE_IN_OUTPUT_LABEL, Tabulator.UNDECLARED_WRITE_IN_OUTPUT_LABEL);
     }
+
+    if (isOverVoteLabelEnabled()) {
+      candidateAliasesToNameMap.put(
+              Tabulator.EXPLICIT_OVERVOTE_LABEL, Tabulator.EXPLICIT_OVERVOTE_LABEL);
+    }
   }
 
   private boolean undeclaredWriteInsEnabled() {
@@ -1141,6 +1146,17 @@ class ContestConfig {
       }
     }
     return includeUwi;
+  }
+
+  private boolean isOverVoteLabelEnabled() {
+    boolean overVote = false;
+    for (CvrSource source : rawConfig.cvrFileSources) {
+      if (!isNullOrBlank(source.getOvervoteLabel())) {
+        overVote = true;
+        break;
+      }
+    }
+    return overVote;
   }
 
   // Possible validation errors


### PR DESCRIPTION
CVR Overvotes was blank in the simple_cvr. With the fix, they are marked now in the generated file as in below (#777): 

<img width="779" alt="Screenshot 2023-12-14 at 17 26 52" src="https://github.com/BrightSpots/rcv/assets/107197063/4231355b-7a1c-45e8-85b7-5ee63ebe4624">
