### PR TITLE
Combine all Generic CSV exported files into one large CSV

### DIFF
--- a/src/main/java/network/brightspots/rcv/ResultsWriter.java
+++ b/src/main/java/network/brightspots/rcv/ResultsWriter.java
@@ -658,6 +658,8 @@ class ResultsWriter {
             // so we need to translate it back to the original candidate ID here.
             if (selection.equals(Tabulator.UNDECLARED_WRITE_IN_OUTPUT_LABEL)) {
               selection = undeclaredWriteInLabel;
+            } else if (selection.equals(Tabulator.EXPLICIT_OVERVOTE_LABEL)) {
+              selection = Tabulator.EXPLICIT_OVERVOTE_LABEL;
             } else {
               selection = config.getNameForCandidate(selection);
             }

--- a/src/main/java/network/brightspots/rcv/ResultsWriter.java
+++ b/src/main/java/network/brightspots/rcv/ResultsWriter.java
@@ -538,9 +538,11 @@ class ResultsWriter {
     generateSummaryJson(roundTallies, tallyTransfers, null, outputPath);
   }
 
-  // write CastVoteRecords for the specified contest to the provided folder,
+  // Write CastVoteRecords for the specified contest to the provided folder,
   // using the simplified RCTab format.
-  // returns the filepath written
+  // Note that the castVoteRecords list MUST be stable, as perSourceDataForCsv
+  // relies on its exact ordering to determine which source each record came from.
+  // Returns the filepath written
   String writeRctabCvrCsv(
       List<CastVoteRecord> castVoteRecords,
       List<PerSourceDataForCsv> perSourceDataForCsv,

--- a/src/main/java/network/brightspots/rcv/ResultsWriter.java
+++ b/src/main/java/network/brightspots/rcv/ResultsWriter.java
@@ -91,7 +91,9 @@ class ResultsWriter {
       String timestampString,
       String sequentialTabulationId) {
     outputType = sanitizeStringForOutput(outputType);
-    String sequence = sequentialTabulationId == null ? "" : sequentialSuffixForOutputPath(sequentialTabulationId);
+    String sequence = sequentialTabulationId == null
+            ? ""
+            : sequentialSuffixForOutputPath(sequentialTabulationId);
     String fileName =
         String.format(
             "%s_%s%s",
@@ -566,18 +568,18 @@ class ResultsWriter {
       // print header:
       // ContestId, TabulatorId, BatchId, RecordId, Precinct, Precinct Portion, rank 1 selection,
       // rank 2 selection, ... rank maxRanks selection
-      csvPrinter.print("Source filepath");
+      csvPrinter.print("Source Filepath");
       csvPrinter.print("Contest Id");
       csvPrinter.print("Tabulator Id");
       csvPrinter.print("Batch Id");
       csvPrinter.print("Record Id");
       csvPrinter.print("Precinct");
-      csvPrinter.print("Precinct portion");
+      csvPrinter.print("Precinct Portion");
 
       // Get the max maxRankingsAllowed across all perSourceDataForCsv
       int maxRankingAcrossSources = 0;
       for (PerSourceDataForCsv sourceData : perSourceDataForCsv) {
-          maxRankingAcrossSources = Math.max(sourceData.maxRankingsAllowed, maxRankingAcrossSources);
+        maxRankingAcrossSources = Math.max(sourceData.maxRankingsAllowed, maxRankingAcrossSources);
       }
 
       for (int rank = 1; rank <= maxRankingAcrossSources; rank++) {
@@ -592,8 +594,7 @@ class ResultsWriter {
       PerSourceDataForCsv currentSourceData = perSourceDataForCsv.get(currentSourceIndex);
 
       // print rows:
-      for (int i = 0; i < castVoteRecords.size(); i++)
-      {
+      for (int i = 0; i < castVoteRecords.size(); i++) {
         if (i > currentSourceData.lastIndexInCvrList) {
           // we've moved on to a new contest, so we need to switch to the next source
           currentSourceIndex++;
@@ -616,7 +617,8 @@ class ResultsWriter {
         } else {
           csvPrinter.print(castVoteRecord.getPrecinctPortion());
         }
-        printRankings(currentSourceData.source.getUndeclaredWriteInLabel(), currentSourceData.maxRankingsAllowed, csvPrinter, castVoteRecord);
+        printRankings(currentSourceData.source.getUndeclaredWriteInLabel(),
+            currentSourceData.maxRankingsAllowed, csvPrinter, castVoteRecord);
         csvPrinter.println();
       }
       // finalize the file
@@ -645,8 +647,7 @@ class ResultsWriter {
     for (int rank = 1; rank <= maxRanks; rank++) {
       if (castVoteRecord.candidateRankings.hasRankingAt(rank)) {
         CandidatesAtRanking candidates = castVoteRecord.candidateRankings.get(rank);
-        if (candidates.count() >= 1)
-        {
+        if (candidates.count() >= 1) {
           // We list all candidates at a given ranking on separate lines
           // This allows algorithms which accept overvotes.
           List<String> allCandidatesAtRanking = new ArrayList<>(candidates.count());

--- a/src/main/java/network/brightspots/rcv/ResultsWriter.java
+++ b/src/main/java/network/brightspots/rcv/ResultsWriter.java
@@ -541,9 +541,10 @@ class ResultsWriter {
     generateSummaryJson(roundTallies, tallyTransfers, null, outputPath);
   }
 
-  // write CastVoteRecords for the specified contest to the provided folder
+  // write CastVoteRecords for the specified contest to the provided folder,
+  // using the simplified RCTab format.
   // returns the filepath written
-  String writeGenericCvrCsv(
+  String writeRctabCvrCsv(
       List<CastVoteRecord> castVoteRecords,
       List<PerSourceDataForCsv> perSourceDataForCsv,
       String csvOutputFolder)
@@ -555,7 +556,7 @@ class ResultsWriter {
     AuditableFile outputFile = new AuditableFile(
                     getOutputFilePath(
                             csvOutputFolder,
-                            "essential_cvr",
+                            "rctab_cvr",
                             timestampString,
                             null)
                             + ".csv");

--- a/src/main/java/network/brightspots/rcv/TabulatorSession.java
+++ b/src/main/java/network/brightspots/rcv/TabulatorSession.java
@@ -341,12 +341,12 @@ class TabulatorSession {
       }
     }
 
-    // Output the Generic CSV CVR
+    // Output the RCTab-CSV CVR
     try {
       ResultsWriter writer =
               new ResultsWriter().setContestConfig(config).setTimestampString(timestampString);
       this.convertedFilePath =
-              writer.writeGenericCvrCsv(
+              writer.writeRctabCvrCsv(
                       castVoteRecords,
                       perSourceDataForCsv,
                       config.getOutputDirectory());

--- a/src/main/java/network/brightspots/rcv/TabulatorSession.java
+++ b/src/main/java/network/brightspots/rcv/TabulatorSession.java
@@ -283,7 +283,8 @@ class TabulatorSession {
     List<ResultsWriter.PerSourceDataForCsv> perSourceDataForCsv = new ArrayList<>();
 
     // At each iteration of the following loop, we add records from another source file.
-    for (RawContestConfig.CvrSource source : config.rawConfig.cvrFileSources) {
+    for (int sourceIndex = 0; sourceIndex < config.rawConfig.cvrFileSources.size(); ++sourceIndex) {
+      RawContestConfig.CvrSource source  = config.rawConfig.cvrFileSources.get(sourceIndex);
       String cvrPath = config.resolveConfigPath(source.getFilePath());
       Provider provider = ContestConfig.getProvider(source);
       try {
@@ -294,6 +295,7 @@ class TabulatorSession {
         // Update the per-source data for the results writer
         perSourceDataForCsv.add(new ResultsWriter.PerSourceDataForCsv(
                 source,
+                sourceIndex,
                 castVoteRecords.size() - 1,
                 reader.getMaxRankingsAllowed(source.getContestId())));
 

--- a/src/main/java/network/brightspots/rcv/TabulatorSession.java
+++ b/src/main/java/network/brightspots/rcv/TabulatorSession.java
@@ -33,8 +33,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import javafx.util.Pair;
 import network.brightspots.rcv.CastVoteRecord.CvrParseException;
 import network.brightspots.rcv.ContestConfig.Provider;
 import network.brightspots.rcv.ContestConfig.UnrecognizedProviderException;
@@ -341,19 +339,19 @@ class TabulatorSession {
         Logger.severe("Unexpected error parsing source file: %s\n%s", cvrPath, exception);
         encounteredSourceProblem = true;
       }
+    }
 
-      // Output the Generic CSV CVR
-      try {
-        ResultsWriter writer =
-                new ResultsWriter().setContestConfig(config).setTimestampString(timestampString);
-        this.convertedFilePath =
-                writer.writeGenericCvrCsv(
-                        castVoteRecords,
-                        perSourceDataForCsv,
-                        config.getOutputDirectory());
-      } catch (IOException exception) {
-        // error already logged in ResultsWriter
-      }
+    // Output the Generic CSV CVR
+    try {
+      ResultsWriter writer =
+              new ResultsWriter().setContestConfig(config).setTimestampString(timestampString);
+      this.convertedFilePath =
+              writer.writeGenericCvrCsv(
+                      castVoteRecords,
+                      perSourceDataForCsv,
+                      config.getOutputDirectory());
+    } catch (IOException exception) {
+      // error already logged in ResultsWriter
     }
 
     if (encounteredSourceProblem) {

--- a/src/test/java/network/brightspots/rcv/TabulatorTests.java
+++ b/src/test/java/network/brightspots/rcv/TabulatorTests.java
@@ -257,6 +257,9 @@ class TabulatorTests {
         if (file.getName().equals(".DS_Store")) {
           continue;
         }
+        if (file.getName().endsWith(".lck")) {
+          continue;
+        }
         if (!file.isDirectory()) {
           try {
             // Every ephemeral file must be set to read-only on close, including audit logs

--- a/src/test/resources/network/brightspots/rcv/test_data/convert_to_cdf_from_cdf/convert_to_cdf_from_cdf_expected.csv
+++ b/src/test/resources/network/brightspots/rcv/test_data/convert_to_cdf_from_cdf/convert_to_cdf_from_cdf_expected.csv
@@ -1,31 +1,31 @@
-Contest Id,Tabulator Id,Batch Id,Record Id,Precinct,Precinct Portion,Rank 1,Rank 2,Rank 3,Rank 4
-,,,1,,,Candidate D Name File 1,Candidate D Name File 1,Unused Display Name Candidate A,undervote
-,,,2,,,Candidate C Name File 1,Unused Display Name Candidate A,Candidate D Name File 1,Candidate B Name File 1
-,,,3,,,Candidate C Name File 1,Candidate B Name File 1,Unused Display Name Candidate A,Candidate D Name File 1
-,,,4,,,Unused Display Name Candidate A,Candidate C Name File 1,Candidate B Name File 1,Candidate D Name File 1
-,,,5,,,Candidate B Name File 1,Candidate C Name File 1,Unused Display Name Candidate A,Candidate D Name File 1
-,,,6,,,Unused Display Name Candidate A,Candidate C Name File 1,Candidate B Name File 1,Candidate D Name File 1
-,,,7,,,Candidate B Name File 1,Unused Display Name Candidate A,Candidate C Name File 1,Candidate D Name File 1
-,,,8,,,Unused Display Name Candidate A,Candidate B Name File 1,Candidate C Name File 1,undervote
-,,,9,,,Candidate B Name File 1,Candidate C Name File 1,Unused Display Name Candidate A,Candidate D Name File 1
-,,,10,,,Unused Display Name Candidate A,Candidate B Name File 1,Candidate D Name File 1,Candidate C Name File 1
-,,,11,,,Candidate B Name File 1,Candidate C Name File 1,Unused Display Name Candidate A,Candidate D Name File 1
-,,,12,,,Candidate B Name File 1,Unused Display Name Candidate A,Candidate D Name File 1,Candidate C Name File 1
-,,,13,,,Candidate C Name File 1,Candidate B Name File 1,undervote,undervote
-,,,14,,,Candidate D Name File 1,Candidate C Name File 1,Unused Display Name Candidate A,undervote
-,,,15,,,Unused Display Name Candidate A,Candidate B Name File 1,Candidate D Name File 1,Candidate C Name File 1
-,,,1,,,Candidate D Name File 1,Candidate D Name File 1,Unused Display Name Candidate A,undervote
-,,,2,,,Candidate C Name File 1,Unused Display Name Candidate A,Candidate D Name File 1,Candidate B Name File 1
-,,,3,,,Candidate C Name File 1,Candidate B Name File 1,Unused Display Name Candidate A,Candidate D Name File 1
-,,,4,,,Unused Display Name Candidate A,Candidate C Name File 1,Candidate B Name File 1,Candidate D Name File 1
-,,,5,,,Candidate B Name File 1,Candidate C Name File 1,Unused Display Name Candidate A,Candidate D Name File 1
-,,,6,,,Unused Display Name Candidate A,Candidate C Name File 1,Candidate B Name File 1,Candidate D Name File 1
-,,,7,,,Candidate B Name File 1,Unused Display Name Candidate A,Candidate C Name File 1,Candidate D Name File 1
-,,,8,,,Unused Display Name Candidate A,Candidate B Name File 1,Candidate C Name File 1,undervote
-,,,9,,,Candidate B Name File 1,Candidate C Name File 1,Unused Display Name Candidate A,Candidate D Name File 1
-,,,10,,,Unused Display Name Candidate A,Candidate B Name File 1,Candidate D Name File 1,Candidate C Name File 1
-,,,11,,,Candidate B Name File 1,Candidate C Name File 1,Unused Display Name Candidate A,Candidate D Name File 1
-,,,12,,,Candidate B Name File 1,Unused Display Name Candidate A,Candidate D Name File 1,Candidate C Name File 1
-,,,13,,,Candidate C Name File 1,Candidate B Name File 1,undervote,undervote
-,,,14,,,Candidate D Name File 1,Candidate C Name File 1,Unused Display Name Candidate A,undervote
-,,,15,,,Unused Display Name Candidate A,Candidate B Name File 1,Candidate D Name File 1,Candidate C Name File 1
+Source Filepath,Contest Id,Tabulator Id,Batch Id,Record Id,Precinct,Precinct Portion,Rank 1,Rank 2,Rank 3,Rank 4
+../_shared/cdf_json/cdf_json_file1_cvr.json,,,,1,,,Candidate D Name File 1,Candidate D Name File 1,Unused Display Name Candidate A,undervote
+../_shared/cdf_json/cdf_json_file1_cvr.json,,,,2,,,Candidate C Name File 1,Unused Display Name Candidate A,Candidate D Name File 1,Candidate B Name File 1
+../_shared/cdf_json/cdf_json_file1_cvr.json,,,,3,,,Candidate C Name File 1,Candidate B Name File 1,Unused Display Name Candidate A,Candidate D Name File 1
+../_shared/cdf_json/cdf_json_file1_cvr.json,,,,4,,,Unused Display Name Candidate A,Candidate C Name File 1,Candidate B Name File 1,Candidate D Name File 1
+../_shared/cdf_json/cdf_json_file1_cvr.json,,,,5,,,Candidate B Name File 1,Candidate C Name File 1,Unused Display Name Candidate A,Candidate D Name File 1
+../_shared/cdf_json/cdf_json_file1_cvr.json,,,,6,,,Unused Display Name Candidate A,Candidate C Name File 1,Candidate B Name File 1,Candidate D Name File 1
+../_shared/cdf_json/cdf_json_file1_cvr.json,,,,7,,,Candidate B Name File 1,Unused Display Name Candidate A,Candidate C Name File 1,Candidate D Name File 1
+../_shared/cdf_json/cdf_json_file1_cvr.json,,,,8,,,Unused Display Name Candidate A,Candidate B Name File 1,Candidate C Name File 1,undervote
+../_shared/cdf_json/cdf_json_file1_cvr.json,,,,9,,,Candidate B Name File 1,Candidate C Name File 1,Unused Display Name Candidate A,Candidate D Name File 1
+../_shared/cdf_json/cdf_json_file1_cvr.json,,,,10,,,Unused Display Name Candidate A,Candidate B Name File 1,Candidate D Name File 1,Candidate C Name File 1
+../_shared/cdf_json/cdf_json_file1_cvr.json,,,,11,,,Candidate B Name File 1,Candidate C Name File 1,Unused Display Name Candidate A,Candidate D Name File 1
+../_shared/cdf_json/cdf_json_file1_cvr.json,,,,12,,,Candidate B Name File 1,Unused Display Name Candidate A,Candidate D Name File 1,Candidate C Name File 1
+../_shared/cdf_json/cdf_json_file1_cvr.json,,,,13,,,Candidate C Name File 1,Candidate B Name File 1,undervote,undervote
+../_shared/cdf_json/cdf_json_file1_cvr.json,,,,14,,,Candidate D Name File 1,Candidate C Name File 1,Unused Display Name Candidate A,undervote
+../_shared/cdf_json/cdf_json_file1_cvr.json,,,,15,,,Unused Display Name Candidate A,Candidate B Name File 1,Candidate D Name File 1,Candidate C Name File 1
+../_shared/cdf_json/cdf_json_file2_cvr.json,,,,1,,,Candidate D Name File 1,Candidate D Name File 1,Unused Display Name Candidate A,undervote
+../_shared/cdf_json/cdf_json_file2_cvr.json,,,,2,,,Candidate C Name File 1,Unused Display Name Candidate A,Candidate D Name File 1,Candidate B Name File 1
+../_shared/cdf_json/cdf_json_file2_cvr.json,,,,3,,,Candidate C Name File 1,Candidate B Name File 1,Unused Display Name Candidate A,Candidate D Name File 1
+../_shared/cdf_json/cdf_json_file2_cvr.json,,,,4,,,Unused Display Name Candidate A,Candidate C Name File 1,Candidate B Name File 1,Candidate D Name File 1
+../_shared/cdf_json/cdf_json_file2_cvr.json,,,,5,,,Candidate B Name File 1,Candidate C Name File 1,Unused Display Name Candidate A,Candidate D Name File 1
+../_shared/cdf_json/cdf_json_file2_cvr.json,,,,6,,,Unused Display Name Candidate A,Candidate C Name File 1,Candidate B Name File 1,Candidate D Name File 1
+../_shared/cdf_json/cdf_json_file2_cvr.json,,,,7,,,Candidate B Name File 1,Unused Display Name Candidate A,Candidate C Name File 1,Candidate D Name File 1
+../_shared/cdf_json/cdf_json_file2_cvr.json,,,,8,,,Unused Display Name Candidate A,Candidate B Name File 1,Candidate C Name File 1,undervote
+../_shared/cdf_json/cdf_json_file2_cvr.json,,,,9,,,Candidate B Name File 1,Candidate C Name File 1,Unused Display Name Candidate A,Candidate D Name File 1
+../_shared/cdf_json/cdf_json_file2_cvr.json,,,,10,,,Unused Display Name Candidate A,Candidate B Name File 1,Candidate D Name File 1,Candidate C Name File 1
+../_shared/cdf_json/cdf_json_file2_cvr.json,,,,11,,,Candidate B Name File 1,Candidate C Name File 1,Unused Display Name Candidate A,Candidate D Name File 1
+../_shared/cdf_json/cdf_json_file2_cvr.json,,,,12,,,Candidate B Name File 1,Unused Display Name Candidate A,Candidate D Name File 1,Candidate C Name File 1
+../_shared/cdf_json/cdf_json_file2_cvr.json,,,,13,,,Candidate C Name File 1,Candidate B Name File 1,undervote,undervote
+../_shared/cdf_json/cdf_json_file2_cvr.json,,,,14,,,Candidate D Name File 1,Candidate C Name File 1,Unused Display Name Candidate A,undervote
+../_shared/cdf_json/cdf_json_file2_cvr.json,,,,15,,,Unused Display Name Candidate A,Candidate B Name File 1,Candidate D Name File 1,Candidate C Name File 1

--- a/src/test/resources/network/brightspots/rcv/test_data/convert_to_cdf_from_dominion/convert_to_cdf_from_dominion_expected.csv
+++ b/src/test/resources/network/brightspots/rcv/test_data/convert_to_cdf_from_dominion/convert_to_cdf_from_dominion_expected.csv
@@ -1,1001 +1,1046 @@
-Contest Id,Tabulator Id,Batch Id,Record Id,Precinct,Precinct Portion,Rank 1,Rank 2,Rank 3,Rank 4,Rank 5
-1,42,1,1,,Precinct 1,Michael R. Bloomberg,Joseph R. Biden,12,Elizabeth Warren,Tulsi Gabbard
-1,42,1,2,,Precinct 1,Joseph R. Biden,12,Bernie Sanders,Pete Buttigieg,Tulsi Gabbard
-1,42,1,3,,Precinct 1,12,Amy Klobuchar,Tulsi Gabbard,Joseph R. Biden,Michael R. Bloomberg
-1,42,1,4,,Precinct 1,Tulsi Gabbard,Bernie Sanders,Tom Steyer,12,Elizabeth Warren
-1,42,1,5,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,42,1,6,,Precinct 1,Tom Steyer,Joseph R. Biden,Elizabeth Warren,Pete Buttigieg,12
-1,42,1,7,,Precinct 1,Tulsi Gabbard,Michael R. Bloomberg,Amy Klobuchar,Bernie Sanders,Joseph R. Biden
-1,42,1,8,,Precinct 1,Tom Steyer,Bernie Sanders,Elizabeth Warren,Amy Klobuchar,Michael R. Bloomberg
-1,42,1,9,,Precinct 1,Michael R. Bloomberg,Bernie Sanders,Elizabeth Warren,Tom Steyer,Pete Buttigieg
-1,42,1,10,,Precinct 1,Tom Steyer,Elizabeth Warren,Bernie Sanders,Tulsi Gabbard,Pete Buttigieg
-1,42,1,11,,Precinct 1,Tom Steyer,Pete Buttigieg,Joseph R. Biden,Tulsi Gabbard,Michael R. Bloomberg
-1,42,1,12,,Precinct 1,Michael R. Bloomberg,Pete Buttigieg,Tulsi Gabbard,Elizabeth Warren,12
-1,42,1,13,,Precinct 1,Elizabeth Warren,Joseph R. Biden,Amy Klobuchar,Bernie Sanders,Tulsi Gabbard
-1,42,1,14,,Precinct 1,Elizabeth Warren,Tom Steyer,Bernie Sanders,12,Tulsi Gabbard
-1,42,1,15,,Precinct 1,Tom Steyer,12,Pete Buttigieg,Elizabeth Warren,Michael R. Bloomberg
-1,42,1,16,,Precinct 1,Tom Steyer,Amy Klobuchar,Tulsi Gabbard,Michael R. Bloomberg,12
-1,42,1,17,,Precinct 1,Michael R. Bloomberg,Elizabeth Warren,Tulsi Gabbard,12,Pete Buttigieg
-1,42,1,18,,Precinct 1,Joseph R. Biden,Bernie Sanders,Tom Steyer,Amy Klobuchar,12
-1,42,1,19,,Precinct 1,Bernie Sanders,Tulsi Gabbard,12,Amy Klobuchar,Elizabeth Warren
-1,42,1,20,,Precinct 1,Pete Buttigieg,Amy Klobuchar,12,Michael R. Bloomberg,Bernie Sanders
-1,34,1,1,,Precinct 1,Pete Buttigieg,Joseph R. Biden,12,Elizabeth Warren,Michael R. Bloomberg
-1,34,1,2,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,34,1,3,,Precinct 1,Bernie Sanders,Tulsi Gabbard,Amy Klobuchar,Michael R. Bloomberg,Pete Buttigieg
-1,34,1,4,,Precinct 1,Elizabeth Warren,Bernie Sanders,Pete Buttigieg,Joseph R. Biden,Tulsi Gabbard
-1,34,1,5,,Precinct 1,Pete Buttigieg,Michael R. Bloomberg,12,Bernie Sanders,Joseph R. Biden
-1,34,1,6,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,34,1,7,,Precinct 1,Tulsi Gabbard,Michael R. Bloomberg,Bernie Sanders,12,Tom Steyer
-1,34,1,8,,Precinct 1,Joseph R. Biden,Bernie Sanders,12,Amy Klobuchar,Michael R. Bloomberg
-1,34,1,9,,Precinct 1,Pete Buttigieg,Tulsi Gabbard,Tom Steyer,Amy Klobuchar,12
-1,34,1,10,,Precinct 1,Bernie Sanders,Elizabeth Warren,Tulsi Gabbard,Amy Klobuchar,Tom Steyer
-1,34,1,11,,Precinct 1,Bernie Sanders,Tulsi Gabbard,Joseph R. Biden,Tom Steyer,Elizabeth Warren
-1,34,1,12,,Precinct 1,Joseph R. Biden,Tulsi Gabbard,Bernie Sanders,Amy Klobuchar,Michael R. Bloomberg
-1,34,1,13,,Precinct 1,Amy Klobuchar,Tom Steyer,Elizabeth Warren,12,Pete Buttigieg
-1,34,1,14,,Precinct 1,Tulsi Gabbard,Amy Klobuchar,12,Michael R. Bloomberg,Bernie Sanders
-1,34,1,15,,Precinct 1,Bernie Sanders,Elizabeth Warren,12,Tom Steyer,Pete Buttigieg
-1,34,1,16,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,34,1,17,,Precinct 1,Amy Klobuchar,Bernie Sanders,Tulsi Gabbard,Michael R. Bloomberg,Pete Buttigieg
-1,34,1,18,,Precinct 1,Tom Steyer,Tulsi Gabbard,Pete Buttigieg,Amy Klobuchar,Michael R. Bloomberg
-1,34,1,19,,Precinct 1,Tom Steyer,Bernie Sanders,Joseph R. Biden,Amy Klobuchar,Elizabeth Warren
-1,34,1,20,,Precinct 1,12,Tulsi Gabbard,Joseph R. Biden,Elizabeth Warren,Bernie Sanders
-1,50,1,1,,Precinct 1,12,Bernie Sanders,Amy Klobuchar,Elizabeth Warren,Tom Steyer
-1,50,1,2,,Precinct 1,Bernie Sanders,Tulsi Gabbard,Tom Steyer,12,Michael R. Bloomberg
-1,50,1,3,,Precinct 1,12,Tulsi Gabbard,Michael R. Bloomberg,Amy Klobuchar,Elizabeth Warren
-1,50,1,4,,Precinct 1,Amy Klobuchar,12,Tom Steyer,Bernie Sanders,Michael R. Bloomberg
-1,50,1,5,,Precinct 1,Michael R. Bloomberg,Tulsi Gabbard,Bernie Sanders,Tom Steyer,Joseph R. Biden
-1,50,1,6,,Precinct 1,Tulsi Gabbard,Michael R. Bloomberg,Amy Klobuchar,Pete Buttigieg,Joseph R. Biden
-1,50,1,7,,Precinct 1,Tom Steyer,Tulsi Gabbard,Pete Buttigieg,Elizabeth Warren,Michael R. Bloomberg
-1,50,1,8,,Precinct 1,Elizabeth Warren,12,Tulsi Gabbard,Bernie Sanders,Amy Klobuchar
-1,50,1,9,,Precinct 1,Joseph R. Biden,Elizabeth Warren,Bernie Sanders,Pete Buttigieg,Amy Klobuchar
-1,50,1,10,,Precinct 1,Tulsi Gabbard,Joseph R. Biden,Pete Buttigieg,12,Elizabeth Warren
-1,50,1,11,,Precinct 1,Michael R. Bloomberg,Tulsi Gabbard,Pete Buttigieg,12,Joseph R. Biden
-1,50,1,12,,Precinct 1,Tom Steyer,Pete Buttigieg,Joseph R. Biden,Bernie Sanders,Elizabeth Warren
-1,50,1,13,,Precinct 1,Michael R. Bloomberg,Tom Steyer,Bernie Sanders,Tulsi Gabbard,Joseph R. Biden
-1,50,1,14,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,50,1,15,,Precinct 1,Tulsi Gabbard,Pete Buttigieg,Amy Klobuchar,12,Tom Steyer
-1,50,1,16,,Precinct 1,Tom Steyer,Pete Buttigieg,Michael R. Bloomberg,Tulsi Gabbard,Bernie Sanders
-1,50,1,17,,Precinct 1,Pete Buttigieg,Bernie Sanders,Michael R. Bloomberg,Tom Steyer,Amy Klobuchar
-1,50,1,18,,Precinct 1,Elizabeth Warren,Bernie Sanders,Tom Steyer,Tulsi Gabbard,Pete Buttigieg
-1,50,1,19,,Precinct 1,Joseph R. Biden,Tom Steyer,12,Michael R. Bloomberg,Tulsi Gabbard
-1,50,1,20,,Precinct 1,Pete Buttigieg,12,Joseph R. Biden,Amy Klobuchar,Tulsi Gabbard
-1,18,1,1,,Precinct 1,Michael R. Bloomberg,Bernie Sanders,Tom Steyer,Amy Klobuchar,12
-1,18,1,2,,Precinct 1,12,Bernie Sanders,Tom Steyer,Amy Klobuchar,Pete Buttigieg
-1,18,1,3,,Precinct 1,Tulsi Gabbard,Tom Steyer,Amy Klobuchar,12,Joseph R. Biden
-1,18,1,4,,Precinct 1,Amy Klobuchar,12,Bernie Sanders,Tom Steyer,Joseph R. Biden
-1,18,1,5,,Precinct 1,Bernie Sanders,Amy Klobuchar,Joseph R. Biden,Pete Buttigieg,Tulsi Gabbard
-1,18,1,6,,Precinct 1,12,Tom Steyer,Bernie Sanders,Michael R. Bloomberg,Joseph R. Biden
-1,18,1,7,,Precinct 1,Tulsi Gabbard,Amy Klobuchar,Tom Steyer,Michael R. Bloomberg,Pete Buttigieg
-1,18,1,8,,Precinct 1,Bernie Sanders,Elizabeth Warren,Pete Buttigieg,Amy Klobuchar,Tulsi Gabbard
-1,18,1,9,,Precinct 1,12,Amy Klobuchar,Tom Steyer,Michael R. Bloomberg,Tulsi Gabbard
-1,18,1,10,,Precinct 1,Bernie Sanders,12,Michael R. Bloomberg,Joseph R. Biden,Tom Steyer
-1,18,1,11,,Precinct 1,12,Michael R. Bloomberg,Pete Buttigieg,Elizabeth Warren,Tom Steyer
-1,18,1,12,,Precinct 1,Pete Buttigieg,Tom Steyer,Tulsi Gabbard,12,Elizabeth Warren
-1,18,1,13,,Precinct 1,Bernie Sanders,Amy Klobuchar,Pete Buttigieg,Elizabeth Warren,Joseph R. Biden
-1,18,1,14,,Precinct 1,Tom Steyer,Joseph R. Biden,Pete Buttigieg,12,Tulsi Gabbard
-1,18,1,15,,Precinct 1,Pete Buttigieg,12,Joseph R. Biden,Amy Klobuchar,Bernie Sanders
-1,18,1,16,,Precinct 1,Pete Buttigieg,Joseph R. Biden,Tom Steyer,Michael R. Bloomberg,Tulsi Gabbard
-1,18,1,17,,Precinct 1,Bernie Sanders,Pete Buttigieg,Tom Steyer,Joseph R. Biden,12
-1,18,1,18,,Precinct 1,Joseph R. Biden,Tom Steyer,Tulsi Gabbard,12,Amy Klobuchar
-1,18,1,19,,Precinct 1,Joseph R. Biden,Amy Klobuchar,Bernie Sanders,Michael R. Bloomberg,Tom Steyer
-1,18,1,20,,Precinct 1,Joseph R. Biden,Pete Buttigieg,Tom Steyer,Tulsi Gabbard,Michael R. Bloomberg
-1,26,1,1,,Precinct 1,Tulsi Gabbard,Tom Steyer,Bernie Sanders,12,Pete Buttigieg
-1,26,1,2,,Precinct 1,Bernie Sanders,Tom Steyer,Michael R. Bloomberg,Tulsi Gabbard,12
-1,26,1,3,,Precinct 1,Michael R. Bloomberg,Tom Steyer,Amy Klobuchar,Bernie Sanders,Tulsi Gabbard
-1,26,1,4,,Precinct 1,Michael R. Bloomberg,Elizabeth Warren,Amy Klobuchar,Joseph R. Biden,12
-1,26,1,5,,Precinct 1,Michael R. Bloomberg,Joseph R. Biden,Elizabeth Warren,Tom Steyer,Tulsi Gabbard
-1,26,1,6,,Precinct 1,Joseph R. Biden,Michael R. Bloomberg,Tom Steyer,Pete Buttigieg,Bernie Sanders
-1,26,1,7,,Precinct 1,Joseph R. Biden,Elizabeth Warren,12,Joseph R. Biden,Bernie Sanders
-1,26,1,8,,Precinct 1,Elizabeth Warren,Michael R. Bloomberg,Amy Klobuchar,Pete Buttigieg,overvote
-1,26,1,9,,Precinct 1,12,Tulsi Gabbard,Michael R. Bloomberg,Bernie Sanders,Amy Klobuchar
-1,26,1,10,,Precinct 1,Pete Buttigieg,Tulsi Gabbard,Michael R. Bloomberg,12,Bernie Sanders
-1,26,1,11,,Precinct 1,Michael R. Bloomberg,Tulsi Gabbard,Joseph R. Biden,12,Amy Klobuchar
-1,26,1,12,,Precinct 1,Amy Klobuchar,Tulsi Gabbard,Bernie Sanders,Tom Steyer,12
-1,26,1,13,,Precinct 1,Pete Buttigieg,Michael R. Bloomberg,Bernie Sanders,Amy Klobuchar,Tulsi Gabbard
-1,26,1,14,,Precinct 1,Joseph R. Biden,Michael R. Bloomberg,Bernie Sanders,Pete Buttigieg,Amy Klobuchar
-1,26,1,15,,Precinct 1,Amy Klobuchar,Elizabeth Warren,Pete Buttigieg,Joseph R. Biden,Michael R. Bloomberg
-1,26,1,16,,Precinct 1,Amy Klobuchar,Pete Buttigieg,Michael R. Bloomberg,Elizabeth Warren,Bernie Sanders
-1,26,1,17,,Precinct 1,Joseph R. Biden,Pete Buttigieg,Tulsi Gabbard,Amy Klobuchar,Elizabeth Warren
-1,26,1,18,,Precinct 1,Elizabeth Warren,Joseph R. Biden,Pete Buttigieg,12,Amy Klobuchar
-1,26,1,19,,Precinct 1,Amy Klobuchar,Bernie Sanders,Elizabeth Warren,Pete Buttigieg,Tulsi Gabbard
-1,26,1,20,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,24,1,1,,Precinct 1,Joseph R. Biden,Bernie Sanders,Amy Klobuchar,Tom Steyer,Tulsi Gabbard
-1,24,1,2,,Precinct 1,Bernie Sanders,Amy Klobuchar,Elizabeth Warren,Tulsi Gabbard,12
-1,24,1,3,,Precinct 1,Tulsi Gabbard,Tom Steyer,Bernie Sanders,Elizabeth Warren,Michael R. Bloomberg
-1,24,1,4,,Precinct 1,Bernie Sanders,Amy Klobuchar,Pete Buttigieg,Elizabeth Warren,Tulsi Gabbard
-1,24,1,5,,Precinct 1,Elizabeth Warren,Michael R. Bloomberg,Bernie Sanders,Joseph R. Biden,12
-1,24,1,6,,Precinct 1,Pete Buttigieg,Elizabeth Warren,Amy Klobuchar,Tom Steyer,12
-1,24,1,7,,Precinct 1,Pete Buttigieg,Elizabeth Warren,Amy Klobuchar,Joseph R. Biden,Tom Steyer
-1,24,1,8,,Precinct 1,Joseph R. Biden,Michael R. Bloomberg,Bernie Sanders,Amy Klobuchar,12
-1,24,1,9,,Precinct 1,Pete Buttigieg,Joseph R. Biden,Bernie Sanders,Tulsi Gabbard,Tom Steyer
-1,24,1,10,,Precinct 1,12,Michael R. Bloomberg,Bernie Sanders,Elizabeth Warren,Pete Buttigieg
-1,24,1,11,,Precinct 1,Amy Klobuchar,Pete Buttigieg,Bernie Sanders,Joseph R. Biden,Tulsi Gabbard
-1,24,1,12,,Precinct 1,Tom Steyer,Amy Klobuchar,Pete Buttigieg,12,Joseph R. Biden
-1,24,1,13,,Precinct 1,Michael R. Bloomberg,Amy Klobuchar,Elizabeth Warren,Pete Buttigieg,12
-1,24,1,14,,Precinct 1,12,Tulsi Gabbard,Bernie Sanders,Elizabeth Warren,Amy Klobuchar
-1,24,1,15,,Precinct 1,Pete Buttigieg,12,Michael R. Bloomberg,Tom Steyer,Tulsi Gabbard
-1,24,1,16,,Precinct 1,Amy Klobuchar,Pete Buttigieg,Michael R. Bloomberg,Bernie Sanders,Tulsi Gabbard
-1,24,1,17,,Precinct 1,Joseph R. Biden,Tom Steyer,Tulsi Gabbard,12,Bernie Sanders
-1,24,1,18,,Precinct 1,Amy Klobuchar,Elizabeth Warren,Michael R. Bloomberg,Pete Buttigieg,Tom Steyer
-1,24,1,19,,Precinct 1,Amy Klobuchar,Tulsi Gabbard,Bernie Sanders,Michael R. Bloomberg,Joseph R. Biden
-1,24,1,20,,Precinct 1,Tom Steyer,Amy Klobuchar,12,Michael R. Bloomberg,Bernie Sanders
-1,49,1,1,,Precinct 1,Tulsi Gabbard,Elizabeth Warren,Tom Steyer,Michael R. Bloomberg,12
-1,49,1,2,,Precinct 1,Amy Klobuchar,Michael R. Bloomberg,Bernie Sanders,Elizabeth Warren,Joseph R. Biden
-1,49,1,3,,Precinct 1,12,Joseph R. Biden,Elizabeth Warren,Tulsi Gabbard,Tom Steyer
-1,49,1,4,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,49,1,5,,Precinct 1,Amy Klobuchar,Pete Buttigieg,Elizabeth Warren,Bernie Sanders,Tulsi Gabbard
-1,49,1,6,,Precinct 1,Tom Steyer,Tulsi Gabbard,Bernie Sanders,Elizabeth Warren,Joseph R. Biden
-1,49,1,7,,Precinct 1,Pete Buttigieg,Michael R. Bloomberg,12,Tulsi Gabbard,Elizabeth Warren
-1,49,1,8,,Precinct 1,Michael R. Bloomberg,12,Joseph R. Biden,Tom Steyer,Bernie Sanders
-1,49,1,9,,Precinct 1,Amy Klobuchar,12,Joseph R. Biden,Tulsi Gabbard,Bernie Sanders
-1,49,1,10,,Precinct 1,Bernie Sanders,12,Tom Steyer,Elizabeth Warren,Michael R. Bloomberg
-1,49,1,11,,Precinct 1,Pete Buttigieg,Tom Steyer,12,Bernie Sanders,Tulsi Gabbard
-1,49,1,12,,Precinct 1,Elizabeth Warren,Pete Buttigieg,Tom Steyer,Joseph R. Biden,12
-1,49,1,13,,Precinct 1,Joseph R. Biden,Michael R. Bloomberg,Amy Klobuchar,Elizabeth Warren,Tulsi Gabbard
-1,49,1,14,,Precinct 1,12,Bernie Sanders,Elizabeth Warren,Tulsi Gabbard,Michael R. Bloomberg
-1,49,1,15,,Precinct 1,Michael R. Bloomberg,Pete Buttigieg,12,Amy Klobuchar,Tulsi Gabbard
-1,49,1,16,,Precinct 1,Tom Steyer,Bernie Sanders,Amy Klobuchar,Tulsi Gabbard,12
-1,49,1,17,,Precinct 1,Bernie Sanders,Joseph R. Biden,Tom Steyer,Pete Buttigieg,12
-1,49,1,18,,Precinct 1,Pete Buttigieg,Amy Klobuchar,Michael R. Bloomberg,Elizabeth Warren,Tulsi Gabbard
-1,49,1,19,,Precinct 1,Pete Buttigieg,Tom Steyer,Bernie Sanders,Joseph R. Biden,Amy Klobuchar
-1,49,1,20,,Precinct 1,12,Elizabeth Warren,Michael R. Bloomberg,Bernie Sanders,Joseph R. Biden
-1,25,1,1,,Precinct 1,Joseph R. Biden,Tulsi Gabbard,12,Pete Buttigieg,Elizabeth Warren
-1,25,1,2,,Precinct 1,Amy Klobuchar,Tulsi Gabbard,Pete Buttigieg,12,Bernie Sanders
-1,25,1,3,,Precinct 1,Michael R. Bloomberg,Tulsi Gabbard,Joseph R. Biden,Bernie Sanders,Elizabeth Warren
-1,25,1,4,,Precinct 1,Bernie Sanders,Elizabeth Warren,Michael R. Bloomberg,Tulsi Gabbard,12
-1,25,1,5,,Precinct 1,Joseph R. Biden,Elizabeth Warren,Tulsi Gabbard,Amy Klobuchar,Pete Buttigieg
-1,25,1,6,,Precinct 1,Tulsi Gabbard,12,Bernie Sanders,Joseph R. Biden,Tom Steyer
-1,25,1,7,,Precinct 1,Tulsi Gabbard,Joseph R. Biden,12,Amy Klobuchar,Michael R. Bloomberg
-1,25,1,8,,Precinct 1,undervote,Bernie Sanders,Joseph R. Biden,Pete Buttigieg,Elizabeth Warren
-1,25,1,9,,Precinct 1,Bernie Sanders,Pete Buttigieg,Tom Steyer,Tulsi Gabbard,Joseph R. Biden
-1,25,1,10,,Precinct 1,Tom Steyer,Pete Buttigieg,Amy Klobuchar,Elizabeth Warren,Tulsi Gabbard
-1,25,1,11,,Precinct 1,Tulsi Gabbard,Joseph R. Biden,Pete Buttigieg,12,Michael R. Bloomberg
-1,25,1,12,,Precinct 1,Amy Klobuchar,Bernie Sanders,12,Elizabeth Warren,Pete Buttigieg
-1,25,1,13,,Precinct 1,Tulsi Gabbard,Joseph R. Biden,Amy Klobuchar,Tom Steyer,Michael R. Bloomberg
-1,25,1,14,,Precinct 1,Michael R. Bloomberg,Pete Buttigieg,12,Amy Klobuchar,Bernie Sanders
-1,25,1,15,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,25,1,16,,Precinct 1,Elizabeth Warren,Tom Steyer,Michael R. Bloomberg,Bernie Sanders,Pete Buttigieg
-1,25,1,17,,Precinct 1,Pete Buttigieg,Bernie Sanders,Elizabeth Warren,Michael R. Bloomberg,Tulsi Gabbard
-1,25,1,18,,Precinct 1,Michael R. Bloomberg,Joseph R. Biden,Tulsi Gabbard,Tom Steyer,Amy Klobuchar
-1,25,1,19,,Precinct 1,12,Tulsi Gabbard,Pete Buttigieg,Bernie Sanders,Joseph R. Biden
-1,25,1,20,,Precinct 1,Amy Klobuchar,Michael R. Bloomberg,Elizabeth Warren,Bernie Sanders,Joseph R. Biden
-1,33,1,1,,Precinct 1,Amy Klobuchar,Bernie Sanders,Pete Buttigieg,12,Tulsi Gabbard
-1,33,1,2,,Precinct 1,Tom Steyer,Pete Buttigieg,Bernie Sanders,Joseph R. Biden,Michael R. Bloomberg
-1,33,1,3,,Precinct 1,Michael R. Bloomberg,12,Tulsi Gabbard,Tom Steyer,Pete Buttigieg
-1,33,1,4,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,33,1,5,,Precinct 1,Elizabeth Warren,Michael R. Bloomberg,Amy Klobuchar,12,Bernie Sanders
-1,33,1,6,,Precinct 1,Michael R. Bloomberg,Joseph R. Biden,12,Elizabeth Warren,Tom Steyer
-1,33,1,7,,Precinct 1,Michael R. Bloomberg,Amy Klobuchar,Tom Steyer,12,Bernie Sanders
-1,33,1,8,,Precinct 1,Tom Steyer,Joseph R. Biden,12,Tulsi Gabbard,Pete Buttigieg
-1,33,1,9,,Precinct 1,Joseph R. Biden,Pete Buttigieg,Bernie Sanders,Amy Klobuchar,12
-1,33,1,10,,Precinct 1,Bernie Sanders,Amy Klobuchar,Tulsi Gabbard,Elizabeth Warren,Michael R. Bloomberg
-1,33,1,11,,Precinct 1,Tulsi Gabbard,12,Elizabeth Warren,Michael R. Bloomberg,Joseph R. Biden
-1,33,1,12,,Precinct 1,Bernie Sanders,Tom Steyer,Elizabeth Warren,Michael R. Bloomberg,Amy Klobuchar
-1,33,1,13,,Precinct 1,Elizabeth Warren,Michael R. Bloomberg,Amy Klobuchar,Tulsi Gabbard,Bernie Sanders
-1,33,1,14,,Precinct 1,Pete Buttigieg,Joseph R. Biden,Tom Steyer,Elizabeth Warren,Bernie Sanders
-1,33,1,15,,Precinct 1,Michael R. Bloomberg,Bernie Sanders,Joseph R. Biden,Tom Steyer,Amy Klobuchar
-1,33,1,16,,Precinct 1,Tulsi Gabbard,Michael R. Bloomberg,Elizabeth Warren,Joseph R. Biden,Pete Buttigieg
-1,33,1,17,,Precinct 1,Amy Klobuchar,Tulsi Gabbard,Bernie Sanders,Michael R. Bloomberg,Elizabeth Warren
-1,33,1,18,,Precinct 1,Pete Buttigieg,Joseph R. Biden,Bernie Sanders,Tom Steyer,Tulsi Gabbard
-1,33,1,19,,Precinct 1,Joseph R. Biden,Amy Klobuchar,Pete Buttigieg,Michael R. Bloomberg,12
-1,33,1,20,,Precinct 1,Bernie Sanders,Tulsi Gabbard,Michael R. Bloomberg,Elizabeth Warren,Joseph R. Biden
-1,32,1,1,,Precinct 1,Elizabeth Warren,Pete Buttigieg,Bernie Sanders,Tom Steyer,Joseph R. Biden
-1,32,1,2,,Precinct 1,12,Joseph R. Biden,Bernie Sanders,Elizabeth Warren,Michael R. Bloomberg
-1,32,1,3,,Precinct 1,Pete Buttigieg,Elizabeth Warren,Michael R. Bloomberg,Bernie Sanders,Tom Steyer
-1,32,1,4,,Precinct 1,Tulsi Gabbard,Joseph R. Biden,Pete Buttigieg,Elizabeth Warren,Amy Klobuchar
-1,32,1,5,,Precinct 1,Bernie Sanders,Tom Steyer,Tulsi Gabbard,Michael R. Bloomberg,12
-1,32,1,6,,Precinct 1,Elizabeth Warren,12,Tom Steyer,Joseph R. Biden,Pete Buttigieg
-1,32,1,7,,Precinct 1,Tom Steyer,Elizabeth Warren,Tulsi Gabbard,Pete Buttigieg,Bernie Sanders
-1,32,1,8,,Precinct 1,Joseph R. Biden,Bernie Sanders,Michael R. Bloomberg,Elizabeth Warren,12
-1,32,1,9,,Precinct 1,Bernie Sanders,12,Elizabeth Warren,Michael R. Bloomberg,Amy Klobuchar
-1,32,1,10,,Precinct 1,Amy Klobuchar,Tom Steyer,Tulsi Gabbard,Michael R. Bloomberg,12
-1,32,1,11,,Precinct 1,Elizabeth Warren,12,Tom Steyer,Michael R. Bloomberg,Tulsi Gabbard
-1,32,1,12,,Precinct 1,Joseph R. Biden,12,Amy Klobuchar,Tom Steyer,Bernie Sanders
-1,32,1,13,,Precinct 1,Elizabeth Warren,12,Amy Klobuchar,Tom Steyer,Michael R. Bloomberg
-1,32,1,14,,Precinct 1,Elizabeth Warren,12,Joseph R. Biden,Tulsi Gabbard,Amy Klobuchar
-1,32,1,15,,Precinct 1,12,Pete Buttigieg,Tom Steyer,Tulsi Gabbard,Elizabeth Warren
-1,32,1,16,,Precinct 1,12,Pete Buttigieg,Tom Steyer,Bernie Sanders,Joseph R. Biden
-1,32,1,17,,Precinct 1,Amy Klobuchar,Bernie Sanders,overvote,Joseph R. Biden,Elizabeth Warren
-1,32,1,18,,Precinct 1,Joseph R. Biden,Tulsi Gabbard,Elizabeth Warren,12,Amy Klobuchar
-1,32,1,19,,Precinct 1,Elizabeth Warren,Pete Buttigieg,Tom Steyer,12,Tulsi Gabbard
-1,32,1,20,,Precinct 1,Pete Buttigieg,Amy Klobuchar,12,Joseph R. Biden,Tulsi Gabbard
-1,41,1,1,,Precinct 1,Bernie Sanders,Amy Klobuchar,Pete Buttigieg,Michael R. Bloomberg,Tulsi Gabbard
-1,41,1,2,,Precinct 1,Tom Steyer,Amy Klobuchar,Tulsi Gabbard,Michael R. Bloomberg,12
-1,41,1,3,,Precinct 1,12,Michael R. Bloomberg,Tom Steyer,Pete Buttigieg,Joseph R. Biden
-1,41,1,4,,Precinct 1,12,Tom Steyer,Tulsi Gabbard,Amy Klobuchar,Bernie Sanders
-1,41,1,5,,Precinct 1,Tom Steyer,Pete Buttigieg,Tulsi Gabbard,Elizabeth Warren,12
-1,41,1,6,,Precinct 1,Pete Buttigieg,12,Bernie Sanders,Elizabeth Warren,Michael R. Bloomberg
-1,41,1,7,,Precinct 1,Joseph R. Biden,Michael R. Bloomberg,Bernie Sanders,Tulsi Gabbard,Pete Buttigieg
-1,41,1,8,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,41,1,9,,Precinct 1,Joseph R. Biden,Bernie Sanders,Tom Steyer,Tulsi Gabbard,Pete Buttigieg
-1,41,1,10,,Precinct 1,Joseph R. Biden,Pete Buttigieg,Tulsi Gabbard,Michael R. Bloomberg,Tom Steyer
-1,41,1,11,,Precinct 1,Amy Klobuchar,Michael R. Bloomberg,Bernie Sanders,Elizabeth Warren,Tulsi Gabbard
-1,41,1,12,,Precinct 1,Elizabeth Warren,Pete Buttigieg,12,Amy Klobuchar,Tulsi Gabbard
-1,41,1,13,,Precinct 1,Tulsi Gabbard,Amy Klobuchar,Pete Buttigieg,Elizabeth Warren,Joseph R. Biden
-1,41,1,14,,Precinct 1,Michael R. Bloomberg,12,Tom Steyer,Tulsi Gabbard,Pete Buttigieg
-1,41,1,15,,Precinct 1,Joseph R. Biden,Tom Steyer,Michael R. Bloomberg,12,Amy Klobuchar
-1,41,1,16,,Precinct 1,Amy Klobuchar,Michael R. Bloomberg,Bernie Sanders,Pete Buttigieg,Tom Steyer
-1,41,1,17,,Precinct 1,12,Amy Klobuchar,Tom Steyer,Pete Buttigieg,Joseph R. Biden
-1,41,1,18,,Precinct 1,Michael R. Bloomberg,Elizabeth Warren,Amy Klobuchar,12,Bernie Sanders
-1,41,1,19,,Precinct 1,Joseph R. Biden,Elizabeth Warren,Tulsi Gabbard,Tom Steyer,Pete Buttigieg
-1,41,1,20,,Precinct 1,Tom Steyer,Bernie Sanders,Joseph R. Biden,12,Michael R. Bloomberg
-1,23,1,1,,Precinct 1,Elizabeth Warren,Amy Klobuchar,12,Tom Steyer,Pete Buttigieg
-1,23,1,2,,Precinct 1,Amy Klobuchar,Michael R. Bloomberg,Tulsi Gabbard,Joseph R. Biden,Bernie Sanders
-1,23,1,3,,Precinct 1,Elizabeth Warren,Tulsi Gabbard,Joseph R. Biden,Amy Klobuchar,12
-1,23,1,4,,Precinct 1,Michael R. Bloomberg,Joseph R. Biden,12,Tom Steyer,Tulsi Gabbard
-1,23,1,5,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,23,1,6,,Precinct 1,Elizabeth Warren,12,Joseph R. Biden,Tulsi Gabbard,Michael R. Bloomberg
-1,23,1,7,,Precinct 1,Joseph R. Biden,Bernie Sanders,Amy Klobuchar,Elizabeth Warren,Michael R. Bloomberg
-1,23,1,8,,Precinct 1,Amy Klobuchar,12,Tom Steyer,Michael R. Bloomberg,Tulsi Gabbard
-1,23,1,9,,Precinct 1,Tom Steyer,Joseph R. Biden,12,Tulsi Gabbard,Michael R. Bloomberg
-1,23,1,10,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,23,1,11,,Precinct 1,Tulsi Gabbard,Amy Klobuchar,Joseph R. Biden,Michael R. Bloomberg,Pete Buttigieg
-1,23,1,12,,Precinct 1,Bernie Sanders,Pete Buttigieg,Tulsi Gabbard,12,Tom Steyer
-1,23,1,13,,Precinct 1,Bernie Sanders,Elizabeth Warren,Michael R. Bloomberg,Tom Steyer,12
-1,23,1,14,,Precinct 1,Tom Steyer,Pete Buttigieg,Bernie Sanders,12,Joseph R. Biden
-1,23,1,15,,Precinct 1,Pete Buttigieg,Tulsi Gabbard,12,Tom Steyer,Elizabeth Warren
-1,23,1,16,,Precinct 1,Tulsi Gabbard,Joseph R. Biden,Michael R. Bloomberg,Pete Buttigieg,Bernie Sanders
-1,23,1,17,,Precinct 1,Pete Buttigieg,Tom Steyer,Joseph R. Biden,Elizabeth Warren,12
-1,23,1,18,,Precinct 1,Tom Steyer,12,Joseph R. Biden,Pete Buttigieg,Michael R. Bloomberg
-1,23,1,19,,Precinct 1,Pete Buttigieg,Elizabeth Warren,12,Bernie Sanders,Michael R. Bloomberg
-1,23,1,20,,Precinct 1,Tulsi Gabbard,Joseph R. Biden,Michael R. Bloomberg,Tom Steyer,Pete Buttigieg
-1,31,1,1,,Precinct 1,Bernie Sanders,Pete Buttigieg,Amy Klobuchar,Michael R. Bloomberg,Joseph R. Biden
-1,31,1,2,,Precinct 1,Elizabeth Warren,12,Michael R. Bloomberg,Joseph R. Biden,Amy Klobuchar
-1,31,1,3,,Precinct 1,Michael R. Bloomberg,Elizabeth Warren,Amy Klobuchar,12,Bernie Sanders
-1,31,1,4,,Precinct 1,Tom Steyer,Bernie Sanders,Michael R. Bloomberg,12,Amy Klobuchar
-1,31,1,5,,Precinct 1,Pete Buttigieg,12,Tom Steyer,Bernie Sanders,Michael R. Bloomberg
-1,31,1,6,,Precinct 1,Tulsi Gabbard,12,Pete Buttigieg,Joseph R. Biden,Michael R. Bloomberg
-1,31,1,7,,Precinct 1,12,Bernie Sanders,Tom Steyer,Joseph R. Biden,Amy Klobuchar
-1,31,1,8,,Precinct 1,Pete Buttigieg,Joseph R. Biden,12,Bernie Sanders,Elizabeth Warren
-1,31,1,9,,Precinct 1,Tom Steyer,12,Joseph R. Biden,Elizabeth Warren,Michael R. Bloomberg
-1,31,1,10,,Precinct 1,Tom Steyer,Amy Klobuchar,Michael R. Bloomberg,Tulsi Gabbard,Pete Buttigieg
-1,31,1,11,,Precinct 1,Tom Steyer,Amy Klobuchar,12,Michael R. Bloomberg,Bernie Sanders
-1,31,1,12,,Precinct 1,Bernie Sanders,Amy Klobuchar,Tulsi Gabbard,Tom Steyer,Pete Buttigieg
-1,31,1,13,,Precinct 1,12,Joseph R. Biden,Tulsi Gabbard,Elizabeth Warren,Michael R. Bloomberg
-1,31,1,14,,Precinct 1,Pete Buttigieg,Joseph R. Biden,Bernie Sanders,Michael R. Bloomberg,Tulsi Gabbard
-1,31,1,15,,Precinct 1,Michael R. Bloomberg,Bernie Sanders,Elizabeth Warren,Amy Klobuchar,Tom Steyer
-1,31,1,16,,Precinct 1,Joseph R. Biden,Pete Buttigieg,Tulsi Gabbard,Bernie Sanders,Elizabeth Warren
-1,31,1,17,,Precinct 1,Tom Steyer,Michael R. Bloomberg,Elizabeth Warren,Pete Buttigieg,12
-1,31,1,18,,Precinct 1,12,Tulsi Gabbard,Joseph R. Biden,Michael R. Bloomberg,Tom Steyer
-1,31,1,19,,Precinct 1,12,Pete Buttigieg,Tom Steyer,Joseph R. Biden,Bernie Sanders
-1,31,1,20,,Precinct 1,Pete Buttigieg,Bernie Sanders,Joseph R. Biden,Amy Klobuchar,12
-1,22,1,1,,Precinct 1,12,Pete Buttigieg,Amy Klobuchar,Elizabeth Warren,Tom Steyer
-1,22,1,2,,Precinct 1,Pete Buttigieg,Tulsi Gabbard,Tom Steyer,12,Joseph R. Biden
-1,22,1,3,,Precinct 1,Michael R. Bloomberg,Bernie Sanders,12,Pete Buttigieg,Tom Steyer
-1,22,1,4,,Precinct 1,Joseph R. Biden,Michael R. Bloomberg,Elizabeth Warren,Pete Buttigieg,Tulsi Gabbard
-1,22,1,5,,Precinct 1,Pete Buttigieg,Tulsi Gabbard,12,Tom Steyer,Amy Klobuchar
-1,22,1,6,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,22,1,7,,Precinct 1,Joseph R. Biden,Bernie Sanders,Elizabeth Warren,Tom Steyer,Amy Klobuchar
-1,22,1,8,,Precinct 1,Pete Buttigieg,Bernie Sanders,Amy Klobuchar,12,Joseph R. Biden
-1,22,1,9,,Precinct 1,Pete Buttigieg,Amy Klobuchar,Joseph R. Biden,Tulsi Gabbard,Bernie Sanders
-1,22,1,10,,Precinct 1,Joseph R. Biden,12,Tom Steyer,Elizabeth Warren,Amy Klobuchar
-1,22,1,11,,Precinct 1,Amy Klobuchar,Pete Buttigieg,Joseph R. Biden,Michael R. Bloomberg,Bernie Sanders
-1,22,1,12,,Precinct 1,Bernie Sanders,Pete Buttigieg,12,Elizabeth Warren,Joseph R. Biden
-1,22,1,13,,Precinct 1,12,Bernie Sanders,Tom Steyer,Amy Klobuchar,Tulsi Gabbard
-1,22,1,14,,Precinct 1,Elizabeth Warren,Tom Steyer,Pete Buttigieg,Amy Klobuchar,Bernie Sanders
-1,22,1,15,,Precinct 1,12,Bernie Sanders,Amy Klobuchar,Joseph R. Biden,Tom Steyer
-1,22,1,16,,Precinct 1,Joseph R. Biden,Amy Klobuchar,12,Elizabeth Warren,Tom Steyer
-1,22,1,17,,Precinct 1,Joseph R. Biden,Elizabeth Warren,Tom Steyer,Pete Buttigieg,Tulsi Gabbard
-1,22,1,18,,Precinct 1,Elizabeth Warren,Tom Steyer,Amy Klobuchar,Bernie Sanders,Joseph R. Biden
-1,22,1,19,,Precinct 1,Michael R. Bloomberg,Tom Steyer,12,Bernie Sanders,Joseph R. Biden
-1,22,1,20,,Precinct 1,Bernie Sanders,Elizabeth Warren,Tulsi Gabbard,12,Michael R. Bloomberg
-1,48,1,1,,Precinct 1,Joseph R. Biden,Pete Buttigieg,12,Elizabeth Warren,Tulsi Gabbard
-1,48,1,2,,Precinct 1,Tulsi Gabbard,Joseph R. Biden,Elizabeth Warren,Bernie Sanders,Michael R. Bloomberg
-1,48,1,3,,Precinct 1,12,Amy Klobuchar,Bernie Sanders,Elizabeth Warren,Tom Steyer
-1,48,1,4,,Precinct 1,Bernie Sanders,Michael R. Bloomberg,Elizabeth Warren,Tom Steyer,Pete Buttigieg
-1,48,1,5,,Precinct 1,Bernie Sanders,Michael R. Bloomberg,12,Elizabeth Warren,Tom Steyer
-1,48,1,6,,Precinct 1,Bernie Sanders,Tom Steyer,Amy Klobuchar,Joseph R. Biden,12
-1,48,1,7,,Precinct 1,12,Bernie Sanders,Elizabeth Warren,Amy Klobuchar,Michael R. Bloomberg
-1,48,1,8,,Precinct 1,Tom Steyer,Amy Klobuchar,Bernie Sanders,Elizabeth Warren,Pete Buttigieg
-1,48,1,9,,Precinct 1,Bernie Sanders,Tulsi Gabbard,Amy Klobuchar,Joseph R. Biden,Tom Steyer
-1,48,1,10,,Precinct 1,Pete Buttigieg,Michael R. Bloomberg,12,Bernie Sanders,Joseph R. Biden
-1,48,1,11,,Precinct 1,Michael R. Bloomberg,Amy Klobuchar,Bernie Sanders,Pete Buttigieg,Tulsi Gabbard
-1,48,1,12,,Precinct 1,Amy Klobuchar,Pete Buttigieg,Tom Steyer,Bernie Sanders,Tulsi Gabbard
-1,48,1,13,,Precinct 1,Joseph R. Biden,Tulsi Gabbard,Michael R. Bloomberg,Bernie Sanders,Tom Steyer
-1,48,1,14,,Precinct 1,Tulsi Gabbard,Amy Klobuchar,Michael R. Bloomberg,Joseph R. Biden,Pete Buttigieg
-1,48,1,15,,Precinct 1,Joseph R. Biden,Amy Klobuchar,Tom Steyer,Bernie Sanders,Tulsi Gabbard
-1,48,1,16,,Precinct 1,Pete Buttigieg,Amy Klobuchar,Elizabeth Warren,12,Joseph R. Biden
-1,48,1,17,,Precinct 1,Joseph R. Biden,Elizabeth Warren,Amy Klobuchar,Tom Steyer,Pete Buttigieg
-1,48,1,18,,Precinct 1,Elizabeth Warren,Bernie Sanders,Tulsi Gabbard,Michael R. Bloomberg,Amy Klobuchar
-1,48,1,19,,Precinct 1,Tulsi Gabbard,Pete Buttigieg,Tom Steyer,Elizabeth Warren,Amy Klobuchar
-1,48,1,20,,Precinct 1,Tulsi Gabbard,Joseph R. Biden,Michael R. Bloomberg,Tom Steyer,Amy Klobuchar
-1,21,1,1,,Precinct 1,Joseph R. Biden,Elizabeth Warren,Pete Buttigieg,Tom Steyer,Michael R. Bloomberg
-1,21,1,2,,Precinct 1,Michael R. Bloomberg,Amy Klobuchar,12,Bernie Sanders,Elizabeth Warren
-1,21,1,3,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,21,1,4,,Precinct 1,12,Elizabeth Warren,Pete Buttigieg,Michael R. Bloomberg,Amy Klobuchar
-1,21,1,5,,Precinct 1,Pete Buttigieg,Elizabeth Warren,Joseph R. Biden,Tulsi Gabbard,Bernie Sanders
-1,21,1,6,,Precinct 1,Tulsi Gabbard,12,Michael R. Bloomberg,Tom Steyer,Pete Buttigieg
-1,21,1,7,,Precinct 1,Joseph R. Biden,Pete Buttigieg,Bernie Sanders,Tom Steyer,Michael R. Bloomberg
-1,21,1,8,,Precinct 1,12,Elizabeth Warren,Pete Buttigieg,Bernie Sanders,Michael R. Bloomberg
-1,21,1,9,,Precinct 1,Amy Klobuchar,Tom Steyer,Bernie Sanders,Pete Buttigieg,Elizabeth Warren
-1,21,1,10,,Precinct 1,Bernie Sanders,12,Pete Buttigieg,Tulsi Gabbard,Amy Klobuchar
-1,21,1,11,,Precinct 1,Michael R. Bloomberg,Amy Klobuchar,Tulsi Gabbard,Tom Steyer,Joseph R. Biden
-1,21,1,12,,Precinct 1,Tom Steyer,Michael R. Bloomberg,12,Pete Buttigieg,Tulsi Gabbard
-1,21,1,13,,Precinct 1,Tulsi Gabbard,Elizabeth Warren,Amy Klobuchar,Tom Steyer,Joseph R. Biden
-1,21,1,14,,Precinct 1,Joseph R. Biden,Bernie Sanders,Tulsi Gabbard,Pete Buttigieg,Elizabeth Warren
-1,21,1,15,,Precinct 1,Elizabeth Warren,Amy Klobuchar,Tom Steyer,12,Pete Buttigieg
-1,21,1,16,,Precinct 1,Pete Buttigieg,Amy Klobuchar,Elizabeth Warren,Tom Steyer,12
-1,21,1,17,,Precinct 1,Tom Steyer,Amy Klobuchar,Joseph R. Biden,Tulsi Gabbard,Michael R. Bloomberg
-1,21,1,18,,Precinct 1,Amy Klobuchar,Tom Steyer,12,Joseph R. Biden,Tulsi Gabbard
-1,21,1,19,,Precinct 1,Michael R. Bloomberg,Bernie Sanders,12,Pete Buttigieg,Joseph R. Biden
-1,21,1,20,,Precinct 1,Elizabeth Warren,Michael R. Bloomberg,Amy Klobuchar,12,Bernie Sanders
-1,47,1,1,,Precinct 1,Elizabeth Warren,Joseph R. Biden,Pete Buttigieg,Michael R. Bloomberg,Amy Klobuchar
-1,47,1,2,,Precinct 1,Tulsi Gabbard,Bernie Sanders,Michael R. Bloomberg,Pete Buttigieg,12
-1,47,1,3,,Precinct 1,Joseph R. Biden,Pete Buttigieg,Tom Steyer,Tulsi Gabbard,Michael R. Bloomberg
-1,47,1,4,,Precinct 1,Michael R. Bloomberg,Amy Klobuchar,Pete Buttigieg,Elizabeth Warren,Tulsi Gabbard
-1,47,1,5,,Precinct 1,Tulsi Gabbard,Tom Steyer,Pete Buttigieg,12,Amy Klobuchar
-1,47,1,6,,Precinct 1,Michael R. Bloomberg,Tulsi Gabbard,Amy Klobuchar,Tom Steyer,Pete Buttigieg
-1,47,1,7,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,47,1,8,,Precinct 1,Bernie Sanders,Tulsi Gabbard,12,Tom Steyer,Pete Buttigieg
-1,47,1,9,,Precinct 1,Michael R. Bloomberg,Amy Klobuchar,Tom Steyer,Pete Buttigieg,Bernie Sanders
-1,47,1,10,,Precinct 1,Bernie Sanders,Michael R. Bloomberg,Pete Buttigieg,Tom Steyer,Tulsi Gabbard
-1,47,1,11,,Precinct 1,Tom Steyer,Amy Klobuchar,Pete Buttigieg,Bernie Sanders,Joseph R. Biden
-1,47,1,12,,Precinct 1,Tulsi Gabbard,Michael R. Bloomberg,Joseph R. Biden,Bernie Sanders,12
-1,47,1,13,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,47,1,14,,Precinct 1,Elizabeth Warren,Amy Klobuchar,12,Pete Buttigieg,Tom Steyer
-1,47,1,15,,Precinct 1,Bernie Sanders,Tulsi Gabbard,Amy Klobuchar,Elizabeth Warren,Michael R. Bloomberg
-1,47,1,16,,Precinct 1,Tulsi Gabbard,Elizabeth Warren,12,Pete Buttigieg,Joseph R. Biden
-1,47,1,17,,Precinct 1,Elizabeth Warren,Tom Steyer,Pete Buttigieg,Amy Klobuchar,12
-1,47,1,18,,Precinct 1,Elizabeth Warren,Tom Steyer,Joseph R. Biden,12,Tulsi Gabbard
-1,47,1,19,,Precinct 1,Pete Buttigieg,Michael R. Bloomberg,Tulsi Gabbard,12,Tom Steyer
-1,47,1,20,,Precinct 1,Amy Klobuchar,12,Bernie Sanders,Joseph R. Biden,Tom Steyer
-1,17,1,1,,Precinct 1,Bernie Sanders,Elizabeth Warren,12,Tom Steyer,Michael R. Bloomberg
-1,17,1,2,,Precinct 1,12,Elizabeth Warren,Bernie Sanders,Michael R. Bloomberg,Tom Steyer
-1,17,1,3,,Precinct 1,Tulsi Gabbard,Elizabeth Warren,Joseph R. Biden,12,Bernie Sanders
-1,17,1,4,,Precinct 1,Pete Buttigieg,Michael R. Bloomberg,Tulsi Gabbard,Elizabeth Warren,Joseph R. Biden
-1,17,1,5,,Precinct 1,Elizabeth Warren,12,Pete Buttigieg,Michael R. Bloomberg,Tom Steyer
-1,17,1,6,,Precinct 1,Amy Klobuchar,Tulsi Gabbard,Michael R. Bloomberg,12,Joseph R. Biden
-1,17,1,7,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,17,1,8,,Precinct 1,Tulsi Gabbard,Elizabeth Warren,Tom Steyer,Joseph R. Biden,Amy Klobuchar
-1,17,1,9,,Precinct 1,Tulsi Gabbard,Pete Buttigieg,Michael R. Bloomberg,12,Tom Steyer
-1,17,1,10,,Precinct 1,Pete Buttigieg,Michael R. Bloomberg,Tom Steyer,12,Tulsi Gabbard
-1,17,1,11,,Precinct 1,Bernie Sanders,Elizabeth Warren,Pete Buttigieg,Joseph R. Biden,Michael R. Bloomberg
-1,17,1,12,,Precinct 1,Tulsi Gabbard,Michael R. Bloomberg,Tom Steyer,12,Amy Klobuchar
-1,17,1,13,,Precinct 1,Joseph R. Biden,Tom Steyer,Tulsi Gabbard,Elizabeth Warren,Pete Buttigieg
-1,17,1,14,,Precinct 1,Tulsi Gabbard,12,Bernie Sanders,Pete Buttigieg,Joseph R. Biden
-1,17,1,15,,Precinct 1,Pete Buttigieg,Joseph R. Biden,Amy Klobuchar,Elizabeth Warren,Tulsi Gabbard
-1,17,1,16,,Precinct 1,Tom Steyer,12,Tulsi Gabbard,Michael R. Bloomberg,Elizabeth Warren
-1,17,1,17,,Precinct 1,Bernie Sanders,Joseph R. Biden,Michael R. Bloomberg,12,Pete Buttigieg
-1,17,1,18,,Precinct 1,Michael R. Bloomberg,Tom Steyer,Pete Buttigieg,Tulsi Gabbard,Bernie Sanders
-1,17,1,19,,Precinct 1,12,Michael R. Bloomberg,Bernie Sanders,Tulsi Gabbard,Amy Klobuchar
-1,17,1,20,,Precinct 1,Tom Steyer,Michael R. Bloomberg,Tulsi Gabbard,Pete Buttigieg,12
-1,40,1,1,,Precinct 1,Tom Steyer,Amy Klobuchar,Pete Buttigieg,Elizabeth Warren,Tulsi Gabbard
-1,40,1,2,,Precinct 1,Tulsi Gabbard,Michael R. Bloomberg,Elizabeth Warren,Tom Steyer,12
-1,40,1,3,,Precinct 1,12,Michael R. Bloomberg,Amy Klobuchar,Elizabeth Warren,Joseph R. Biden
-1,40,1,4,,Precinct 1,Michael R. Bloomberg,Elizabeth Warren,12,Amy Klobuchar,Tom Steyer
-1,40,1,5,,Precinct 1,Tulsi Gabbard,Michael R. Bloomberg,Bernie Sanders,12,Tom Steyer
-1,40,1,6,,Precinct 1,Pete Buttigieg,12,Joseph R. Biden,Bernie Sanders,Tulsi Gabbard
-1,40,1,7,,Precinct 1,12,Joseph R. Biden,Bernie Sanders,Tom Steyer,Michael R. Bloomberg
-1,40,1,8,,Precinct 1,Tulsi Gabbard,Tom Steyer,Bernie Sanders,12,Amy Klobuchar
-1,40,1,9,,Precinct 1,12,Amy Klobuchar,Joseph R. Biden,Bernie Sanders,Tulsi Gabbard
-1,40,1,10,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,40,1,11,,Precinct 1,Pete Buttigieg,Joseph R. Biden,Amy Klobuchar,12,Bernie Sanders
-1,40,1,12,,Precinct 1,Tulsi Gabbard,Joseph R. Biden,Amy Klobuchar,Bernie Sanders,12
-1,40,1,13,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,40,1,14,,Precinct 1,Elizabeth Warren,Tulsi Gabbard,Bernie Sanders,Pete Buttigieg,Joseph R. Biden
-1,40,1,15,,Precinct 1,Amy Klobuchar,Bernie Sanders,12,Tom Steyer,Pete Buttigieg
-1,40,1,16,,Precinct 1,Michael R. Bloomberg,Joseph R. Biden,12,Pete Buttigieg,Amy Klobuchar
-1,40,1,17,,Precinct 1,Amy Klobuchar,Pete Buttigieg,12,Elizabeth Warren,Tulsi Gabbard
-1,40,1,18,,Precinct 1,Tom Steyer,Pete Buttigieg,Michael R. Bloomberg,Amy Klobuchar,Bernie Sanders
-1,40,1,19,,Precinct 1,Amy Klobuchar,Joseph R. Biden,Michael R. Bloomberg,12,Tulsi Gabbard
-1,40,1,20,,Precinct 1,Tom Steyer,Pete Buttigieg,12,Michael R. Bloomberg,Bernie Sanders
-1,16,1,1,,Precinct 1,Pete Buttigieg,Michael R. Bloomberg,Elizabeth Warren,Tom Steyer,Amy Klobuchar
-1,16,1,2,,Precinct 1,Joseph R. Biden,12,Tulsi Gabbard,Amy Klobuchar,Michael R. Bloomberg
-1,16,1,3,,Precinct 1,Pete Buttigieg,Tulsi Gabbard,Michael R. Bloomberg,Amy Klobuchar,overvote
-1,16,1,4,,Precinct 1,Amy Klobuchar,Pete Buttigieg,Michael R. Bloomberg,12,Elizabeth Warren
-1,16,1,5,,Precinct 1,12,Elizabeth Warren,Amy Klobuchar,Tom Steyer,Pete Buttigieg
-1,16,1,6,,Precinct 1,Elizabeth Warren,12,Tom Steyer,Joseph R. Biden,Amy Klobuchar
-1,16,1,7,,Precinct 1,Elizabeth Warren,Tulsi Gabbard,Amy Klobuchar,Pete Buttigieg,12
-1,16,1,8,,Precinct 1,Michael R. Bloomberg,Tom Steyer,Joseph R. Biden,Amy Klobuchar,Bernie Sanders
-1,16,1,9,,Precinct 1,Joseph R. Biden,Elizabeth Warren,Bernie Sanders,Amy Klobuchar,Pete Buttigieg
-1,16,1,10,,Precinct 1,Amy Klobuchar,Tom Steyer,Tulsi Gabbard,Elizabeth Warren,12
-1,16,1,11,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,16,1,12,,Precinct 1,12,Tom Steyer,Michael R. Bloomberg,Elizabeth Warren,Pete Buttigieg
-1,16,1,13,,Precinct 1,Amy Klobuchar,12,Tom Steyer,Pete Buttigieg,Elizabeth Warren
-1,16,1,14,,Precinct 1,12,Tulsi Gabbard,Amy Klobuchar,Tom Steyer,Elizabeth Warren
-1,16,1,15,,Precinct 1,Bernie Sanders,Elizabeth Warren,12,Michael R. Bloomberg,Amy Klobuchar
-1,16,1,16,,Precinct 1,Amy Klobuchar,12,Tom Steyer,Bernie Sanders,Elizabeth Warren
-1,16,1,17,,Precinct 1,Bernie Sanders,Amy Klobuchar,Elizabeth Warren,Tom Steyer,Tulsi Gabbard
-1,16,1,18,,Precinct 1,12,Joseph R. Biden,Tom Steyer,Elizabeth Warren,Michael R. Bloomberg
-1,16,1,19,,Precinct 1,Michael R. Bloomberg,Tom Steyer,Joseph R. Biden,12,Tulsi Gabbard
-1,16,1,20,,Precinct 1,Amy Klobuchar,Tom Steyer,Elizabeth Warren,Pete Buttigieg,Tulsi Gabbard
-1,39,1,1,,Precinct 1,Michael R. Bloomberg,Amy Klobuchar,Tulsi Gabbard,Elizabeth Warren,Tom Steyer
-1,39,1,2,,Precinct 1,Elizabeth Warren,Joseph R. Biden,Pete Buttigieg,12,Bernie Sanders
-1,39,1,3,,Precinct 1,12,Tom Steyer,Amy Klobuchar,Elizabeth Warren,Tulsi Gabbard
-1,39,1,4,,Precinct 1,Tom Steyer,Elizabeth Warren,Joseph R. Biden,Bernie Sanders,Amy Klobuchar
-1,39,1,5,,Precinct 1,Michael R. Bloomberg,Tom Steyer,Joseph R. Biden,Bernie Sanders,Elizabeth Warren
-1,39,1,6,,Precinct 1,Bernie Sanders,Tom Steyer,Elizabeth Warren,Tulsi Gabbard,Michael R. Bloomberg
-1,39,1,7,,Precinct 1,Bernie Sanders,Elizabeth Warren,Joseph R. Biden,Tulsi Gabbard,Tom Steyer
-1,39,1,8,,Precinct 1,Pete Buttigieg,Amy Klobuchar,12,Bernie Sanders,Michael R. Bloomberg
-1,39,1,9,,Precinct 1,Elizabeth Warren,Amy Klobuchar,Tom Steyer,Tulsi Gabbard,Bernie Sanders
-1,39,1,10,,Precinct 1,Tulsi Gabbard,Tom Steyer,Amy Klobuchar,Bernie Sanders,Pete Buttigieg
-1,39,1,11,,Precinct 1,Joseph R. Biden,Tom Steyer,Bernie Sanders,12,Amy Klobuchar
-1,39,1,12,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,39,1,13,,Precinct 1,Tulsi Gabbard,Michael R. Bloomberg,Joseph R. Biden,12,Tom Steyer
-1,39,1,14,,Precinct 1,Amy Klobuchar,Joseph R. Biden,Pete Buttigieg,Michael R. Bloomberg,Elizabeth Warren
-1,39,1,15,,Precinct 1,12,Bernie Sanders,Amy Klobuchar,Michael R. Bloomberg,Tulsi Gabbard
-1,39,1,16,,Precinct 1,Amy Klobuchar,Pete Buttigieg,Tom Steyer,12,Bernie Sanders
-1,39,1,17,,Precinct 1,Joseph R. Biden,Elizabeth Warren,Tom Steyer,Amy Klobuchar,Pete Buttigieg
-1,39,1,18,,Precinct 1,Michael R. Bloomberg,Bernie Sanders,Elizabeth Warren,Tom Steyer,Pete Buttigieg
-1,39,1,19,,Precinct 1,Tulsi Gabbard,Joseph R. Biden,Tom Steyer,Pete Buttigieg,Bernie Sanders
-1,39,1,20,,Precinct 1,Pete Buttigieg,Bernie Sanders,Tulsi Gabbard,Michael R. Bloomberg,Elizabeth Warren
-1,38,1,1,,Precinct 1,Amy Klobuchar,Tulsi Gabbard,Elizabeth Warren,Joseph R. Biden,Bernie Sanders
-1,38,1,2,,Precinct 1,Tom Steyer,Pete Buttigieg,Amy Klobuchar,Bernie Sanders,Tulsi Gabbard
-1,38,1,3,,Precinct 1,Pete Buttigieg,Bernie Sanders,12,Joseph R. Biden,Elizabeth Warren
-1,38,1,4,,Precinct 1,Pete Buttigieg,Tulsi Gabbard,12,Bernie Sanders,Michael R. Bloomberg
-1,38,1,5,,Precinct 1,Amy Klobuchar,Joseph R. Biden,12,Michael R. Bloomberg,Tulsi Gabbard
-1,38,1,6,,Precinct 1,Joseph R. Biden,Bernie Sanders,Amy Klobuchar,Elizabeth Warren,Pete Buttigieg
-1,38,1,7,,Precinct 1,Joseph R. Biden,Bernie Sanders,12,Michael R. Bloomberg,Tom Steyer
-1,38,1,8,,Precinct 1,Elizabeth Warren,Tom Steyer,Bernie Sanders,12,Michael R. Bloomberg
-1,38,1,9,,Precinct 1,Tulsi Gabbard,Elizabeth Warren,Michael R. Bloomberg,Joseph R. Biden,Bernie Sanders
-1,38,1,10,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,38,1,11,,Precinct 1,12,Michael R. Bloomberg,Amy Klobuchar,Tulsi Gabbard,Elizabeth Warren
-1,38,1,12,,Precinct 1,Tom Steyer,Michael R. Bloomberg,Tulsi Gabbard,Bernie Sanders,Amy Klobuchar
-1,38,1,13,,Precinct 1,Michael R. Bloomberg,Amy Klobuchar,12,Tom Steyer,Pete Buttigieg
-1,38,1,14,,Precinct 1,Amy Klobuchar,Tom Steyer,12,Elizabeth Warren,Joseph R. Biden
-1,38,1,15,,Precinct 1,Bernie Sanders,Elizabeth Warren,Joseph R. Biden,Tom Steyer,Amy Klobuchar
-1,38,1,16,,Precinct 1,Pete Buttigieg,Tulsi Gabbard,Joseph R. Biden,Michael R. Bloomberg,Tom Steyer
-1,38,1,17,,Precinct 1,Elizabeth Warren,Tulsi Gabbard,Amy Klobuchar,Joseph R. Biden,12
-1,38,1,18,,Precinct 1,Elizabeth Warren,Michael R. Bloomberg,Joseph R. Biden,Amy Klobuchar,Tulsi Gabbard
-1,38,1,19,,Precinct 1,Michael R. Bloomberg,12,Elizabeth Warren,Pete Buttigieg,Tulsi Gabbard
-1,38,1,20,,Precinct 1,Bernie Sanders,12,Elizabeth Warren,Michael R. Bloomberg,Tulsi Gabbard
-1,20,1,1,,Precinct 1,Amy Klobuchar,Tom Steyer,Tulsi Gabbard,Michael R. Bloomberg,Joseph R. Biden
-1,20,1,2,,Precinct 1,Tom Steyer,Bernie Sanders,Michael R. Bloomberg,Amy Klobuchar,Elizabeth Warren
-1,20,1,3,,Precinct 1,Elizabeth Warren,Pete Buttigieg,12,Amy Klobuchar,Bernie Sanders
-1,20,1,4,,Precinct 1,Bernie Sanders,Joseph R. Biden,Amy Klobuchar,Elizabeth Warren,Michael R. Bloomberg
-1,20,1,5,,Precinct 1,Amy Klobuchar,Joseph R. Biden,Elizabeth Warren,Pete Buttigieg,Tom Steyer
-1,20,1,6,,Precinct 1,Elizabeth Warren,Pete Buttigieg,Tom Steyer,Tulsi Gabbard,12
-1,20,1,7,,Precinct 1,Amy Klobuchar,Bernie Sanders,Elizabeth Warren,12,Tom Steyer
-1,20,1,8,,Precinct 1,Tom Steyer,Elizabeth Warren,Michael R. Bloomberg,Amy Klobuchar,Joseph R. Biden
-1,20,1,9,,Precinct 1,Amy Klobuchar,Bernie Sanders,Pete Buttigieg,12,Tulsi Gabbard
-1,20,1,10,,Precinct 1,Pete Buttigieg,12,Tom Steyer,Joseph R. Biden,Michael R. Bloomberg
-1,20,1,11,,Precinct 1,Pete Buttigieg,Joseph R. Biden,Amy Klobuchar,Tom Steyer,Elizabeth Warren
-1,20,1,12,,Precinct 1,Tulsi Gabbard,Bernie Sanders,Amy Klobuchar,Tom Steyer,Elizabeth Warren
-1,20,1,13,,Precinct 1,Michael R. Bloomberg,Amy Klobuchar,Tom Steyer,Tulsi Gabbard,Elizabeth Warren
-1,20,1,14,,Precinct 1,Tulsi Gabbard,Pete Buttigieg,Elizabeth Warren,Bernie Sanders,Michael R. Bloomberg
-1,20,1,15,,Precinct 1,Joseph R. Biden,Bernie Sanders,Michael R. Bloomberg,Elizabeth Warren,Pete Buttigieg
-1,20,1,16,,Precinct 1,Elizabeth Warren,Joseph R. Biden,Amy Klobuchar,12,Tom Steyer
-1,20,1,17,,Precinct 1,Bernie Sanders,Elizabeth Warren,Joseph R. Biden,Tom Steyer,Pete Buttigieg
-1,20,1,18,,Precinct 1,Michael R. Bloomberg,Elizabeth Warren,Pete Buttigieg,Joseph R. Biden,Amy Klobuchar
-1,20,1,19,,Precinct 1,Amy Klobuchar,Michael R. Bloomberg,Tulsi Gabbard,Bernie Sanders,Pete Buttigieg
-1,20,1,20,,Precinct 1,Joseph R. Biden,Tom Steyer,Tulsi Gabbard,Elizabeth Warren,Amy Klobuchar
-1,37,1,1,,Precinct 1,12,Elizabeth Warren,Bernie Sanders,Tom Steyer,Joseph R. Biden
-1,37,1,2,,Precinct 1,Bernie Sanders,Tom Steyer,Tulsi Gabbard,12,Michael R. Bloomberg
-1,37,1,3,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,37,1,4,,Precinct 1,12,Tulsi Gabbard,Bernie Sanders,Joseph R. Biden,Elizabeth Warren
-1,37,1,5,,Precinct 1,Tom Steyer,Tulsi Gabbard,Joseph R. Biden,Pete Buttigieg,12
-1,37,1,6,,Precinct 1,12,Bernie Sanders,Tulsi Gabbard,Michael R. Bloomberg,Amy Klobuchar
-1,37,1,7,,Precinct 1,Elizabeth Warren,Michael R. Bloomberg,Pete Buttigieg,Amy Klobuchar,Tom Steyer
-1,37,1,8,,Precinct 1,Pete Buttigieg,Tulsi Gabbard,Bernie Sanders,Amy Klobuchar,Michael R. Bloomberg
-1,37,1,9,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,37,1,10,,Precinct 1,Elizabeth Warren,Michael R. Bloomberg,Joseph R. Biden,Pete Buttigieg,12
-1,37,1,11,,Precinct 1,Elizabeth Warren,Michael R. Bloomberg,12,Pete Buttigieg,Tom Steyer
-1,37,1,12,,Precinct 1,Tom Steyer,Amy Klobuchar,Pete Buttigieg,Tulsi Gabbard,12
-1,37,1,13,,Precinct 1,Elizabeth Warren,Amy Klobuchar,12,Michael R. Bloomberg,Joseph R. Biden
-1,37,1,14,,Precinct 1,Elizabeth Warren,Amy Klobuchar,Michael R. Bloomberg,Tom Steyer,Bernie Sanders
-1,37,1,15,,Precinct 1,Pete Buttigieg,12,Bernie Sanders,Tom Steyer,Michael R. Bloomberg
-1,37,1,16,,Precinct 1,Michael R. Bloomberg,Tulsi Gabbard,Pete Buttigieg,Elizabeth Warren,Joseph R. Biden
-1,37,1,17,,Precinct 1,Tulsi Gabbard,Pete Buttigieg,Elizabeth Warren,12,Amy Klobuchar
-1,37,1,18,,Precinct 1,Tom Steyer,Michael R. Bloomberg,Elizabeth Warren,Pete Buttigieg,Tulsi Gabbard
-1,37,1,19,,Precinct 1,Tulsi Gabbard,Tom Steyer,Amy Klobuchar,Elizabeth Warren,12
-1,37,1,20,,Precinct 1,Amy Klobuchar,Joseph R. Biden,Michael R. Bloomberg,Elizabeth Warren,Bernie Sanders
-1,15,1,1,,Precinct 1,Michael R. Bloomberg,Pete Buttigieg,Elizabeth Warren,Joseph R. Biden,Amy Klobuchar
-1,15,1,2,,Precinct 1,Amy Klobuchar,Bernie Sanders,Pete Buttigieg,Joseph R. Biden,Michael R. Bloomberg
-1,15,1,3,,Precinct 1,Tulsi Gabbard,Joseph R. Biden,Bernie Sanders,Michael R. Bloomberg,Pete Buttigieg
-1,15,1,4,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,15,1,5,,Precinct 1,Amy Klobuchar,Joseph R. Biden,Bernie Sanders,Tulsi Gabbard,Pete Buttigieg
-1,15,1,6,,Precinct 1,Elizabeth Warren,Amy Klobuchar,Tom Steyer,Michael R. Bloomberg,Tulsi Gabbard
-1,15,1,7,,Precinct 1,Tom Steyer,12,Pete Buttigieg,Michael R. Bloomberg,Amy Klobuchar
-1,15,1,8,,Precinct 1,Joseph R. Biden,Tulsi Gabbard,Pete Buttigieg,12,Elizabeth Warren
-1,15,1,9,,Precinct 1,Bernie Sanders,Tom Steyer,Michael R. Bloomberg,Joseph R. Biden,overvote
-1,15,1,10,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,15,1,11,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,15,1,12,,Precinct 1,Joseph R. Biden,Elizabeth Warren,Amy Klobuchar,Pete Buttigieg,Tulsi Gabbard
-1,15,1,13,,Precinct 1,Pete Buttigieg,Bernie Sanders,Tulsi Gabbard,Joseph R. Biden,Elizabeth Warren
-1,15,1,14,,Precinct 1,Michael R. Bloomberg,Pete Buttigieg,Tulsi Gabbard,Tom Steyer,Joseph R. Biden
-1,15,1,15,,Precinct 1,12,Joseph R. Biden,Michael R. Bloomberg,Tom Steyer,Bernie Sanders
-1,15,1,16,,Precinct 1,Joseph R. Biden,Amy Klobuchar,Michael R. Bloomberg,Tom Steyer,Pete Buttigieg
-1,15,1,17,,Precinct 1,Amy Klobuchar,12,Elizabeth Warren,Michael R. Bloomberg,Pete Buttigieg
-1,15,1,18,,Precinct 1,Tulsi Gabbard,Tom Steyer,Amy Klobuchar,Pete Buttigieg,Elizabeth Warren
-1,15,1,19,,Precinct 1,12,Pete Buttigieg,Tulsi Gabbard,Amy Klobuchar,Elizabeth Warren
-1,15,1,20,,Precinct 1,Pete Buttigieg,Tom Steyer,12,Tulsi Gabbard,Joseph R. Biden
-1,30,1,1,,Precinct 1,Tulsi Gabbard,Bernie Sanders,12,Joseph R. Biden,Michael R. Bloomberg
-1,30,1,2,,Precinct 1,Amy Klobuchar,Joseph R. Biden,Michael R. Bloomberg,Elizabeth Warren,Tulsi Gabbard
-1,30,1,3,,Precinct 1,Pete Buttigieg,Tulsi Gabbard,Elizabeth Warren,Joseph R. Biden,Tom Steyer
-1,30,1,4,,Precinct 1,Bernie Sanders,Amy Klobuchar,Michael R. Bloomberg,Pete Buttigieg,Tom Steyer
-1,30,1,5,,Precinct 1,Joseph R. Biden,Tom Steyer,Pete Buttigieg,Tulsi Gabbard,12
-1,30,1,6,,Precinct 1,Tulsi Gabbard,Elizabeth Warren,Pete Buttigieg,Joseph R. Biden,Bernie Sanders
-1,30,1,7,,Precinct 1,Pete Buttigieg,12,Bernie Sanders,Joseph R. Biden,Amy Klobuchar
-1,30,1,8,,Precinct 1,Tulsi Gabbard,Amy Klobuchar,Pete Buttigieg,Bernie Sanders,Elizabeth Warren
-1,30,1,9,,Precinct 1,Tulsi Gabbard,Amy Klobuchar,Elizabeth Warren,Michael R. Bloomberg,Tom Steyer
-1,30,1,10,,Precinct 1,Elizabeth Warren,Tulsi Gabbard,Tom Steyer,Joseph R. Biden,Amy Klobuchar
-1,30,1,11,,Precinct 1,Tulsi Gabbard,Elizabeth Warren,Tom Steyer,12,Bernie Sanders
-1,30,1,12,,Precinct 1,Amy Klobuchar,Tom Steyer,12,Tulsi Gabbard,Joseph R. Biden
-1,30,1,13,,Precinct 1,Michael R. Bloomberg,12,Amy Klobuchar,Tom Steyer,Bernie Sanders
-1,30,1,14,,Precinct 1,Elizabeth Warren,Pete Buttigieg,Tulsi Gabbard,Joseph R. Biden,Tom Steyer
-1,30,1,15,,Precinct 1,Tom Steyer,Elizabeth Warren,Pete Buttigieg,Joseph R. Biden,Michael R. Bloomberg
-1,30,1,16,,Precinct 1,12,Michael R. Bloomberg,Tom Steyer,Joseph R. Biden,Amy Klobuchar
-1,30,1,17,,Precinct 1,Tulsi Gabbard,Pete Buttigieg,Tom Steyer,Michael R. Bloomberg,Amy Klobuchar
-1,30,1,18,,Precinct 1,Bernie Sanders,Joseph R. Biden,Pete Buttigieg,Tulsi Gabbard,Elizabeth Warren
-1,30,1,19,,Precinct 1,Tulsi Gabbard,Elizabeth Warren,Pete Buttigieg,Joseph R. Biden,Tom Steyer
-1,30,1,20,,Precinct 1,Elizabeth Warren,Amy Klobuchar,Joseph R. Biden,Pete Buttigieg,12
-1,36,1,1,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,36,1,2,,Precinct 1,Joseph R. Biden,Tom Steyer,12,Bernie Sanders,Michael R. Bloomberg
-1,36,1,3,,Precinct 1,Bernie Sanders,12,Tom Steyer,Elizabeth Warren,Amy Klobuchar
-1,36,1,4,,Precinct 1,Tom Steyer,Tulsi Gabbard,Elizabeth Warren,Pete Buttigieg,Michael R. Bloomberg
-1,36,1,5,,Precinct 1,Bernie Sanders,Elizabeth Warren,Pete Buttigieg,Amy Klobuchar,Michael R. Bloomberg
-1,36,1,6,,Precinct 1,Amy Klobuchar,12,Bernie Sanders,Pete Buttigieg,Tulsi Gabbard
-1,36,1,7,,Precinct 1,Elizabeth Warren,Joseph R. Biden,Tom Steyer,12,Amy Klobuchar
-1,36,1,8,,Precinct 1,Michael R. Bloomberg,Elizabeth Warren,Pete Buttigieg,12,Bernie Sanders
-1,36,1,9,,Precinct 1,12,Bernie Sanders,Amy Klobuchar,Michael R. Bloomberg,Pete Buttigieg
-1,36,1,10,,Precinct 1,Bernie Sanders,Pete Buttigieg,12,Elizabeth Warren,Joseph R. Biden
-1,36,1,11,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,36,1,12,,Precinct 1,Pete Buttigieg,12,Joseph R. Biden,Bernie Sanders,Amy Klobuchar
-1,36,1,13,,Precinct 1,12,Bernie Sanders,Tom Steyer,Michael R. Bloomberg,Tulsi Gabbard
-1,36,1,14,,Precinct 1,Michael R. Bloomberg,Pete Buttigieg,Joseph R. Biden,12,Tom Steyer
-1,36,1,15,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,36,1,16,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,36,1,17,,Precinct 1,Joseph R. Biden,Bernie Sanders,overvote,Pete Buttigieg,Amy Klobuchar
-1,36,1,18,,Precinct 1,Tulsi Gabbard,Elizabeth Warren,12,Tom Steyer,Joseph R. Biden
-1,36,1,19,,Precinct 1,Amy Klobuchar,Tom Steyer,12,Bernie Sanders,Tulsi Gabbard
-1,36,1,20,,Precinct 1,Tom Steyer,12,Michael R. Bloomberg,Amy Klobuchar,Bernie Sanders
-1,46,1,1,,Precinct 1,Tulsi Gabbard,Joseph R. Biden,Pete Buttigieg,Elizabeth Warren,Amy Klobuchar
-1,46,1,2,,Precinct 1,Pete Buttigieg,Elizabeth Warren,Michael R. Bloomberg,Bernie Sanders,12
-1,46,1,3,,Precinct 1,12,Michael R. Bloomberg,Amy Klobuchar,Tom Steyer,Elizabeth Warren
-1,46,1,4,,Precinct 1,Elizabeth Warren,Joseph R. Biden,Bernie Sanders,12,Tulsi Gabbard
-1,46,1,5,,Precinct 1,Pete Buttigieg,Joseph R. Biden,Elizabeth Warren,Bernie Sanders,Tom Steyer
-1,46,1,6,,Precinct 1,Michael R. Bloomberg,Tulsi Gabbard,Bernie Sanders,Pete Buttigieg,Tom Steyer
-1,46,1,7,,Precinct 1,Tom Steyer,Bernie Sanders,Elizabeth Warren,Tulsi Gabbard,Joseph R. Biden
-1,46,1,8,,Precinct 1,Bernie Sanders,Tulsi Gabbard,Michael R. Bloomberg,Pete Buttigieg,Elizabeth Warren
-1,46,1,9,,Precinct 1,Pete Buttigieg,Joseph R. Biden,Tom Steyer,Michael R. Bloomberg,Bernie Sanders
-1,46,1,10,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,46,1,11,,Precinct 1,Michael R. Bloomberg,Elizabeth Warren,Pete Buttigieg,Amy Klobuchar,12
-1,46,1,12,,Precinct 1,Amy Klobuchar,12,Tulsi Gabbard,Pete Buttigieg,Joseph R. Biden
-1,46,1,13,,Precinct 1,12,Elizabeth Warren,Amy Klobuchar,Joseph R. Biden,Michael R. Bloomberg
-1,46,1,14,,Precinct 1,Tom Steyer,Tulsi Gabbard,Bernie Sanders,Pete Buttigieg,Joseph R. Biden
-1,46,1,15,,Precinct 1,Joseph R. Biden,Amy Klobuchar,Pete Buttigieg,Tom Steyer,Tulsi Gabbard
-1,46,1,16,,Precinct 1,Pete Buttigieg,Michael R. Bloomberg,Tulsi Gabbard,Joseph R. Biden,Tom Steyer
-1,46,1,17,,Precinct 1,Tulsi Gabbard,12,Pete Buttigieg,Bernie Sanders,Amy Klobuchar
-1,46,1,18,,Precinct 1,Michael R. Bloomberg,Joseph R. Biden,Bernie Sanders,Elizabeth Warren,12
-1,46,1,19,,Precinct 1,Joseph R. Biden,Pete Buttigieg,Elizabeth Warren,Michael R. Bloomberg,Tom Steyer
-1,46,1,20,,Precinct 1,Bernie Sanders,Elizabeth Warren,12,Tom Steyer,Pete Buttigieg
-1,14,1,1,,Precinct 1,Tom Steyer,Joseph R. Biden,Elizabeth Warren,Bernie Sanders,Tulsi Gabbard
-1,14,1,2,,Precinct 1,Tulsi Gabbard,Michael R. Bloomberg,Pete Buttigieg,Elizabeth Warren,Joseph R. Biden
-1,14,1,3,,Precinct 1,Tulsi Gabbard,Amy Klobuchar,12,Bernie Sanders,Pete Buttigieg
-1,14,1,4,,Precinct 1,Elizabeth Warren,12,Amy Klobuchar,Pete Buttigieg,Michael R. Bloomberg
-1,14,1,5,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,14,1,6,,Precinct 1,Amy Klobuchar,Joseph R. Biden,Tulsi Gabbard,Tom Steyer,Michael R. Bloomberg
-1,14,1,7,,Precinct 1,Tom Steyer,Bernie Sanders,Joseph R. Biden,12,Tulsi Gabbard
-1,14,1,8,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,14,1,9,,Precinct 1,Amy Klobuchar,Bernie Sanders,Pete Buttigieg,Tulsi Gabbard,Tom Steyer
-1,14,1,10,,Precinct 1,Pete Buttigieg,Bernie Sanders,Michael R. Bloomberg,Tom Steyer,Amy Klobuchar
-1,14,1,11,,Precinct 1,Bernie Sanders,Tulsi Gabbard,Joseph R. Biden,12,Tom Steyer
-1,14,1,12,,Precinct 1,Tom Steyer,Michael R. Bloomberg,Elizabeth Warren,12,Pete Buttigieg
-1,14,1,13,,Precinct 1,Tom Steyer,Amy Klobuchar,Joseph R. Biden,12,Michael R. Bloomberg
-1,14,1,14,,Precinct 1,Amy Klobuchar,Tulsi Gabbard,Michael R. Bloomberg,Joseph R. Biden,Elizabeth Warren
-1,14,1,15,,Precinct 1,Joseph R. Biden,Bernie Sanders,Pete Buttigieg,12,Amy Klobuchar
-1,14,1,16,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,14,1,17,,Precinct 1,Elizabeth Warren,Tom Steyer,Bernie Sanders,Amy Klobuchar,Tulsi Gabbard
-1,14,1,18,,Precinct 1,Bernie Sanders,Michael R. Bloomberg,Elizabeth Warren,Tom Steyer,12
-1,14,1,19,,Precinct 1,Amy Klobuchar,Elizabeth Warren,Tom Steyer,Pete Buttigieg,12
-1,14,1,20,,Precinct 1,Tulsi Gabbard,Elizabeth Warren,Bernie Sanders,12,Amy Klobuchar
-1,13,1,1,,Precinct 1,Joseph R. Biden,12,Tulsi Gabbard,Pete Buttigieg,Amy Klobuchar
-1,13,1,2,,Precinct 1,Michael R. Bloomberg,Joseph R. Biden,Tom Steyer,Tulsi Gabbard,Bernie Sanders
-1,13,1,3,,Precinct 1,Tulsi Gabbard,Amy Klobuchar,Bernie Sanders,Tom Steyer,Joseph R. Biden
-1,13,1,4,,Precinct 1,Tulsi Gabbard,Amy Klobuchar,12,Joseph R. Biden,Michael R. Bloomberg
-1,13,1,5,,Precinct 1,Michael R. Bloomberg,Elizabeth Warren,Tom Steyer,Joseph R. Biden,Pete Buttigieg
-1,13,1,6,,Precinct 1,Joseph R. Biden,12,Tom Steyer,Tulsi Gabbard,Bernie Sanders
-1,13,1,7,,Precinct 1,Amy Klobuchar,Michael R. Bloomberg,12,Joseph R. Biden,Bernie Sanders
-1,13,1,8,,Precinct 1,Pete Buttigieg,12,Bernie Sanders,Tulsi Gabbard,Tom Steyer
-1,13,1,9,,Precinct 1,Michael R. Bloomberg,Amy Klobuchar,12,Tom Steyer,Bernie Sanders
-1,13,1,10,,Precinct 1,Tom Steyer,Michael R. Bloomberg,Tulsi Gabbard,Pete Buttigieg,Elizabeth Warren
-1,13,1,11,,Precinct 1,Joseph R. Biden,Elizabeth Warren,Bernie Sanders,Michael R. Bloomberg,Amy Klobuchar
-1,13,1,12,,Precinct 1,Bernie Sanders,Tom Steyer,Michael R. Bloomberg,Pete Buttigieg,12
-1,13,1,13,,Precinct 1,Joseph R. Biden,Tulsi Gabbard,12,Michael R. Bloomberg,Elizabeth Warren
-1,13,1,14,,Precinct 1,Elizabeth Warren,Pete Buttigieg,Michael R. Bloomberg,Tulsi Gabbard,Joseph R. Biden
-1,13,1,15,,Precinct 1,Amy Klobuchar,Pete Buttigieg,Joseph R. Biden,Michael R. Bloomberg,Tulsi Gabbard
-1,13,1,16,,Precinct 1,Tulsi Gabbard,Elizabeth Warren,Pete Buttigieg,Tom Steyer,12
-1,13,1,17,,Precinct 1,Tom Steyer,Elizabeth Warren,Tulsi Gabbard,Joseph R. Biden,Bernie Sanders
-1,13,1,18,,Precinct 1,Amy Klobuchar,Elizabeth Warren,12,Bernie Sanders,overvote
-1,13,1,19,,Precinct 1,12,Joseph R. Biden,Elizabeth Warren,Michael R. Bloomberg,Bernie Sanders
-1,13,1,20,,Precinct 1,12,Tom Steyer,Pete Buttigieg,Bernie Sanders,Joseph R. Biden
-1,29,1,1,,Precinct 1,Tulsi Gabbard,Pete Buttigieg,Amy Klobuchar,12,Tom Steyer
-1,29,1,2,,Precinct 1,Pete Buttigieg,Tom Steyer,Bernie Sanders,Tulsi Gabbard,Amy Klobuchar
-1,29,1,3,,Precinct 1,Michael R. Bloomberg,Bernie Sanders,Tulsi Gabbard,Pete Buttigieg,Elizabeth Warren
-1,29,1,4,,Precinct 1,Joseph R. Biden,Tulsi Gabbard,Michael R. Bloomberg,12,Tom Steyer
-1,29,1,5,,Precinct 1,12,Joseph R. Biden,Bernie Sanders,Amy Klobuchar,Michael R. Bloomberg
-1,29,1,6,,Precinct 1,Bernie Sanders,Joseph R. Biden,Elizabeth Warren,12,Michael R. Bloomberg
-1,29,1,7,,Precinct 1,Tulsi Gabbard,Tom Steyer,Joseph R. Biden,Michael R. Bloomberg,Amy Klobuchar
-1,29,1,8,,Precinct 1,12,Elizabeth Warren,Joseph R. Biden,Tom Steyer,Amy Klobuchar
-1,29,1,9,,Precinct 1,Michael R. Bloomberg,Pete Buttigieg,Bernie Sanders,undervote,12
-1,29,1,10,,Precinct 1,Tulsi Gabbard,Joseph R. Biden,Pete Buttigieg,Michael R. Bloomberg,Tom Steyer
-1,29,1,11,,Precinct 1,Bernie Sanders,Pete Buttigieg,Amy Klobuchar,Elizabeth Warren,Michael R. Bloomberg
-1,29,1,12,,Precinct 1,12,Amy Klobuchar,Pete Buttigieg,Tulsi Gabbard,Michael R. Bloomberg
-1,29,1,13,,Precinct 1,12,Elizabeth Warren,Amy Klobuchar,Joseph R. Biden,Bernie Sanders
-1,29,1,14,,Precinct 1,12,Joseph R. Biden,Pete Buttigieg,Tom Steyer,Tulsi Gabbard
-1,29,1,15,,Precinct 1,Pete Buttigieg,Amy Klobuchar,Michael R. Bloomberg,Bernie Sanders,Tom Steyer
-1,29,1,16,,Precinct 1,Bernie Sanders,Michael R. Bloomberg,Joseph R. Biden,Tom Steyer,Tulsi Gabbard
-1,29,1,17,,Precinct 1,Tulsi Gabbard,Joseph R. Biden,Tom Steyer,Bernie Sanders,Elizabeth Warren
-1,29,1,18,,Precinct 1,Amy Klobuchar,Tulsi Gabbard,Elizabeth Warren,12,Michael R. Bloomberg
-1,29,1,19,,Precinct 1,Joseph R. Biden,12,Michael R. Bloomberg,Bernie Sanders,Tom Steyer
-1,29,1,20,,Precinct 1,Pete Buttigieg,Tom Steyer,Amy Klobuchar,12,Michael R. Bloomberg
-1,12,1,1,,Precinct 1,Elizabeth Warren,Tom Steyer,Amy Klobuchar,12,Joseph R. Biden
-1,12,1,2,,Precinct 1,Pete Buttigieg,Bernie Sanders,Tom Steyer,Joseph R. Biden,Elizabeth Warren
-1,12,1,3,,Precinct 1,Tulsi Gabbard,Pete Buttigieg,Joseph R. Biden,Tom Steyer,Amy Klobuchar
-1,12,1,4,,Precinct 1,12,Bernie Sanders,Tom Steyer,Elizabeth Warren,Michael R. Bloomberg
-1,12,1,5,,Precinct 1,12,Bernie Sanders,Pete Buttigieg,Amy Klobuchar,Michael R. Bloomberg
-1,12,1,6,,Precinct 1,Tulsi Gabbard,Bernie Sanders,Amy Klobuchar,Michael R. Bloomberg,12
-1,12,1,7,,Precinct 1,Pete Buttigieg,Tom Steyer,Michael R. Bloomberg,Amy Klobuchar,Elizabeth Warren
-1,12,1,8,,Precinct 1,Tom Steyer,Joseph R. Biden,Amy Klobuchar,12,Pete Buttigieg
-1,12,1,9,,Precinct 1,Amy Klobuchar,Tulsi Gabbard,12,Bernie Sanders,Joseph R. Biden
-1,12,1,10,,Precinct 1,Pete Buttigieg,Tulsi Gabbard,Elizabeth Warren,Joseph R. Biden,12
-1,12,1,11,,Precinct 1,Elizabeth Warren,Joseph R. Biden,Tom Steyer,Michael R. Bloomberg,Amy Klobuchar
-1,12,1,12,,Precinct 1,Amy Klobuchar,Michael R. Bloomberg,Pete Buttigieg,Bernie Sanders,Elizabeth Warren
-1,12,1,13,,Precinct 1,Bernie Sanders,Joseph R. Biden,Michael R. Bloomberg,Pete Buttigieg,Tom Steyer
-1,12,1,14,,Precinct 1,Joseph R. Biden,Joseph R. Biden,Pete Buttigieg,Tom Steyer,12
-1,12,1,15,,Precinct 1,Bernie Sanders,Amy Klobuchar,Joseph R. Biden,Michael R. Bloomberg,Tulsi Gabbard
-1,12,1,16,,Precinct 1,Bernie Sanders,Tulsi Gabbard,overvote,Michael R. Bloomberg,Joseph R. Biden
-1,12,1,17,,Precinct 1,Tom Steyer,Michael R. Bloomberg,12,Tulsi Gabbard,Amy Klobuchar
-1,12,1,18,,Precinct 1,Pete Buttigieg,Elizabeth Warren,Tom Steyer,Joseph R. Biden,12
-1,12,1,19,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,12,1,20,,Precinct 1,12,Bernie Sanders,Amy Klobuchar,Pete Buttigieg,Joseph R. Biden
-1,35,1,1,,Precinct 1,Bernie Sanders,Pete Buttigieg,Tom Steyer,Michael R. Bloomberg,Joseph R. Biden
-1,35,1,2,,Precinct 1,12,Tom Steyer,Joseph R. Biden,Pete Buttigieg,Michael R. Bloomberg
-1,35,1,3,,Precinct 1,Michael R. Bloomberg,Joseph R. Biden,Tom Steyer,Tulsi Gabbard,Amy Klobuchar
-1,35,1,4,,Precinct 1,Amy Klobuchar,Bernie Sanders,Tulsi Gabbard,Pete Buttigieg,Elizabeth Warren
-1,35,1,5,,Precinct 1,Tulsi Gabbard,Pete Buttigieg,Tom Steyer,12,Elizabeth Warren
-1,35,1,6,,Precinct 1,Pete Buttigieg,Michael R. Bloomberg,Amy Klobuchar,12,Tulsi Gabbard
-1,35,1,7,,Precinct 1,Elizabeth Warren,12,Tulsi Gabbard,Michael R. Bloomberg,Joseph R. Biden
-1,35,1,8,,Precinct 1,12,Amy Klobuchar,Joseph R. Biden,Elizabeth Warren,Michael R. Bloomberg
-1,35,1,9,,Precinct 1,Michael R. Bloomberg,Tulsi Gabbard,Joseph R. Biden,Amy Klobuchar,Bernie Sanders
-1,35,1,10,,Precinct 1,Tulsi Gabbard,Tom Steyer,Elizabeth Warren,Amy Klobuchar,12
-1,35,1,11,,Precinct 1,Tom Steyer,Pete Buttigieg,Bernie Sanders,Michael R. Bloomberg,Amy Klobuchar
-1,35,1,12,,Precinct 1,Michael R. Bloomberg,12,Tulsi Gabbard,Elizabeth Warren,Pete Buttigieg
-1,35,1,13,,Precinct 1,Elizabeth Warren,12,Joseph R. Biden,Tulsi Gabbard,Pete Buttigieg
-1,35,1,14,,Precinct 1,Joseph R. Biden,Elizabeth Warren,Pete Buttigieg,Michael R. Bloomberg,Bernie Sanders
-1,35,1,15,,Precinct 1,Michael R. Bloomberg,Elizabeth Warren,Bernie Sanders,Tom Steyer,Pete Buttigieg
-1,35,1,16,,Precinct 1,Pete Buttigieg,Elizabeth Warren,Amy Klobuchar,Michael R. Bloomberg,Bernie Sanders
-1,35,1,17,,Precinct 1,Pete Buttigieg,Elizabeth Warren,Bernie Sanders,Tom Steyer,Joseph R. Biden
-1,35,1,18,,Precinct 1,Amy Klobuchar,Bernie Sanders,12,Joseph R. Biden,Tulsi Gabbard
-1,35,1,19,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,35,1,20,,Precinct 1,Tulsi Gabbard,12,Tom Steyer,Michael R. Bloomberg,Pete Buttigieg
-1,19,1,1,,Precinct 1,12,Amy Klobuchar,Tom Steyer,Elizabeth Warren,Pete Buttigieg
-1,19,1,2,,Precinct 1,Bernie Sanders,Elizabeth Warren,Pete Buttigieg,Michael R. Bloomberg,12
-1,19,1,3,,Precinct 1,Elizabeth Warren,Tom Steyer,Pete Buttigieg,Tulsi Gabbard,12
-1,19,1,4,,Precinct 1,Michael R. Bloomberg,12,Amy Klobuchar,Pete Buttigieg,Bernie Sanders
-1,19,1,5,,Precinct 1,Michael R. Bloomberg,Tulsi Gabbard,Bernie Sanders,Joseph R. Biden,Amy Klobuchar
-1,19,1,6,,Precinct 1,Joseph R. Biden,Bernie Sanders,Elizabeth Warren,Pete Buttigieg,12
-1,19,1,7,,Precinct 1,Michael R. Bloomberg,Pete Buttigieg,Amy Klobuchar,Tom Steyer,Elizabeth Warren
-1,19,1,8,,Precinct 1,Tulsi Gabbard,Michael R. Bloomberg,Amy Klobuchar,12,Pete Buttigieg
-1,19,1,9,,Precinct 1,12,Bernie Sanders,Pete Buttigieg,Joseph R. Biden,Amy Klobuchar
-1,19,1,10,,Precinct 1,Tulsi Gabbard,Pete Buttigieg,Bernie Sanders,Tom Steyer,Joseph R. Biden
-1,19,1,11,,Precinct 1,Amy Klobuchar,Tulsi Gabbard,Tom Steyer,12,Michael R. Bloomberg
-1,19,1,12,,Precinct 1,Elizabeth Warren,Pete Buttigieg,Amy Klobuchar,12,Joseph R. Biden
-1,19,1,13,,Precinct 1,12,Tom Steyer,Pete Buttigieg,Amy Klobuchar,Joseph R. Biden
-1,19,1,14,,Precinct 1,Pete Buttigieg,12,Tulsi Gabbard,Amy Klobuchar,Bernie Sanders
-1,19,1,15,,Precinct 1,Joseph R. Biden,Elizabeth Warren,Michael R. Bloomberg,Amy Klobuchar,Pete Buttigieg
-1,19,1,16,,Precinct 1,Michael R. Bloomberg,Tom Steyer,Pete Buttigieg,Elizabeth Warren,12
-1,19,1,17,,Precinct 1,Tom Steyer,Bernie Sanders,Pete Buttigieg,Michael R. Bloomberg,Tulsi Gabbard
-1,19,1,18,,Precinct 1,Michael R. Bloomberg,12,Amy Klobuchar,Bernie Sanders,Pete Buttigieg
-1,19,1,19,,Precinct 1,Joseph R. Biden,Tom Steyer,Michael R. Bloomberg,Tulsi Gabbard,Amy Klobuchar
-1,19,1,20,,Precinct 1,Tom Steyer,Pete Buttigieg,12,Tulsi Gabbard,Elizabeth Warren
-1,11,1,1,,Precinct 1,Tom Steyer,Tulsi Gabbard,Bernie Sanders,12,Pete Buttigieg
-1,11,1,2,,Precinct 1,12,Elizabeth Warren,Bernie Sanders,Michael R. Bloomberg,Pete Buttigieg
-1,11,1,3,,Precinct 1,Tulsi Gabbard,Tom Steyer,Pete Buttigieg,Joseph R. Biden,Elizabeth Warren
-1,11,1,4,,Precinct 1,Amy Klobuchar,Tom Steyer,Tulsi Gabbard,Joseph R. Biden,Pete Buttigieg
-1,11,1,5,,Precinct 1,Bernie Sanders,Pete Buttigieg,Michael R. Bloomberg,Tulsi Gabbard,Joseph R. Biden
-1,11,1,6,,Precinct 1,12,Tulsi Gabbard,Michael R. Bloomberg,Elizabeth Warren,Pete Buttigieg
-1,11,1,7,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,11,1,8,,Precinct 1,Pete Buttigieg,Tom Steyer,Joseph R. Biden,Tulsi Gabbard,12
-1,11,1,9,,Precinct 1,Amy Klobuchar,12,Joseph R. Biden,Tulsi Gabbard,Bernie Sanders
-1,11,1,10,,Precinct 1,Joseph R. Biden,Pete Buttigieg,Elizabeth Warren,12,Tulsi Gabbard
-1,11,1,11,,Precinct 1,Michael R. Bloomberg,Elizabeth Warren,12,Bernie Sanders,Tom Steyer
-1,11,1,12,,Precinct 1,Elizabeth Warren,Tom Steyer,Bernie Sanders,Amy Klobuchar,Michael R. Bloomberg
-1,11,1,13,,Precinct 1,12,Elizabeth Warren,Pete Buttigieg,overvote,Elizabeth Warren
-1,11,1,14,,Precinct 1,Tom Steyer,Tulsi Gabbard,Bernie Sanders,Pete Buttigieg,Amy Klobuchar
-1,11,1,15,,Precinct 1,Elizabeth Warren,Tom Steyer,Pete Buttigieg,12,Bernie Sanders
-1,11,1,16,,Precinct 1,Tulsi Gabbard,12,Pete Buttigieg,Amy Klobuchar,Joseph R. Biden
-1,11,1,17,,Precinct 1,Tulsi Gabbard,Joseph R. Biden,12,Michael R. Bloomberg,Bernie Sanders
-1,11,1,18,,Precinct 1,12,Tom Steyer,Elizabeth Warren,Amy Klobuchar,Joseph R. Biden
-1,11,1,19,,Precinct 1,Elizabeth Warren,Pete Buttigieg,Tom Steyer,Michael R. Bloomberg,Joseph R. Biden
-1,11,1,20,,Precinct 1,Tulsi Gabbard,Amy Klobuchar,12,Tom Steyer,Pete Buttigieg
-1,45,1,1,,Precinct 1,Joseph R. Biden,Amy Klobuchar,Elizabeth Warren,Michael R. Bloomberg,Bernie Sanders
-1,45,1,2,,Precinct 1,12,Joseph R. Biden,Pete Buttigieg,Tom Steyer,Amy Klobuchar
-1,45,1,3,,Precinct 1,12,Tom Steyer,Bernie Sanders,Joseph R. Biden,Pete Buttigieg
-1,45,1,4,,Precinct 1,Joseph R. Biden,Pete Buttigieg,Tulsi Gabbard,Amy Klobuchar,Elizabeth Warren
-1,45,1,5,,Precinct 1,Tom Steyer,Michael R. Bloomberg,Amy Klobuchar,Elizabeth Warren,Joseph R. Biden
-1,45,1,6,,Precinct 1,Tom Steyer,Pete Buttigieg,Michael R. Bloomberg,12,Bernie Sanders
-1,45,1,7,,Precinct 1,Elizabeth Warren,Michael R. Bloomberg,Amy Klobuchar,Pete Buttigieg,Tulsi Gabbard
-1,45,1,8,,Precinct 1,Elizabeth Warren,Tulsi Gabbard,Bernie Sanders,Tom Steyer,Amy Klobuchar
-1,45,1,9,,Precinct 1,Tulsi Gabbard,12,Tom Steyer,Pete Buttigieg,Michael R. Bloomberg
-1,45,1,10,,Precinct 1,Tom Steyer,Bernie Sanders,12,Pete Buttigieg,Tulsi Gabbard
-1,45,1,11,,Precinct 1,Elizabeth Warren,Joseph R. Biden,Tulsi Gabbard,12,Pete Buttigieg
-1,45,1,12,,Precinct 1,Elizabeth Warren,Tom Steyer,Pete Buttigieg,Amy Klobuchar,Bernie Sanders
-1,45,1,13,,Precinct 1,Joseph R. Biden,Tulsi Gabbard,Michael R. Bloomberg,Bernie Sanders,Pete Buttigieg
-1,45,1,14,,Precinct 1,Tulsi Gabbard,Bernie Sanders,Tom Steyer,Michael R. Bloomberg,Elizabeth Warren
-1,45,1,15,,Precinct 1,Bernie Sanders,12,Elizabeth Warren,Tulsi Gabbard,Joseph R. Biden
-1,45,1,16,,Precinct 1,Michael R. Bloomberg,Tom Steyer,Pete Buttigieg,Elizabeth Warren,Bernie Sanders
-1,45,1,17,,Precinct 1,Tulsi Gabbard,Tom Steyer,Amy Klobuchar,Elizabeth Warren,Pete Buttigieg
-1,45,1,18,,Precinct 1,Bernie Sanders,12,Tom Steyer,Elizabeth Warren,Tulsi Gabbard
-1,45,1,19,,Precinct 1,12,Tulsi Gabbard,Bernie Sanders,Pete Buttigieg,Amy Klobuchar
-1,45,1,20,,Precinct 1,Tom Steyer,Bernie Sanders,12,Amy Klobuchar,Joseph R. Biden
-1,27,1,1,,Precinct 1,12,Pete Buttigieg,Bernie Sanders,Elizabeth Warren,Joseph R. Biden
-1,27,1,2,,Precinct 1,Bernie Sanders,Pete Buttigieg,Tulsi Gabbard,Michael R. Bloomberg,Amy Klobuchar
-1,27,1,3,,Precinct 1,Michael R. Bloomberg,Elizabeth Warren,Amy Klobuchar,Bernie Sanders,Joseph R. Biden
-1,27,1,4,,Precinct 1,Bernie Sanders,Pete Buttigieg,Tom Steyer,Elizabeth Warren,12
-1,27,1,5,,Precinct 1,Tulsi Gabbard,Elizabeth Warren,12,Pete Buttigieg,Tom Steyer
-1,27,1,6,,Precinct 1,Elizabeth Warren,Amy Klobuchar,Michael R. Bloomberg,Tulsi Gabbard,Joseph R. Biden
-1,27,1,7,,Precinct 1,Michael R. Bloomberg,Joseph R. Biden,12,Tulsi Gabbard,Elizabeth Warren
-1,27,1,8,,Precinct 1,Joseph R. Biden,Pete Buttigieg,Tulsi Gabbard,Amy Klobuchar,Bernie Sanders
-1,27,1,9,,Precinct 1,Bernie Sanders,Tulsi Gabbard,Joseph R. Biden,Tom Steyer,Amy Klobuchar
-1,27,1,10,,Precinct 1,Tulsi Gabbard,Bernie Sanders,Joseph R. Biden,Pete Buttigieg,12
-1,27,1,11,,Precinct 1,Elizabeth Warren,Bernie Sanders,Tulsi Gabbard,Michael R. Bloomberg,Tom Steyer
-1,27,1,12,,Precinct 1,Pete Buttigieg,Tom Steyer,Joseph R. Biden,Amy Klobuchar,Tulsi Gabbard
-1,27,1,13,,Precinct 1,Tulsi Gabbard,Joseph R. Biden,Elizabeth Warren,Amy Klobuchar,12
-1,27,1,14,,Precinct 1,Joseph R. Biden,Elizabeth Warren,Michael R. Bloomberg,Tom Steyer,Tulsi Gabbard
-1,27,1,15,,Precinct 1,Michael R. Bloomberg,Bernie Sanders,Pete Buttigieg,Tulsi Gabbard,12
-1,27,1,16,,Precinct 1,Elizabeth Warren,Tom Steyer,12,Tulsi Gabbard,Michael R. Bloomberg
-1,27,1,17,,Precinct 1,Amy Klobuchar,Tulsi Gabbard,Elizabeth Warren,12,Michael R. Bloomberg
-1,27,1,18,,Precinct 1,Tulsi Gabbard,Joseph R. Biden,Michael R. Bloomberg,12,Tom Steyer
-1,27,1,19,,Precinct 1,Michael R. Bloomberg,Pete Buttigieg,12,Elizabeth Warren,Joseph R. Biden
-1,27,1,20,,Precinct 1,Michael R. Bloomberg,12,Joseph R. Biden,Pete Buttigieg,Tom Steyer
-1,10,1,1,,Precinct 1,Joseph R. Biden,Tulsi Gabbard,Bernie Sanders,Pete Buttigieg,Tom Steyer
-1,10,1,2,,Precinct 1,Bernie Sanders,Joseph R. Biden,Michael R. Bloomberg,Tulsi Gabbard,12
-1,10,1,3,,Precinct 1,Amy Klobuchar,Tom Steyer,Joseph R. Biden,Pete Buttigieg,Michael R. Bloomberg
-1,10,1,4,,Precinct 1,Tom Steyer,Michael R. Bloomberg,Pete Buttigieg,Bernie Sanders,Tulsi Gabbard
-1,10,1,5,,Precinct 1,Tulsi Gabbard,Michael R. Bloomberg,Elizabeth Warren,12,Bernie Sanders
-1,10,1,6,,Precinct 1,overvote,12,Elizabeth Warren,Joseph R. Biden,Bernie Sanders
-1,10,1,7,,Precinct 1,Bernie Sanders,12,Elizabeth Warren,Tom Steyer,Joseph R. Biden
-1,10,1,8,,Precinct 1,Joseph R. Biden,Tulsi Gabbard,Bernie Sanders,Amy Klobuchar,12
-1,10,1,9,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,10,1,10,,Precinct 1,Joseph R. Biden,Bernie Sanders,Tulsi Gabbard,Pete Buttigieg,12
-1,10,1,11,,Precinct 1,Tulsi Gabbard,Joseph R. Biden,Elizabeth Warren,12,Pete Buttigieg
-1,10,1,12,,Precinct 1,Tom Steyer,12,Elizabeth Warren,Amy Klobuchar,Joseph R. Biden
-1,10,1,13,,Precinct 1,Tom Steyer,Pete Buttigieg,Tulsi Gabbard,Bernie Sanders,Elizabeth Warren
-1,10,1,14,,Precinct 1,Pete Buttigieg,Michael R. Bloomberg,12,Elizabeth Warren,Joseph R. Biden
-1,10,1,15,,Precinct 1,Elizabeth Warren,Michael R. Bloomberg,Pete Buttigieg,Bernie Sanders,Amy Klobuchar
-1,10,1,16,,Precinct 1,Tom Steyer,Tulsi Gabbard,Joseph R. Biden,Amy Klobuchar,Michael R. Bloomberg
-1,10,1,17,,Precinct 1,Tom Steyer,Tulsi Gabbard,Elizabeth Warren,Michael R. Bloomberg,Joseph R. Biden
-1,10,1,18,,Precinct 1,12,Tom Steyer,Bernie Sanders,Elizabeth Warren,Joseph R. Biden
-1,10,1,19,,Precinct 1,Joseph R. Biden,12,Bernie Sanders,Tulsi Gabbard,Elizabeth Warren
-1,10,1,20,,Precinct 1,12,Michael R. Bloomberg,Joseph R. Biden,Pete Buttigieg,Tom Steyer
-1,44,1,1,,Precinct 1,Elizabeth Warren,Tulsi Gabbard,Bernie Sanders,Michael R. Bloomberg,Joseph R. Biden
-1,44,1,2,,Precinct 1,12,Bernie Sanders,Joseph R. Biden,Michael R. Bloomberg,Elizabeth Warren
-1,44,1,3,,Precinct 1,12,Elizabeth Warren,Pete Buttigieg,Joseph R. Biden,Bernie Sanders
-1,44,1,4,,Precinct 1,Tulsi Gabbard,Michael R. Bloomberg,Pete Buttigieg,12,Bernie Sanders
-1,44,1,5,,Precinct 1,Amy Klobuchar,Tom Steyer,Bernie Sanders,Pete Buttigieg,Tulsi Gabbard
-1,44,1,6,,Precinct 1,Elizabeth Warren,Joseph R. Biden,Bernie Sanders,Amy Klobuchar,Tulsi Gabbard
-1,44,1,7,,Precinct 1,12,Tom Steyer,Amy Klobuchar,Bernie Sanders,Joseph R. Biden
-1,44,1,8,,Precinct 1,Pete Buttigieg,Michael R. Bloomberg,Tom Steyer,Tulsi Gabbard,Joseph R. Biden
-1,44,1,9,,Precinct 1,Tom Steyer,12,Bernie Sanders,Joseph R. Biden,Michael R. Bloomberg
-1,44,1,10,,Precinct 1,Pete Buttigieg,Joseph R. Biden,Tom Steyer,Amy Klobuchar,Michael R. Bloomberg
-1,44,1,11,,Precinct 1,Tom Steyer,Elizabeth Warren,Amy Klobuchar,12,Joseph R. Biden
-1,44,1,12,,Precinct 1,Michael R. Bloomberg,Elizabeth Warren,Pete Buttigieg,Joseph R. Biden,Tom Steyer
-1,44,1,13,,Precinct 1,Bernie Sanders,Joseph R. Biden,Tulsi Gabbard,Amy Klobuchar,Elizabeth Warren
-1,44,1,14,,Precinct 1,12,Tulsi Gabbard,Joseph R. Biden,Pete Buttigieg,Bernie Sanders
-1,44,1,15,,Precinct 1,Tom Steyer,Tulsi Gabbard,Elizabeth Warren,Amy Klobuchar,12
-1,44,1,16,,Precinct 1,12,Bernie Sanders,Tom Steyer,Elizabeth Warren,Amy Klobuchar
-1,44,1,17,,Precinct 1,Amy Klobuchar,12,Joseph R. Biden,Pete Buttigieg,Elizabeth Warren
-1,44,1,18,,Precinct 1,Bernie Sanders,Tom Steyer,12,Pete Buttigieg,Michael R. Bloomberg
-1,44,1,19,,Precinct 1,Elizabeth Warren,12,Amy Klobuchar,Michael R. Bloomberg,Joseph R. Biden
-1,44,1,20,,Precinct 1,Bernie Sanders,Joseph R. Biden,Elizabeth Warren,Tulsi Gabbard,Pete Buttigieg
-1,1,1,1,,Precinct 1,Tulsi Gabbard,Joseph R. Biden,Pete Buttigieg,Amy Klobuchar,Elizabeth Warren
-1,1,1,2,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,1,1,3,,Precinct 1,Pete Buttigieg,Amy Klobuchar,Tom Steyer,12,Bernie Sanders
-1,1,1,4,,Precinct 1,Michael R. Bloomberg,Tom Steyer,Elizabeth Warren,Joseph R. Biden,Bernie Sanders
-1,1,1,5,,Precinct 1,Joseph R. Biden,Bernie Sanders,Elizabeth Warren,Tulsi Gabbard,12
-1,1,1,6,,Precinct 1,Amy Klobuchar,12,Tulsi Gabbard,Joseph R. Biden,Tom Steyer
-1,1,1,7,,Precinct 1,Tulsi Gabbard,12,Joseph R. Biden,Amy Klobuchar,Elizabeth Warren
-1,1,1,8,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,1,1,9,,Precinct 1,Tulsi Gabbard,Michael R. Bloomberg,Bernie Sanders,Tom Steyer,Elizabeth Warren
-1,1,1,10,,Precinct 1,Bernie Sanders,Joseph R. Biden,Tulsi Gabbard,Amy Klobuchar,12
-1,1,1,11,,Precinct 1,Elizabeth Warren,Pete Buttigieg,Tom Steyer,Bernie Sanders,Amy Klobuchar
-1,1,1,12,,Precinct 1,Pete Buttigieg,Amy Klobuchar,Tulsi Gabbard,Tom Steyer,Michael R. Bloomberg
-1,1,1,13,,Precinct 1,Michael R. Bloomberg,Joseph R. Biden,Pete Buttigieg,Tulsi Gabbard,12
-1,1,1,14,,Precinct 1,Joseph R. Biden,12,Elizabeth Warren,Pete Buttigieg,Bernie Sanders
-1,1,1,15,,Precinct 1,Tom Steyer,Elizabeth Warren,Pete Buttigieg,Joseph R. Biden,Michael R. Bloomberg
-1,1,1,16,,Precinct 1,Pete Buttigieg,Amy Klobuchar,Tom Steyer,Bernie Sanders,12
-1,1,1,17,,Precinct 1,12,Elizabeth Warren,Tulsi Gabbard,Michael R. Bloomberg,Joseph R. Biden
-1,1,1,18,,Precinct 1,Amy Klobuchar,Elizabeth Warren,Michael R. Bloomberg,Bernie Sanders,Tulsi Gabbard
-1,1,1,19,,Precinct 1,Tulsi Gabbard,Bernie Sanders,Amy Klobuchar,Joseph R. Biden,Elizabeth Warren
-1,1,1,20,,Precinct 1,Tulsi Gabbard,Tom Steyer,12,Amy Klobuchar,Joseph R. Biden
-1,43,1,1,,Precinct 1,Tom Steyer,Pete Buttigieg,Bernie Sanders,Michael R. Bloomberg,12
-1,43,1,2,,Precinct 1,Joseph R. Biden,Michael R. Bloomberg,Bernie Sanders,Amy Klobuchar,Tom Steyer
-1,43,1,3,,Precinct 1,12,Joseph R. Biden,Elizabeth Warren,Tom Steyer,Tulsi Gabbard
-1,43,1,4,,Precinct 1,12,Tulsi Gabbard,Pete Buttigieg,Bernie Sanders,Amy Klobuchar
-1,43,1,5,,Precinct 1,Elizabeth Warren,Michael R. Bloomberg,12,Joseph R. Biden,Amy Klobuchar
-1,43,1,6,,Precinct 1,Joseph R. Biden,Tulsi Gabbard,Elizabeth Warren,Amy Klobuchar,Tom Steyer
-1,43,1,7,,Precinct 1,Bernie Sanders,Michael R. Bloomberg,Amy Klobuchar,Elizabeth Warren,Pete Buttigieg
-1,43,1,8,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,43,1,9,,Precinct 1,Tulsi Gabbard,Amy Klobuchar,Tom Steyer,Joseph R. Biden,Pete Buttigieg
-1,43,1,10,,Precinct 1,Bernie Sanders,Tulsi Gabbard,Pete Buttigieg,Joseph R. Biden,Tom Steyer
-1,43,1,11,,Precinct 1,Joseph R. Biden,Tom Steyer,Michael R. Bloomberg,Amy Klobuchar,Bernie Sanders
-1,43,1,12,,Precinct 1,12,Michael R. Bloomberg,Bernie Sanders,Joseph R. Biden,Pete Buttigieg
-1,43,1,13,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,43,1,14,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,43,1,15,,Precinct 1,Tom Steyer,Amy Klobuchar,Joseph R. Biden,Bernie Sanders,Pete Buttigieg
-1,43,1,16,,Precinct 1,12,Joseph R. Biden,Amy Klobuchar,Bernie Sanders,Michael R. Bloomberg
-1,43,1,17,,Precinct 1,Tulsi Gabbard,Tom Steyer,Bernie Sanders,Amy Klobuchar,Elizabeth Warren
-1,43,1,18,,Precinct 1,Bernie Sanders,Elizabeth Warren,Tulsi Gabbard,Joseph R. Biden,Amy Klobuchar
-1,43,1,19,,Precinct 1,Bernie Sanders,Amy Klobuchar,Joseph R. Biden,Michael R. Bloomberg,Elizabeth Warren
-1,43,1,20,,Precinct 1,Michael R. Bloomberg,Elizabeth Warren,Joseph R. Biden,Amy Klobuchar,Tulsi Gabbard
-1,9,1,1,,Precinct 1,Elizabeth Warren,Michael R. Bloomberg,12,Tulsi Gabbard,Amy Klobuchar
-1,9,1,2,,Precinct 1,Bernie Sanders,Tulsi Gabbard,Michael R. Bloomberg,12,Tom Steyer
-1,9,1,3,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,9,1,4,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,9,1,5,,Precinct 1,Elizabeth Warren,Tulsi Gabbard,12,Michael R. Bloomberg,Bernie Sanders
-1,9,1,6,,Precinct 1,Elizabeth Warren,Amy Klobuchar,Tulsi Gabbard,Tom Steyer,Michael R. Bloomberg
-1,9,1,7,,Precinct 1,Pete Buttigieg,Amy Klobuchar,Michael R. Bloomberg,Bernie Sanders,12
-1,9,1,8,,Precinct 1,Bernie Sanders,12,Elizabeth Warren,Michael R. Bloomberg,Tom Steyer
-1,9,1,9,,Precinct 1,Bernie Sanders,Michael R. Bloomberg,Amy Klobuchar,Elizabeth Warren,Joseph R. Biden
-1,9,1,10,,Precinct 1,Tulsi Gabbard,Joseph R. Biden,Elizabeth Warren,Michael R. Bloomberg,Pete Buttigieg
-1,9,1,11,,Precinct 1,Elizabeth Warren,Pete Buttigieg,Michael R. Bloomberg,12,Tulsi Gabbard
-1,9,1,12,,Precinct 1,Tom Steyer,Michael R. Bloomberg,Bernie Sanders,Elizabeth Warren,Joseph R. Biden
-1,9,1,13,,Precinct 1,12,Tulsi Gabbard,Bernie Sanders,Amy Klobuchar,Pete Buttigieg
-1,9,1,14,,Precinct 1,12,Elizabeth Warren,Tulsi Gabbard,Tom Steyer,Joseph R. Biden
-1,9,1,15,,Precinct 1,Amy Klobuchar,Bernie Sanders,12,Elizabeth Warren,Tom Steyer
-1,9,1,16,,Precinct 1,Tom Steyer,Bernie Sanders,Tulsi Gabbard,12,Michael R. Bloomberg
-1,9,1,17,,Precinct 1,Elizabeth Warren,Tulsi Gabbard,Michael R. Bloomberg,Bernie Sanders,12
-1,9,1,18,,Precinct 1,Bernie Sanders,Elizabeth Warren,Joseph R. Biden,Amy Klobuchar,12
-1,9,1,19,,Precinct 1,12,Amy Klobuchar,Joseph R. Biden,Bernie Sanders,Pete Buttigieg
-1,9,1,20,,Precinct 1,Tom Steyer,Amy Klobuchar,Joseph R. Biden,Bernie Sanders,12
-1,4,1,1,,Precinct 1,Michael R. Bloomberg,Elizabeth Warren,Tom Steyer,Pete Buttigieg,12
-1,4,1,2,,Precinct 1,Pete Buttigieg,Joseph R. Biden,Amy Klobuchar,Tom Steyer,12
-1,4,1,3,,Precinct 1,Amy Klobuchar,Bernie Sanders,Tom Steyer,Tulsi Gabbard,Joseph R. Biden
-1,4,1,4,,Precinct 1,Amy Klobuchar,Bernie Sanders,Tulsi Gabbard,12,Tom Steyer
-1,4,1,5,,Precinct 1,Tom Steyer,Amy Klobuchar,Tulsi Gabbard,Michael R. Bloomberg,12
-1,4,1,6,,Precinct 1,Joseph R. Biden,Tom Steyer,Tulsi Gabbard,Pete Buttigieg,Michael R. Bloomberg
-1,4,1,7,,Precinct 1,Pete Buttigieg,Michael R. Bloomberg,Bernie Sanders,Joseph R. Biden,Elizabeth Warren
-1,4,1,8,,Precinct 1,Tulsi Gabbard,12,Tom Steyer,Amy Klobuchar,Elizabeth Warren
-1,4,1,9,,Precinct 1,Joseph R. Biden,Amy Klobuchar,Michael R. Bloomberg,Tulsi Gabbard,Bernie Sanders
-1,4,1,10,,Precinct 1,Pete Buttigieg,Joseph R. Biden,12,Tulsi Gabbard,Tom Steyer
-1,4,1,11,,Precinct 1,Amy Klobuchar,Tom Steyer,Pete Buttigieg,Michael R. Bloomberg,12
-1,4,1,12,,Precinct 1,Tom Steyer,Amy Klobuchar,Joseph R. Biden,Bernie Sanders,Pete Buttigieg
-1,4,1,13,,Precinct 1,Michael R. Bloomberg,Tom Steyer,Joseph R. Biden,Elizabeth Warren,Tulsi Gabbard
-1,4,1,14,,Precinct 1,Pete Buttigieg,Amy Klobuchar,Michael R. Bloomberg,Tulsi Gabbard,Elizabeth Warren
-1,4,1,15,,Precinct 1,Elizabeth Warren,Tulsi Gabbard,Pete Buttigieg,Bernie Sanders,Joseph R. Biden
-1,4,1,16,,Precinct 1,12,Elizabeth Warren,Tom Steyer,Amy Klobuchar,Bernie Sanders
-1,4,1,17,,Precinct 1,12,Joseph R. Biden,Amy Klobuchar,Elizabeth Warren,Pete Buttigieg
-1,4,1,18,,Precinct 1,Amy Klobuchar,Tom Steyer,Elizabeth Warren,Tulsi Gabbard,12
-1,4,1,19,,Precinct 1,Amy Klobuchar,Joseph R. Biden,Tulsi Gabbard,Michael R. Bloomberg,Tom Steyer
-1,4,1,20,,Precinct 1,Michael R. Bloomberg,Joseph R. Biden,Tulsi Gabbard,Amy Klobuchar,12
-1,8,1,1,,Precinct 1,Tom Steyer,12,Michael R. Bloomberg,Pete Buttigieg,Amy Klobuchar
-1,8,1,2,,Precinct 1,Amy Klobuchar,Michael R. Bloomberg,Pete Buttigieg,Tulsi Gabbard,Elizabeth Warren
-1,8,1,3,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,8,1,4,,Precinct 1,Joseph R. Biden,Tulsi Gabbard,Amy Klobuchar,12,Bernie Sanders
-1,8,1,5,,Precinct 1,Tulsi Gabbard,Bernie Sanders,Michael R. Bloomberg,Joseph R. Biden,12
-1,8,1,6,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,8,1,7,,Precinct 1,Amy Klobuchar,Pete Buttigieg,Michael R. Bloomberg,Elizabeth Warren,Tulsi Gabbard
-1,8,1,8,,Precinct 1,Bernie Sanders,Elizabeth Warren,12,Tom Steyer,Michael R. Bloomberg
-1,8,1,9,,Precinct 1,Tulsi Gabbard,Michael R. Bloomberg,Amy Klobuchar,12,Bernie Sanders
-1,8,1,10,,Precinct 1,Elizabeth Warren,12,Pete Buttigieg,Tom Steyer,Michael R. Bloomberg
-1,8,1,11,,Precinct 1,Bernie Sanders,Tulsi Gabbard,Amy Klobuchar,12,Pete Buttigieg
-1,8,1,12,,Precinct 1,Bernie Sanders,Elizabeth Warren,Tom Steyer,Tulsi Gabbard,Pete Buttigieg
-1,8,1,13,,Precinct 1,Joseph R. Biden,Tom Steyer,Bernie Sanders,Pete Buttigieg,Tulsi Gabbard
-1,8,1,14,,Precinct 1,Tulsi Gabbard,Joseph R. Biden,Elizabeth Warren,overvote,Pete Buttigieg
-1,8,1,15,,Precinct 1,Bernie Sanders,Tulsi Gabbard,Tom Steyer,Amy Klobuchar,12
-1,8,1,16,,Precinct 1,Bernie Sanders,Tulsi Gabbard,Amy Klobuchar,Elizabeth Warren,12
-1,8,1,17,,Precinct 1,Pete Buttigieg,Michael R. Bloomberg,Tulsi Gabbard,Elizabeth Warren,12
-1,8,1,18,,Precinct 1,Bernie Sanders,Elizabeth Warren,Michael R. Bloomberg,Pete Buttigieg,Tulsi Gabbard
-1,8,1,19,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,8,1,20,,Precinct 1,Tulsi Gabbard,Elizabeth Warren,12,Amy Klobuchar,Michael R. Bloomberg
-1,7,1,1,,Precinct 1,Joseph R. Biden,12,Michael R. Bloomberg,Tulsi Gabbard,Elizabeth Warren
-1,7,1,2,,Precinct 1,Michael R. Bloomberg,Joseph R. Biden,Tom Steyer,Amy Klobuchar,Pete Buttigieg
-1,7,1,3,,Precinct 1,Amy Klobuchar,Joseph R. Biden,12,Tulsi Gabbard,Bernie Sanders
-1,7,1,4,,Precinct 1,12,Pete Buttigieg,Tulsi Gabbard,Bernie Sanders,Tom Steyer
-1,7,1,5,,Precinct 1,Amy Klobuchar,Michael R. Bloomberg,Joseph R. Biden,Pete Buttigieg,Bernie Sanders
-1,7,1,6,,Precinct 1,Michael R. Bloomberg,Tom Steyer,Bernie Sanders,Joseph R. Biden,12
-1,7,1,7,,Precinct 1,Michael R. Bloomberg,Amy Klobuchar,Tulsi Gabbard,12,Tom Steyer
-1,7,1,8,,Precinct 1,Michael R. Bloomberg,Amy Klobuchar,Pete Buttigieg,Joseph R. Biden,Tulsi Gabbard
-1,7,1,9,,Precinct 1,Tom Steyer,Tulsi Gabbard,Elizabeth Warren,12,Michael R. Bloomberg
-1,7,1,10,,Precinct 1,Michael R. Bloomberg,Bernie Sanders,Tulsi Gabbard,Pete Buttigieg,Amy Klobuchar
-1,7,1,11,,Precinct 1,Michael R. Bloomberg,Pete Buttigieg,Bernie Sanders,Tom Steyer,Amy Klobuchar
-1,7,1,12,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,7,1,13,,Precinct 1,Joseph R. Biden,Pete Buttigieg,Elizabeth Warren,Michael R. Bloomberg,12
-1,7,1,14,,Precinct 1,Bernie Sanders,Tom Steyer,Michael R. Bloomberg,Amy Klobuchar,Elizabeth Warren
-1,7,1,15,,Precinct 1,Tom Steyer,Amy Klobuchar,Michael R. Bloomberg,Bernie Sanders,12
-1,7,1,16,,Precinct 1,Pete Buttigieg,Amy Klobuchar,Michael R. Bloomberg,Bernie Sanders,Tom Steyer
-1,7,1,17,,Precinct 1,Bernie Sanders,Amy Klobuchar,Tom Steyer,Joseph R. Biden,Elizabeth Warren
-1,7,1,18,,Precinct 1,Joseph R. Biden,12,Amy Klobuchar,Pete Buttigieg,Elizabeth Warren
-1,7,1,19,,Precinct 1,Tom Steyer,Tulsi Gabbard,Amy Klobuchar,Pete Buttigieg,Elizabeth Warren
-1,7,1,20,,Precinct 1,Amy Klobuchar,Tulsi Gabbard,Tom Steyer,Elizabeth Warren,Pete Buttigieg
-1,28,1,1,,Precinct 1,Amy Klobuchar,Michael R. Bloomberg,Tulsi Gabbard,Pete Buttigieg,Tom Steyer
-1,28,1,2,,Precinct 1,Tom Steyer,undervote,Elizabeth Warren,Pete Buttigieg,Bernie Sanders
-1,28,1,3,,Precinct 1,Joseph R. Biden,Elizabeth Warren,Michael R. Bloomberg,12,Tulsi Gabbard
-1,28,1,4,,Precinct 1,Joseph R. Biden,Bernie Sanders,Tom Steyer,Michael R. Bloomberg,Pete Buttigieg
-1,28,1,5,,Precinct 1,Amy Klobuchar,Michael R. Bloomberg,Joseph R. Biden,12,Elizabeth Warren
-1,28,1,6,,Precinct 1,12,Michael R. Bloomberg,Tom Steyer,Amy Klobuchar,Tulsi Gabbard
-1,28,1,7,,Precinct 1,Bernie Sanders,Elizabeth Warren,Tom Steyer,Joseph R. Biden,12
-1,28,1,8,,Precinct 1,Tulsi Gabbard,Amy Klobuchar,12,Pete Buttigieg,Tom Steyer
-1,28,1,9,,Precinct 1,Bernie Sanders,12,Tom Steyer,Tulsi Gabbard,Amy Klobuchar
-1,28,1,10,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,28,1,11,,Precinct 1,12,Tulsi Gabbard,Elizabeth Warren,Bernie Sanders,Amy Klobuchar
-1,28,1,12,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,28,1,13,,Precinct 1,Tom Steyer,Bernie Sanders,Joseph R. Biden,Michael R. Bloomberg,Elizabeth Warren
-1,28,1,14,,Precinct 1,Amy Klobuchar,12,Elizabeth Warren,Pete Buttigieg,Michael R. Bloomberg
-1,28,1,15,,Precinct 1,Bernie Sanders,Michael R. Bloomberg,Pete Buttigieg,Tulsi Gabbard,Tom Steyer
-1,28,1,16,,Precinct 1,Pete Buttigieg,Joseph R. Biden,Elizabeth Warren,12,Tulsi Gabbard
-1,28,1,17,,Precinct 1,Joseph R. Biden,Michael R. Bloomberg,Amy Klobuchar,Elizabeth Warren,Tom Steyer
-1,28,1,18,,Precinct 1,Michael R. Bloomberg,Tom Steyer,Amy Klobuchar,12,Bernie Sanders
-1,28,1,19,,Precinct 1,Michael R. Bloomberg,Amy Klobuchar,12,Bernie Sanders,Tulsi Gabbard
-1,28,1,20,,Precinct 1,Michael R. Bloomberg,Bernie Sanders,Amy Klobuchar,Pete Buttigieg,Joseph R. Biden
-1,6,1,1,,Precinct 1,Elizabeth Warren,Tom Steyer,Tulsi Gabbard,Pete Buttigieg,Bernie Sanders
-1,6,1,2,,Precinct 1,Michael R. Bloomberg,Amy Klobuchar,Tom Steyer,12,Joseph R. Biden
-1,6,1,3,,Precinct 1,Amy Klobuchar,Tulsi Gabbard,Pete Buttigieg,Bernie Sanders,Michael R. Bloomberg
-1,6,1,4,,Precinct 1,Tulsi Gabbard,Michael R. Bloomberg,12,Pete Buttigieg,Tom Steyer
-1,6,1,5,,Precinct 1,overvote,Tom Steyer,Elizabeth Warren,Bernie Sanders,Tom Steyer
-1,6,1,6,,Precinct 1,12,Tulsi Gabbard,Pete Buttigieg,Michael R. Bloomberg,Joseph R. Biden
-1,6,1,7,,Precinct 1,Michael R. Bloomberg,Tulsi Gabbard,Bernie Sanders,Joseph R. Biden,12
-1,6,1,8,,Precinct 1,Joseph R. Biden,12,Pete Buttigieg,Tulsi Gabbard,Michael R. Bloomberg
-1,6,1,9,,Precinct 1,Elizabeth Warren,Michael R. Bloomberg,Amy Klobuchar,Tom Steyer,Tulsi Gabbard
-1,6,1,10,,Precinct 1,12,Michael R. Bloomberg,Amy Klobuchar,Pete Buttigieg,Tom Steyer
-1,6,1,11,,Precinct 1,Michael R. Bloomberg,12,Elizabeth Warren,Amy Klobuchar,Pete Buttigieg
-1,6,1,12,,Precinct 1,Tom Steyer,Joseph R. Biden,12,Pete Buttigieg,Amy Klobuchar
-1,6,1,13,,Precinct 1,Pete Buttigieg,Elizabeth Warren,Joseph R. Biden,12,Tom Steyer
-1,6,1,14,,Precinct 1,Tulsi Gabbard,Amy Klobuchar,Bernie Sanders,Elizabeth Warren,Pete Buttigieg
-1,6,1,15,,Precinct 1,Pete Buttigieg,Michael R. Bloomberg,Amy Klobuchar,Elizabeth Warren,Bernie Sanders
-1,6,1,16,,Precinct 1,Joseph R. Biden,12,Pete Buttigieg,Elizabeth Warren,Tom Steyer
-1,6,1,17,,Precinct 1,Tulsi Gabbard,Pete Buttigieg,12,Tom Steyer,Amy Klobuchar
-1,6,1,18,,Precinct 1,Tulsi Gabbard,12,Amy Klobuchar,Elizabeth Warren,Pete Buttigieg
-1,6,1,19,,Precinct 1,Tom Steyer,Tulsi Gabbard,Amy Klobuchar,12,Elizabeth Warren
-1,6,1,20,,Precinct 1,Pete Buttigieg,Tom Steyer,Joseph R. Biden,Michael R. Bloomberg,Amy Klobuchar
-1,5,1,1,,Precinct 1,Tom Steyer,Tulsi Gabbard,Amy Klobuchar,Pete Buttigieg,Joseph R. Biden
-1,5,1,2,,Precinct 1,Pete Buttigieg,Elizabeth Warren,Bernie Sanders,Tulsi Gabbard,Amy Klobuchar
-1,5,1,3,,Precinct 1,Amy Klobuchar,Pete Buttigieg,Tulsi Gabbard,Tom Steyer,12
-1,5,1,4,,Precinct 1,12,Tulsi Gabbard,Tom Steyer,Amy Klobuchar,Bernie Sanders
-1,5,1,5,,Precinct 1,12,Michael R. Bloomberg,Tulsi Gabbard,Tom Steyer,Elizabeth Warren
-1,5,1,6,,Precinct 1,Elizabeth Warren,Michael R. Bloomberg,12,Amy Klobuchar,Tulsi Gabbard
-1,5,1,7,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,5,1,8,,Precinct 1,Tom Steyer,Michael R. Bloomberg,12,Elizabeth Warren,Amy Klobuchar
-1,5,1,9,,Precinct 1,Amy Klobuchar,12,Bernie Sanders,Pete Buttigieg,Tulsi Gabbard
-1,5,1,10,,Precinct 1,Bernie Sanders,Pete Buttigieg,12,Elizabeth Warren,Tulsi Gabbard
-1,5,1,11,,Precinct 1,Bernie Sanders,Michael R. Bloomberg,Tom Steyer,Pete Buttigieg,Elizabeth Warren
-1,5,1,12,,Precinct 1,Pete Buttigieg,Elizabeth Warren,Tom Steyer,Amy Klobuchar,Tulsi Gabbard
-1,5,1,13,,Precinct 1,Pete Buttigieg,Amy Klobuchar,Tulsi Gabbard,Tom Steyer,Michael R. Bloomberg
-1,5,1,14,,Precinct 1,Tulsi Gabbard,Elizabeth Warren,Michael R. Bloomberg,Pete Buttigieg,Tom Steyer
-1,5,1,15,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,5,1,16,,Precinct 1,Joseph R. Biden,Amy Klobuchar,Tulsi Gabbard,Pete Buttigieg,Michael R. Bloomberg
-1,5,1,17,,Precinct 1,Bernie Sanders,Tom Steyer,Pete Buttigieg,Elizabeth Warren,12
-1,5,1,18,,Precinct 1,Pete Buttigieg,Elizabeth Warren,12,Tom Steyer,Amy Klobuchar
-1,5,1,19,,Precinct 1,Bernie Sanders,Tulsi Gabbard,Michael R. Bloomberg,Pete Buttigieg,Tom Steyer
-1,5,1,20,,Precinct 1,Joseph R. Biden,Pete Buttigieg,Amy Klobuchar,Elizabeth Warren,Tom Steyer
-1,3,1,1,,Precinct 1,Amy Klobuchar,Elizabeth Warren,Tom Steyer,Bernie Sanders,Joseph R. Biden
-1,3,1,2,,Precinct 1,Tulsi Gabbard,Pete Buttigieg,12,Amy Klobuchar,Michael R. Bloomberg
-1,3,1,3,,Precinct 1,Bernie Sanders,Amy Klobuchar,12,Michael R. Bloomberg,Tom Steyer
-1,3,1,4,,Precinct 1,Joseph R. Biden,Tulsi Gabbard,Bernie Sanders,Amy Klobuchar,12
-1,3,1,5,,Precinct 1,Pete Buttigieg,Joseph R. Biden,Tom Steyer,Amy Klobuchar,Michael R. Bloomberg
-1,3,1,6,,Precinct 1,Pete Buttigieg,Joseph R. Biden,12,Elizabeth Warren,Michael R. Bloomberg
-1,3,1,7,,Precinct 1,Elizabeth Warren,Tulsi Gabbard,Joseph R. Biden,Amy Klobuchar,Pete Buttigieg
-1,3,1,8,,Precinct 1,Bernie Sanders,Pete Buttigieg,Tulsi Gabbard,Joseph R. Biden,Tom Steyer
-1,3,1,9,,Precinct 1,Joseph R. Biden,Tulsi Gabbard,Tom Steyer,Amy Klobuchar,Michael R. Bloomberg
-1,3,1,10,,Precinct 1,Elizabeth Warren,Joseph R. Biden,Amy Klobuchar,Tulsi Gabbard,Tom Steyer
-1,3,1,11,,Precinct 1,Pete Buttigieg,Tulsi Gabbard,Amy Klobuchar,12,Tom Steyer
-1,3,1,12,,Precinct 1,Bernie Sanders,Michael R. Bloomberg,Joseph R. Biden,Tom Steyer,Tulsi Gabbard
-1,3,1,13,,Precinct 1,undervote,undervote,undervote,undervote,undervote
-1,3,1,14,,Precinct 1,Elizabeth Warren,Bernie Sanders,Pete Buttigieg,Amy Klobuchar,Joseph R. Biden
-1,3,1,15,,Precinct 1,Pete Buttigieg,12,Elizabeth Warren,Joseph R. Biden,Tulsi Gabbard
-1,3,1,16,,Precinct 1,Tom Steyer,Amy Klobuchar,Elizabeth Warren,Pete Buttigieg,Tulsi Gabbard
-1,3,1,17,,Precinct 1,Michael R. Bloomberg,Amy Klobuchar,Elizabeth Warren,Tulsi Gabbard,Pete Buttigieg
-1,3,1,18,,Precinct 1,Michael R. Bloomberg,Pete Buttigieg,Joseph R. Biden,Elizabeth Warren,12
-1,3,1,19,,Precinct 1,Michael R. Bloomberg,Elizabeth Warren,12,Pete Buttigieg,Bernie Sanders
-1,3,1,20,,Precinct 1,Joseph R. Biden,Bernie Sanders,Tom Steyer,Tulsi Gabbard,Amy Klobuchar
-1,2,1,1,,Precinct 1,12,Michael R. Bloomberg,Pete Buttigieg,Bernie Sanders,Elizabeth Warren
-1,2,1,2,,Precinct 1,Elizabeth Warren,Tom Steyer,Joseph R. Biden,Bernie Sanders,Tulsi Gabbard
-1,2,1,3,,Precinct 1,Bernie Sanders,Michael R. Bloomberg,Elizabeth Warren,Tulsi Gabbard,Pete Buttigieg
-1,2,1,4,,Precinct 1,Tulsi Gabbard,Bernie Sanders,Elizabeth Warren,Pete Buttigieg,12
-1,2,1,5,,Precinct 1,Joseph R. Biden,Michael R. Bloomberg,12,Amy Klobuchar,Pete Buttigieg
-1,2,1,6,,Precinct 1,Bernie Sanders,Amy Klobuchar,Tulsi Gabbard,12,Michael R. Bloomberg
-1,2,1,7,,Precinct 1,12,Joseph R. Biden,Tom Steyer,Michael R. Bloomberg,Amy Klobuchar
-1,2,1,8,,Precinct 1,Elizabeth Warren,12,Tom Steyer,Tulsi Gabbard,Pete Buttigieg
-1,2,1,9,,Precinct 1,Elizabeth Warren,Amy Klobuchar,Tom Steyer,Tulsi Gabbard,Bernie Sanders
-1,2,1,10,,Precinct 1,Amy Klobuchar,Joseph R. Biden,Elizabeth Warren,Pete Buttigieg,Bernie Sanders
-1,2,1,11,,Precinct 1,Amy Klobuchar,Joseph R. Biden,Tulsi Gabbard,Pete Buttigieg,Elizabeth Warren
-1,2,1,12,,Precinct 1,Amy Klobuchar,Bernie Sanders,Tom Steyer,Michael R. Bloomberg,Joseph R. Biden
-1,2,1,13,,Precinct 1,Tom Steyer,12,Elizabeth Warren,Pete Buttigieg,Michael R. Bloomberg
-1,2,1,14,,Precinct 1,Tulsi Gabbard,Michael R. Bloomberg,Pete Buttigieg,Joseph R. Biden,Elizabeth Warren
-1,2,1,15,,Precinct 1,Bernie Sanders,Amy Klobuchar,Joseph R. Biden,Tulsi Gabbard,Michael R. Bloomberg
-1,2,1,16,,Precinct 1,Tom Steyer,Pete Buttigieg,12,Bernie Sanders,Elizabeth Warren
-1,2,1,17,,Precinct 1,12,Bernie Sanders,Amy Klobuchar,Tulsi Gabbard,Joseph R. Biden
-1,2,1,18,,Precinct 1,Michael R. Bloomberg,Elizabeth Warren,Joseph R. Biden,Tom Steyer,12
-1,2,1,19,,Precinct 1,Tom Steyer,Michael R. Bloomberg,Joseph R. Biden,Elizabeth Warren,Pete Buttigieg
-1,2,1,20,,Precinct 1,Michael R. Bloomberg,12,Tom Steyer,Amy Klobuchar,Bernie Sanders
+Source Filepath,Contest Id,Tabulator Id,Batch Id,Record Id,Precinct,Precinct Portion,Rank 1,Rank 2,Rank 3,Rank 4,Rank 5
+../_shared/dominion_alaska/alaska_input_data,1,42,1,1,,Precinct 1,Michael R. Bloomberg,Joseph R. Biden,12,Elizabeth Warren,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,42,1,2,,Precinct 1,Joseph R. Biden,12,Bernie Sanders,Pete Buttigieg,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,42,1,3,,Precinct 1,12,Amy Klobuchar,Tulsi Gabbard,Joseph R. Biden,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,42,1,4,,Precinct 1,Tulsi Gabbard,Bernie Sanders,Tom Steyer,12,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,42,1,5,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,42,1,6,,Precinct 1,Tom Steyer,Joseph R. Biden,Elizabeth Warren,Pete Buttigieg,12
+../_shared/dominion_alaska/alaska_input_data,1,42,1,7,,Precinct 1,Tulsi Gabbard,Michael R. Bloomberg,Amy Klobuchar,Bernie Sanders,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,42,1,8,,Precinct 1,Tom Steyer,Bernie Sanders,Elizabeth Warren,Amy Klobuchar,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,42,1,9,,Precinct 1,Michael R. Bloomberg,Bernie Sanders,Elizabeth Warren,Tom Steyer,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,42,1,10,,Precinct 1,Tom Steyer,Elizabeth Warren,Bernie Sanders,Tulsi Gabbard,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,42,1,11,,Precinct 1,Tom Steyer,Pete Buttigieg,Joseph R. Biden,Tulsi Gabbard,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,42,1,12,,Precinct 1,Michael R. Bloomberg,Pete Buttigieg,Tulsi Gabbard,Elizabeth Warren,12
+../_shared/dominion_alaska/alaska_input_data,1,42,1,13,,Precinct 1,Elizabeth Warren,Joseph R. Biden,Amy Klobuchar,Bernie Sanders,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,42,1,14,,Precinct 1,Elizabeth Warren,Tom Steyer,Bernie Sanders,12,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,42,1,15,,Precinct 1,Tom Steyer,12,Pete Buttigieg,Elizabeth Warren,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,42,1,16,,Precinct 1,Tom Steyer,Amy Klobuchar,Tulsi Gabbard,Michael R. Bloomberg,12
+../_shared/dominion_alaska/alaska_input_data,1,42,1,17,,Precinct 1,Michael R. Bloomberg,Elizabeth Warren,Tulsi Gabbard,12,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,42,1,18,,Precinct 1,Joseph R. Biden,Bernie Sanders,Tom Steyer,Amy Klobuchar,12
+../_shared/dominion_alaska/alaska_input_data,1,42,1,19,,Precinct 1,Bernie Sanders,Tulsi Gabbard,12,Amy Klobuchar,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,42,1,20,,Precinct 1,Pete Buttigieg,Amy Klobuchar,12,Michael R. Bloomberg,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,34,1,1,,Precinct 1,Pete Buttigieg,Joseph R. Biden,12,Elizabeth Warren,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,34,1,2,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,34,1,3,,Precinct 1,Bernie Sanders,Tulsi Gabbard,Amy Klobuchar,Michael R. Bloomberg,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,34,1,4,,Precinct 1,Elizabeth Warren,Bernie Sanders,Pete Buttigieg,Joseph R. Biden,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,34,1,5,,Precinct 1,Pete Buttigieg,Michael R. Bloomberg,12,Bernie Sanders,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,34,1,6,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,34,1,7,,Precinct 1,Tulsi Gabbard,Michael R. Bloomberg,Bernie Sanders,12,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,34,1,8,,Precinct 1,Joseph R. Biden,Bernie Sanders,12,Amy Klobuchar,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,34,1,9,,Precinct 1,Pete Buttigieg,Tulsi Gabbard,Tom Steyer,Amy Klobuchar,12
+../_shared/dominion_alaska/alaska_input_data,1,34,1,10,,Precinct 1,Bernie Sanders,Elizabeth Warren,Tulsi Gabbard,Amy Klobuchar,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,34,1,11,,Precinct 1,Bernie Sanders,Tulsi Gabbard,Joseph R. Biden,Tom Steyer,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,34,1,12,,Precinct 1,Joseph R. Biden,Tulsi Gabbard,Bernie Sanders,Amy Klobuchar,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,34,1,13,,Precinct 1,Amy Klobuchar,Tom Steyer,Elizabeth Warren,12,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,34,1,14,,Precinct 1,Tulsi Gabbard,Amy Klobuchar,12,Michael R. Bloomberg,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,34,1,15,,Precinct 1,Bernie Sanders,Elizabeth Warren,12,Tom Steyer,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,34,1,16,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,34,1,17,,Precinct 1,Amy Klobuchar,Bernie Sanders,Tulsi Gabbard,Michael R. Bloomberg,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,34,1,18,,Precinct 1,Tom Steyer,Tulsi Gabbard,Pete Buttigieg,Amy Klobuchar,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,34,1,19,,Precinct 1,Tom Steyer,Bernie Sanders,Joseph R. Biden,Amy Klobuchar,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,34,1,20,,Precinct 1,12,Tulsi Gabbard,Joseph R. Biden,Elizabeth Warren,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,50,1,1,,Precinct 1,12,Bernie Sanders,Amy Klobuchar,Elizabeth Warren,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,50,1,2,,Precinct 1,Bernie Sanders,Tulsi Gabbard,Tom Steyer,12,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,50,1,3,,Precinct 1,12,Tulsi Gabbard,Michael R. Bloomberg,Amy Klobuchar,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,50,1,4,,Precinct 1,Amy Klobuchar,12,Tom Steyer,Bernie Sanders,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,50,1,5,,Precinct 1,Michael R. Bloomberg,Tulsi Gabbard,Bernie Sanders,Tom Steyer,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,50,1,6,,Precinct 1,Tulsi Gabbard,Michael R. Bloomberg,Amy Klobuchar,Pete Buttigieg,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,50,1,7,,Precinct 1,Tom Steyer,Tulsi Gabbard,Pete Buttigieg,Elizabeth Warren,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,50,1,8,,Precinct 1,Elizabeth Warren,12,Tulsi Gabbard,Bernie Sanders,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,50,1,9,,Precinct 1,Joseph R. Biden,Elizabeth Warren,Bernie Sanders,Pete Buttigieg,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,50,1,10,,Precinct 1,Tulsi Gabbard,Joseph R. Biden,Pete Buttigieg,12,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,50,1,11,,Precinct 1,Michael R. Bloomberg,Tulsi Gabbard,Pete Buttigieg,12,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,50,1,12,,Precinct 1,Tom Steyer,Pete Buttigieg,Joseph R. Biden,Bernie Sanders,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,50,1,13,,Precinct 1,Michael R. Bloomberg,Tom Steyer,Bernie Sanders,Tulsi Gabbard,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,50,1,14,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,50,1,15,,Precinct 1,Tulsi Gabbard,Pete Buttigieg,Amy Klobuchar,12,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,50,1,16,,Precinct 1,Tom Steyer,Pete Buttigieg,Michael R. Bloomberg,Tulsi Gabbard,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,50,1,17,,Precinct 1,Pete Buttigieg,Bernie Sanders,Michael R. Bloomberg,Tom Steyer,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,50,1,18,,Precinct 1,Elizabeth Warren,Bernie Sanders,Tom Steyer,Tulsi Gabbard,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,50,1,19,,Precinct 1,Joseph R. Biden,Tom Steyer,12,Michael R. Bloomberg,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,50,1,20,,Precinct 1,Pete Buttigieg,12,Joseph R. Biden,Amy Klobuchar,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,18,1,1,,Precinct 1,Michael R. Bloomberg,Bernie Sanders,Tom Steyer,Amy Klobuchar,12
+../_shared/dominion_alaska/alaska_input_data,1,18,1,2,,Precinct 1,12,Bernie Sanders,Tom Steyer,Amy Klobuchar,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,18,1,3,,Precinct 1,Tulsi Gabbard,Tom Steyer,Amy Klobuchar,12,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,18,1,4,,Precinct 1,Amy Klobuchar,12,Bernie Sanders,Tom Steyer,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,18,1,5,,Precinct 1,Bernie Sanders,Amy Klobuchar,Joseph R. Biden,Pete Buttigieg,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,18,1,6,,Precinct 1,12,Tom Steyer,Bernie Sanders,Michael R. Bloomberg,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,18,1,7,,Precinct 1,Tulsi Gabbard,Amy Klobuchar,Tom Steyer,Michael R. Bloomberg,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,18,1,8,,Precinct 1,Bernie Sanders,Elizabeth Warren,Pete Buttigieg,Amy Klobuchar,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,18,1,9,,Precinct 1,12,Amy Klobuchar,Tom Steyer,Michael R. Bloomberg,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,18,1,10,,Precinct 1,Bernie Sanders,12,Michael R. Bloomberg,Joseph R. Biden,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,18,1,11,,Precinct 1,12,Michael R. Bloomberg,Pete Buttigieg,Elizabeth Warren,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,18,1,12,,Precinct 1,Pete Buttigieg,Tom Steyer,Tulsi Gabbard,12,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,18,1,13,,Precinct 1,Bernie Sanders,Amy Klobuchar,Pete Buttigieg,Elizabeth Warren,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,18,1,14,,Precinct 1,Tom Steyer,Joseph R. Biden,Pete Buttigieg,12,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,18,1,15,,Precinct 1,Pete Buttigieg,12,Joseph R. Biden,Amy Klobuchar,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,18,1,16,,Precinct 1,Pete Buttigieg,Joseph R. Biden,Tom Steyer,Michael R. Bloomberg,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,18,1,17,,Precinct 1,Bernie Sanders,Pete Buttigieg,Tom Steyer,Joseph R. Biden,12
+../_shared/dominion_alaska/alaska_input_data,1,18,1,18,,Precinct 1,Joseph R. Biden,Tom Steyer,Tulsi Gabbard,12,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,18,1,19,,Precinct 1,Joseph R. Biden,Amy Klobuchar,Bernie Sanders,Michael R. Bloomberg,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,18,1,20,,Precinct 1,Joseph R. Biden,Pete Buttigieg,Tom Steyer,Tulsi Gabbard,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,26,1,1,,Precinct 1,Tulsi Gabbard,Tom Steyer,Bernie Sanders,12,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,26,1,2,,Precinct 1,Bernie Sanders,Tom Steyer,Michael R. Bloomberg,Tulsi Gabbard,12
+../_shared/dominion_alaska/alaska_input_data,1,26,1,3,,Precinct 1,Michael R. Bloomberg,Tom Steyer,Amy Klobuchar,Bernie Sanders,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,26,1,4,,Precinct 1,Michael R. Bloomberg,Elizabeth Warren,Amy Klobuchar,Joseph R. Biden,12
+../_shared/dominion_alaska/alaska_input_data,1,26,1,5,,Precinct 1,Michael R. Bloomberg,Joseph R. Biden,Elizabeth Warren,Tom Steyer,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,26,1,6,,Precinct 1,Joseph R. Biden,Michael R. Bloomberg,Tom Steyer,Pete Buttigieg,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,26,1,7,,Precinct 1,Joseph R. Biden,Elizabeth Warren,12,Joseph R. Biden,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,26,1,8,,Precinct 1,Elizabeth Warren,Michael R. Bloomberg,Amy Klobuchar,Pete Buttigieg,"Joseph R. Biden
+Tom Steyer
+Bernie Sanders
+Tulsi Gabbard
+Pete Buttigieg
+12"
+../_shared/dominion_alaska/alaska_input_data,1,26,1,9,,Precinct 1,12,Tulsi Gabbard,Michael R. Bloomberg,Bernie Sanders,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,26,1,10,,Precinct 1,Pete Buttigieg,Tulsi Gabbard,Michael R. Bloomberg,12,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,26,1,11,,Precinct 1,Michael R. Bloomberg,Tulsi Gabbard,Joseph R. Biden,12,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,26,1,12,,Precinct 1,Amy Klobuchar,Tulsi Gabbard,Bernie Sanders,Tom Steyer,12
+../_shared/dominion_alaska/alaska_input_data,1,26,1,13,,Precinct 1,Pete Buttigieg,Michael R. Bloomberg,Bernie Sanders,Amy Klobuchar,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,26,1,14,,Precinct 1,Joseph R. Biden,Michael R. Bloomberg,Bernie Sanders,Pete Buttigieg,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,26,1,15,,Precinct 1,Amy Klobuchar,Elizabeth Warren,Pete Buttigieg,Joseph R. Biden,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,26,1,16,,Precinct 1,Amy Klobuchar,Pete Buttigieg,Michael R. Bloomberg,Elizabeth Warren,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,26,1,17,,Precinct 1,Joseph R. Biden,Pete Buttigieg,Tulsi Gabbard,Amy Klobuchar,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,26,1,18,,Precinct 1,Elizabeth Warren,Joseph R. Biden,Pete Buttigieg,12,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,26,1,19,,Precinct 1,Amy Klobuchar,Bernie Sanders,Elizabeth Warren,Pete Buttigieg,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,26,1,20,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,24,1,1,,Precinct 1,Joseph R. Biden,Bernie Sanders,Amy Klobuchar,Tom Steyer,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,24,1,2,,Precinct 1,Bernie Sanders,Amy Klobuchar,Elizabeth Warren,Tulsi Gabbard,12
+../_shared/dominion_alaska/alaska_input_data,1,24,1,3,,Precinct 1,Tulsi Gabbard,Tom Steyer,Bernie Sanders,Elizabeth Warren,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,24,1,4,,Precinct 1,Bernie Sanders,Amy Klobuchar,Pete Buttigieg,Elizabeth Warren,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,24,1,5,,Precinct 1,Elizabeth Warren,Michael R. Bloomberg,Bernie Sanders,Joseph R. Biden,12
+../_shared/dominion_alaska/alaska_input_data,1,24,1,6,,Precinct 1,Pete Buttigieg,Elizabeth Warren,Amy Klobuchar,Tom Steyer,12
+../_shared/dominion_alaska/alaska_input_data,1,24,1,7,,Precinct 1,Pete Buttigieg,Elizabeth Warren,Amy Klobuchar,Joseph R. Biden,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,24,1,8,,Precinct 1,Joseph R. Biden,Michael R. Bloomberg,Bernie Sanders,Amy Klobuchar,12
+../_shared/dominion_alaska/alaska_input_data,1,24,1,9,,Precinct 1,Pete Buttigieg,Joseph R. Biden,Bernie Sanders,Tulsi Gabbard,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,24,1,10,,Precinct 1,12,Michael R. Bloomberg,Bernie Sanders,Elizabeth Warren,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,24,1,11,,Precinct 1,Amy Klobuchar,Pete Buttigieg,Bernie Sanders,Joseph R. Biden,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,24,1,12,,Precinct 1,Tom Steyer,Amy Klobuchar,Pete Buttigieg,12,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,24,1,13,,Precinct 1,Michael R. Bloomberg,Amy Klobuchar,Elizabeth Warren,Pete Buttigieg,12
+../_shared/dominion_alaska/alaska_input_data,1,24,1,14,,Precinct 1,12,Tulsi Gabbard,Bernie Sanders,Elizabeth Warren,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,24,1,15,,Precinct 1,Pete Buttigieg,12,Michael R. Bloomberg,Tom Steyer,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,24,1,16,,Precinct 1,Amy Klobuchar,Pete Buttigieg,Michael R. Bloomberg,Bernie Sanders,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,24,1,17,,Precinct 1,Joseph R. Biden,Tom Steyer,Tulsi Gabbard,12,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,24,1,18,,Precinct 1,Amy Klobuchar,Elizabeth Warren,Michael R. Bloomberg,Pete Buttigieg,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,24,1,19,,Precinct 1,Amy Klobuchar,Tulsi Gabbard,Bernie Sanders,Michael R. Bloomberg,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,24,1,20,,Precinct 1,Tom Steyer,Amy Klobuchar,12,Michael R. Bloomberg,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,49,1,1,,Precinct 1,Tulsi Gabbard,Elizabeth Warren,Tom Steyer,Michael R. Bloomberg,12
+../_shared/dominion_alaska/alaska_input_data,1,49,1,2,,Precinct 1,Amy Klobuchar,Michael R. Bloomberg,Bernie Sanders,Elizabeth Warren,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,49,1,3,,Precinct 1,12,Joseph R. Biden,Elizabeth Warren,Tulsi Gabbard,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,49,1,4,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,49,1,5,,Precinct 1,Amy Klobuchar,Pete Buttigieg,Elizabeth Warren,Bernie Sanders,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,49,1,6,,Precinct 1,Tom Steyer,Tulsi Gabbard,Bernie Sanders,Elizabeth Warren,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,49,1,7,,Precinct 1,Pete Buttigieg,Michael R. Bloomberg,12,Tulsi Gabbard,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,49,1,8,,Precinct 1,Michael R. Bloomberg,12,Joseph R. Biden,Tom Steyer,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,49,1,9,,Precinct 1,Amy Klobuchar,12,Joseph R. Biden,Tulsi Gabbard,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,49,1,10,,Precinct 1,Bernie Sanders,12,Tom Steyer,Elizabeth Warren,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,49,1,11,,Precinct 1,Pete Buttigieg,Tom Steyer,12,Bernie Sanders,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,49,1,12,,Precinct 1,Elizabeth Warren,Pete Buttigieg,Tom Steyer,Joseph R. Biden,12
+../_shared/dominion_alaska/alaska_input_data,1,49,1,13,,Precinct 1,Joseph R. Biden,Michael R. Bloomberg,Amy Klobuchar,Elizabeth Warren,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,49,1,14,,Precinct 1,12,Bernie Sanders,Elizabeth Warren,Tulsi Gabbard,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,49,1,15,,Precinct 1,Michael R. Bloomberg,Pete Buttigieg,12,Amy Klobuchar,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,49,1,16,,Precinct 1,Tom Steyer,Bernie Sanders,Amy Klobuchar,Tulsi Gabbard,12
+../_shared/dominion_alaska/alaska_input_data,1,49,1,17,,Precinct 1,Bernie Sanders,Joseph R. Biden,Tom Steyer,Pete Buttigieg,12
+../_shared/dominion_alaska/alaska_input_data,1,49,1,18,,Precinct 1,Pete Buttigieg,Amy Klobuchar,Michael R. Bloomberg,Elizabeth Warren,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,49,1,19,,Precinct 1,Pete Buttigieg,Tom Steyer,Bernie Sanders,Joseph R. Biden,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,49,1,20,,Precinct 1,12,Elizabeth Warren,Michael R. Bloomberg,Bernie Sanders,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,25,1,1,,Precinct 1,Joseph R. Biden,Tulsi Gabbard,12,Pete Buttigieg,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,25,1,2,,Precinct 1,Amy Klobuchar,Tulsi Gabbard,Pete Buttigieg,12,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,25,1,3,,Precinct 1,Michael R. Bloomberg,Tulsi Gabbard,Joseph R. Biden,Bernie Sanders,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,25,1,4,,Precinct 1,Bernie Sanders,Elizabeth Warren,Michael R. Bloomberg,Tulsi Gabbard,12
+../_shared/dominion_alaska/alaska_input_data,1,25,1,5,,Precinct 1,Joseph R. Biden,Elizabeth Warren,Tulsi Gabbard,Amy Klobuchar,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,25,1,6,,Precinct 1,Tulsi Gabbard,12,Bernie Sanders,Joseph R. Biden,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,25,1,7,,Precinct 1,Tulsi Gabbard,Joseph R. Biden,12,Amy Klobuchar,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,25,1,8,,Precinct 1,undervote,Bernie Sanders,Joseph R. Biden,Pete Buttigieg,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,25,1,9,,Precinct 1,Bernie Sanders,Pete Buttigieg,Tom Steyer,Tulsi Gabbard,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,25,1,10,,Precinct 1,Tom Steyer,Pete Buttigieg,Amy Klobuchar,Elizabeth Warren,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,25,1,11,,Precinct 1,Tulsi Gabbard,Joseph R. Biden,Pete Buttigieg,12,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,25,1,12,,Precinct 1,Amy Klobuchar,Bernie Sanders,12,Elizabeth Warren,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,25,1,13,,Precinct 1,Tulsi Gabbard,Joseph R. Biden,Amy Klobuchar,Tom Steyer,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,25,1,14,,Precinct 1,Michael R. Bloomberg,Pete Buttigieg,12,Amy Klobuchar,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,25,1,15,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,25,1,16,,Precinct 1,Elizabeth Warren,Tom Steyer,Michael R. Bloomberg,Bernie Sanders,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,25,1,17,,Precinct 1,Pete Buttigieg,Bernie Sanders,Elizabeth Warren,Michael R. Bloomberg,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,25,1,18,,Precinct 1,Michael R. Bloomberg,Joseph R. Biden,Tulsi Gabbard,Tom Steyer,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,25,1,19,,Precinct 1,12,Tulsi Gabbard,Pete Buttigieg,Bernie Sanders,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,25,1,20,,Precinct 1,Amy Klobuchar,Michael R. Bloomberg,Elizabeth Warren,Bernie Sanders,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,33,1,1,,Precinct 1,Amy Klobuchar,Bernie Sanders,Pete Buttigieg,12,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,33,1,2,,Precinct 1,Tom Steyer,Pete Buttigieg,Bernie Sanders,Joseph R. Biden,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,33,1,3,,Precinct 1,Michael R. Bloomberg,12,Tulsi Gabbard,Tom Steyer,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,33,1,4,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,33,1,5,,Precinct 1,Elizabeth Warren,Michael R. Bloomberg,Amy Klobuchar,12,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,33,1,6,,Precinct 1,Michael R. Bloomberg,Joseph R. Biden,12,Elizabeth Warren,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,33,1,7,,Precinct 1,Michael R. Bloomberg,Amy Klobuchar,Tom Steyer,12,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,33,1,8,,Precinct 1,Tom Steyer,Joseph R. Biden,12,Tulsi Gabbard,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,33,1,9,,Precinct 1,Joseph R. Biden,Pete Buttigieg,Bernie Sanders,Amy Klobuchar,12
+../_shared/dominion_alaska/alaska_input_data,1,33,1,10,,Precinct 1,Bernie Sanders,Amy Klobuchar,Tulsi Gabbard,Elizabeth Warren,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,33,1,11,,Precinct 1,Tulsi Gabbard,12,Elizabeth Warren,Michael R. Bloomberg,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,33,1,12,,Precinct 1,Bernie Sanders,Tom Steyer,Elizabeth Warren,Michael R. Bloomberg,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,33,1,13,,Precinct 1,Elizabeth Warren,Michael R. Bloomberg,Amy Klobuchar,Tulsi Gabbard,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,33,1,14,,Precinct 1,Pete Buttigieg,Joseph R. Biden,Tom Steyer,Elizabeth Warren,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,33,1,15,,Precinct 1,Michael R. Bloomberg,Bernie Sanders,Joseph R. Biden,Tom Steyer,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,33,1,16,,Precinct 1,Tulsi Gabbard,Michael R. Bloomberg,Elizabeth Warren,Joseph R. Biden,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,33,1,17,,Precinct 1,Amy Klobuchar,Tulsi Gabbard,Bernie Sanders,Michael R. Bloomberg,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,33,1,18,,Precinct 1,Pete Buttigieg,Joseph R. Biden,Bernie Sanders,Tom Steyer,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,33,1,19,,Precinct 1,Joseph R. Biden,Amy Klobuchar,Pete Buttigieg,Michael R. Bloomberg,12
+../_shared/dominion_alaska/alaska_input_data,1,33,1,20,,Precinct 1,Bernie Sanders,Tulsi Gabbard,Michael R. Bloomberg,Elizabeth Warren,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,32,1,1,,Precinct 1,Elizabeth Warren,Pete Buttigieg,Bernie Sanders,Tom Steyer,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,32,1,2,,Precinct 1,12,Joseph R. Biden,Bernie Sanders,Elizabeth Warren,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,32,1,3,,Precinct 1,Pete Buttigieg,Elizabeth Warren,Michael R. Bloomberg,Bernie Sanders,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,32,1,4,,Precinct 1,Tulsi Gabbard,Joseph R. Biden,Pete Buttigieg,Elizabeth Warren,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,32,1,5,,Precinct 1,Bernie Sanders,Tom Steyer,Tulsi Gabbard,Michael R. Bloomberg,12
+../_shared/dominion_alaska/alaska_input_data,1,32,1,6,,Precinct 1,Elizabeth Warren,12,Tom Steyer,Joseph R. Biden,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,32,1,7,,Precinct 1,Tom Steyer,Elizabeth Warren,Tulsi Gabbard,Pete Buttigieg,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,32,1,8,,Precinct 1,Joseph R. Biden,Bernie Sanders,Michael R. Bloomberg,Elizabeth Warren,12
+../_shared/dominion_alaska/alaska_input_data,1,32,1,9,,Precinct 1,Bernie Sanders,12,Elizabeth Warren,Michael R. Bloomberg,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,32,1,10,,Precinct 1,Amy Klobuchar,Tom Steyer,Tulsi Gabbard,Michael R. Bloomberg,12
+../_shared/dominion_alaska/alaska_input_data,1,32,1,11,,Precinct 1,Elizabeth Warren,12,Tom Steyer,Michael R. Bloomberg,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,32,1,12,,Precinct 1,Joseph R. Biden,12,Amy Klobuchar,Tom Steyer,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,32,1,13,,Precinct 1,Elizabeth Warren,12,Amy Klobuchar,Tom Steyer,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,32,1,14,,Precinct 1,Elizabeth Warren,12,Joseph R. Biden,Tulsi Gabbard,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,32,1,15,,Precinct 1,12,Pete Buttigieg,Tom Steyer,Tulsi Gabbard,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,32,1,16,,Precinct 1,12,Pete Buttigieg,Tom Steyer,Bernie Sanders,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,32,1,17,,Precinct 1,Amy Klobuchar,Bernie Sanders,"Tulsi Gabbard
+Michael R. Bloomberg
+Pete Buttigieg",Joseph R. Biden,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,32,1,18,,Precinct 1,Joseph R. Biden,Tulsi Gabbard,Elizabeth Warren,12,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,32,1,19,,Precinct 1,Elizabeth Warren,Pete Buttigieg,Tom Steyer,12,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,32,1,20,,Precinct 1,Pete Buttigieg,Amy Klobuchar,12,Joseph R. Biden,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,41,1,1,,Precinct 1,Bernie Sanders,Amy Klobuchar,Pete Buttigieg,Michael R. Bloomberg,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,41,1,2,,Precinct 1,Tom Steyer,Amy Klobuchar,Tulsi Gabbard,Michael R. Bloomberg,12
+../_shared/dominion_alaska/alaska_input_data,1,41,1,3,,Precinct 1,12,Michael R. Bloomberg,Tom Steyer,Pete Buttigieg,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,41,1,4,,Precinct 1,12,Tom Steyer,Tulsi Gabbard,Amy Klobuchar,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,41,1,5,,Precinct 1,Tom Steyer,Pete Buttigieg,Tulsi Gabbard,Elizabeth Warren,12
+../_shared/dominion_alaska/alaska_input_data,1,41,1,6,,Precinct 1,Pete Buttigieg,12,Bernie Sanders,Elizabeth Warren,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,41,1,7,,Precinct 1,Joseph R. Biden,Michael R. Bloomberg,Bernie Sanders,Tulsi Gabbard,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,41,1,8,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,41,1,9,,Precinct 1,Joseph R. Biden,Bernie Sanders,Tom Steyer,Tulsi Gabbard,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,41,1,10,,Precinct 1,Joseph R. Biden,Pete Buttigieg,Tulsi Gabbard,Michael R. Bloomberg,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,41,1,11,,Precinct 1,Amy Klobuchar,Michael R. Bloomberg,Bernie Sanders,Elizabeth Warren,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,41,1,12,,Precinct 1,Elizabeth Warren,Pete Buttigieg,12,Amy Klobuchar,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,41,1,13,,Precinct 1,Tulsi Gabbard,Amy Klobuchar,Pete Buttigieg,Elizabeth Warren,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,41,1,14,,Precinct 1,Michael R. Bloomberg,12,Tom Steyer,Tulsi Gabbard,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,41,1,15,,Precinct 1,Joseph R. Biden,Tom Steyer,Michael R. Bloomberg,12,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,41,1,16,,Precinct 1,Amy Klobuchar,Michael R. Bloomberg,Bernie Sanders,Pete Buttigieg,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,41,1,17,,Precinct 1,12,Amy Klobuchar,Tom Steyer,Pete Buttigieg,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,41,1,18,,Precinct 1,Michael R. Bloomberg,Elizabeth Warren,Amy Klobuchar,12,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,41,1,19,,Precinct 1,Joseph R. Biden,Elizabeth Warren,Tulsi Gabbard,Tom Steyer,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,41,1,20,,Precinct 1,Tom Steyer,Bernie Sanders,Joseph R. Biden,12,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,23,1,1,,Precinct 1,Elizabeth Warren,Amy Klobuchar,12,Tom Steyer,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,23,1,2,,Precinct 1,Amy Klobuchar,Michael R. Bloomberg,Tulsi Gabbard,Joseph R. Biden,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,23,1,3,,Precinct 1,Elizabeth Warren,Tulsi Gabbard,Joseph R. Biden,Amy Klobuchar,12
+../_shared/dominion_alaska/alaska_input_data,1,23,1,4,,Precinct 1,Michael R. Bloomberg,Joseph R. Biden,12,Tom Steyer,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,23,1,5,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,23,1,6,,Precinct 1,Elizabeth Warren,12,Joseph R. Biden,Tulsi Gabbard,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,23,1,7,,Precinct 1,Joseph R. Biden,Bernie Sanders,Amy Klobuchar,Elizabeth Warren,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,23,1,8,,Precinct 1,Amy Klobuchar,12,Tom Steyer,Michael R. Bloomberg,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,23,1,9,,Precinct 1,Tom Steyer,Joseph R. Biden,12,Tulsi Gabbard,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,23,1,10,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,23,1,11,,Precinct 1,Tulsi Gabbard,Amy Klobuchar,Joseph R. Biden,Michael R. Bloomberg,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,23,1,12,,Precinct 1,Bernie Sanders,Pete Buttigieg,Tulsi Gabbard,12,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,23,1,13,,Precinct 1,Bernie Sanders,Elizabeth Warren,Michael R. Bloomberg,Tom Steyer,12
+../_shared/dominion_alaska/alaska_input_data,1,23,1,14,,Precinct 1,Tom Steyer,Pete Buttigieg,Bernie Sanders,12,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,23,1,15,,Precinct 1,Pete Buttigieg,Tulsi Gabbard,12,Tom Steyer,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,23,1,16,,Precinct 1,Tulsi Gabbard,Joseph R. Biden,Michael R. Bloomberg,Pete Buttigieg,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,23,1,17,,Precinct 1,Pete Buttigieg,Tom Steyer,Joseph R. Biden,Elizabeth Warren,12
+../_shared/dominion_alaska/alaska_input_data,1,23,1,18,,Precinct 1,Tom Steyer,12,Joseph R. Biden,Pete Buttigieg,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,23,1,19,,Precinct 1,Pete Buttigieg,Elizabeth Warren,12,Bernie Sanders,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,23,1,20,,Precinct 1,Tulsi Gabbard,Joseph R. Biden,Michael R. Bloomberg,Tom Steyer,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,31,1,1,,Precinct 1,Bernie Sanders,Pete Buttigieg,Amy Klobuchar,Michael R. Bloomberg,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,31,1,2,,Precinct 1,Elizabeth Warren,12,Michael R. Bloomberg,Joseph R. Biden,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,31,1,3,,Precinct 1,Michael R. Bloomberg,Elizabeth Warren,Amy Klobuchar,12,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,31,1,4,,Precinct 1,Tom Steyer,Bernie Sanders,Michael R. Bloomberg,12,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,31,1,5,,Precinct 1,Pete Buttigieg,12,Tom Steyer,Bernie Sanders,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,31,1,6,,Precinct 1,Tulsi Gabbard,12,Pete Buttigieg,Joseph R. Biden,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,31,1,7,,Precinct 1,12,Bernie Sanders,Tom Steyer,Joseph R. Biden,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,31,1,8,,Precinct 1,Pete Buttigieg,Joseph R. Biden,12,Bernie Sanders,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,31,1,9,,Precinct 1,Tom Steyer,12,Joseph R. Biden,Elizabeth Warren,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,31,1,10,,Precinct 1,Tom Steyer,Amy Klobuchar,Michael R. Bloomberg,Tulsi Gabbard,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,31,1,11,,Precinct 1,Tom Steyer,Amy Klobuchar,12,Michael R. Bloomberg,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,31,1,12,,Precinct 1,Bernie Sanders,Amy Klobuchar,Tulsi Gabbard,Tom Steyer,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,31,1,13,,Precinct 1,12,Joseph R. Biden,Tulsi Gabbard,Elizabeth Warren,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,31,1,14,,Precinct 1,Pete Buttigieg,Joseph R. Biden,Bernie Sanders,Michael R. Bloomberg,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,31,1,15,,Precinct 1,Michael R. Bloomberg,Bernie Sanders,Elizabeth Warren,Amy Klobuchar,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,31,1,16,,Precinct 1,Joseph R. Biden,Pete Buttigieg,Tulsi Gabbard,Bernie Sanders,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,31,1,17,,Precinct 1,Tom Steyer,Michael R. Bloomberg,Elizabeth Warren,Pete Buttigieg,12
+../_shared/dominion_alaska/alaska_input_data,1,31,1,18,,Precinct 1,12,Tulsi Gabbard,Joseph R. Biden,Michael R. Bloomberg,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,31,1,19,,Precinct 1,12,Pete Buttigieg,Tom Steyer,Joseph R. Biden,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,31,1,20,,Precinct 1,Pete Buttigieg,Bernie Sanders,Joseph R. Biden,Amy Klobuchar,12
+../_shared/dominion_alaska/alaska_input_data,1,22,1,1,,Precinct 1,12,Pete Buttigieg,Amy Klobuchar,Elizabeth Warren,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,22,1,2,,Precinct 1,Pete Buttigieg,Tulsi Gabbard,Tom Steyer,12,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,22,1,3,,Precinct 1,Michael R. Bloomberg,Bernie Sanders,12,Pete Buttigieg,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,22,1,4,,Precinct 1,Joseph R. Biden,Michael R. Bloomberg,Elizabeth Warren,Pete Buttigieg,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,22,1,5,,Precinct 1,Pete Buttigieg,Tulsi Gabbard,12,Tom Steyer,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,22,1,6,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,22,1,7,,Precinct 1,Joseph R. Biden,Bernie Sanders,Elizabeth Warren,Tom Steyer,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,22,1,8,,Precinct 1,Pete Buttigieg,Bernie Sanders,Amy Klobuchar,12,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,22,1,9,,Precinct 1,Pete Buttigieg,Amy Klobuchar,Joseph R. Biden,Tulsi Gabbard,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,22,1,10,,Precinct 1,Joseph R. Biden,12,Tom Steyer,Elizabeth Warren,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,22,1,11,,Precinct 1,Amy Klobuchar,Pete Buttigieg,Joseph R. Biden,Michael R. Bloomberg,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,22,1,12,,Precinct 1,Bernie Sanders,Pete Buttigieg,12,Elizabeth Warren,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,22,1,13,,Precinct 1,12,Bernie Sanders,Tom Steyer,Amy Klobuchar,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,22,1,14,,Precinct 1,Elizabeth Warren,Tom Steyer,Pete Buttigieg,Amy Klobuchar,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,22,1,15,,Precinct 1,12,Bernie Sanders,Amy Klobuchar,Joseph R. Biden,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,22,1,16,,Precinct 1,Joseph R. Biden,Amy Klobuchar,12,Elizabeth Warren,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,22,1,17,,Precinct 1,Joseph R. Biden,Elizabeth Warren,Tom Steyer,Pete Buttigieg,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,22,1,18,,Precinct 1,Elizabeth Warren,Tom Steyer,Amy Klobuchar,Bernie Sanders,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,22,1,19,,Precinct 1,Michael R. Bloomberg,Tom Steyer,12,Bernie Sanders,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,22,1,20,,Precinct 1,Bernie Sanders,Elizabeth Warren,Tulsi Gabbard,12,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,48,1,1,,Precinct 1,Joseph R. Biden,Pete Buttigieg,12,Elizabeth Warren,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,48,1,2,,Precinct 1,Tulsi Gabbard,Joseph R. Biden,Elizabeth Warren,Bernie Sanders,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,48,1,3,,Precinct 1,12,Amy Klobuchar,Bernie Sanders,Elizabeth Warren,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,48,1,4,,Precinct 1,Bernie Sanders,Michael R. Bloomberg,Elizabeth Warren,Tom Steyer,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,48,1,5,,Precinct 1,Bernie Sanders,Michael R. Bloomberg,12,Elizabeth Warren,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,48,1,6,,Precinct 1,Bernie Sanders,Tom Steyer,Amy Klobuchar,Joseph R. Biden,12
+../_shared/dominion_alaska/alaska_input_data,1,48,1,7,,Precinct 1,12,Bernie Sanders,Elizabeth Warren,Amy Klobuchar,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,48,1,8,,Precinct 1,Tom Steyer,Amy Klobuchar,Bernie Sanders,Elizabeth Warren,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,48,1,9,,Precinct 1,Bernie Sanders,Tulsi Gabbard,Amy Klobuchar,Joseph R. Biden,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,48,1,10,,Precinct 1,Pete Buttigieg,Michael R. Bloomberg,12,Bernie Sanders,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,48,1,11,,Precinct 1,Michael R. Bloomberg,Amy Klobuchar,Bernie Sanders,Pete Buttigieg,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,48,1,12,,Precinct 1,Amy Klobuchar,Pete Buttigieg,Tom Steyer,Bernie Sanders,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,48,1,13,,Precinct 1,Joseph R. Biden,Tulsi Gabbard,Michael R. Bloomberg,Bernie Sanders,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,48,1,14,,Precinct 1,Tulsi Gabbard,Amy Klobuchar,Michael R. Bloomberg,Joseph R. Biden,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,48,1,15,,Precinct 1,Joseph R. Biden,Amy Klobuchar,Tom Steyer,Bernie Sanders,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,48,1,16,,Precinct 1,Pete Buttigieg,Amy Klobuchar,Elizabeth Warren,12,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,48,1,17,,Precinct 1,Joseph R. Biden,Elizabeth Warren,Amy Klobuchar,Tom Steyer,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,48,1,18,,Precinct 1,Elizabeth Warren,Bernie Sanders,Tulsi Gabbard,Michael R. Bloomberg,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,48,1,19,,Precinct 1,Tulsi Gabbard,Pete Buttigieg,Tom Steyer,Elizabeth Warren,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,48,1,20,,Precinct 1,Tulsi Gabbard,Joseph R. Biden,Michael R. Bloomberg,Tom Steyer,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,21,1,1,,Precinct 1,Joseph R. Biden,Elizabeth Warren,Pete Buttigieg,Tom Steyer,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,21,1,2,,Precinct 1,Michael R. Bloomberg,Amy Klobuchar,12,Bernie Sanders,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,21,1,3,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,21,1,4,,Precinct 1,12,Elizabeth Warren,Pete Buttigieg,Michael R. Bloomberg,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,21,1,5,,Precinct 1,Pete Buttigieg,Elizabeth Warren,Joseph R. Biden,Tulsi Gabbard,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,21,1,6,,Precinct 1,Tulsi Gabbard,12,Michael R. Bloomberg,Tom Steyer,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,21,1,7,,Precinct 1,Joseph R. Biden,Pete Buttigieg,Bernie Sanders,Tom Steyer,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,21,1,8,,Precinct 1,12,Elizabeth Warren,Pete Buttigieg,Bernie Sanders,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,21,1,9,,Precinct 1,Amy Klobuchar,Tom Steyer,Bernie Sanders,Pete Buttigieg,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,21,1,10,,Precinct 1,Bernie Sanders,12,Pete Buttigieg,Tulsi Gabbard,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,21,1,11,,Precinct 1,Michael R. Bloomberg,Amy Klobuchar,Tulsi Gabbard,Tom Steyer,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,21,1,12,,Precinct 1,Tom Steyer,Michael R. Bloomberg,12,Pete Buttigieg,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,21,1,13,,Precinct 1,Tulsi Gabbard,Elizabeth Warren,Amy Klobuchar,Tom Steyer,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,21,1,14,,Precinct 1,Joseph R. Biden,Bernie Sanders,Tulsi Gabbard,Pete Buttigieg,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,21,1,15,,Precinct 1,Elizabeth Warren,Amy Klobuchar,Tom Steyer,12,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,21,1,16,,Precinct 1,Pete Buttigieg,Amy Klobuchar,Elizabeth Warren,Tom Steyer,12
+../_shared/dominion_alaska/alaska_input_data,1,21,1,17,,Precinct 1,Tom Steyer,Amy Klobuchar,Joseph R. Biden,Tulsi Gabbard,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,21,1,18,,Precinct 1,Amy Klobuchar,Tom Steyer,12,Joseph R. Biden,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,21,1,19,,Precinct 1,Michael R. Bloomberg,Bernie Sanders,12,Pete Buttigieg,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,21,1,20,,Precinct 1,Elizabeth Warren,Michael R. Bloomberg,Amy Klobuchar,12,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,47,1,1,,Precinct 1,Elizabeth Warren,Joseph R. Biden,Pete Buttigieg,Michael R. Bloomberg,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,47,1,2,,Precinct 1,Tulsi Gabbard,Bernie Sanders,Michael R. Bloomberg,Pete Buttigieg,12
+../_shared/dominion_alaska/alaska_input_data,1,47,1,3,,Precinct 1,Joseph R. Biden,Pete Buttigieg,Tom Steyer,Tulsi Gabbard,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,47,1,4,,Precinct 1,Michael R. Bloomberg,Amy Klobuchar,Pete Buttigieg,Elizabeth Warren,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,47,1,5,,Precinct 1,Tulsi Gabbard,Tom Steyer,Pete Buttigieg,12,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,47,1,6,,Precinct 1,Michael R. Bloomberg,Tulsi Gabbard,Amy Klobuchar,Tom Steyer,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,47,1,7,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,47,1,8,,Precinct 1,Bernie Sanders,Tulsi Gabbard,12,Tom Steyer,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,47,1,9,,Precinct 1,Michael R. Bloomberg,Amy Klobuchar,Tom Steyer,Pete Buttigieg,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,47,1,10,,Precinct 1,Bernie Sanders,Michael R. Bloomberg,Pete Buttigieg,Tom Steyer,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,47,1,11,,Precinct 1,Tom Steyer,Amy Klobuchar,Pete Buttigieg,Bernie Sanders,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,47,1,12,,Precinct 1,Tulsi Gabbard,Michael R. Bloomberg,Joseph R. Biden,Bernie Sanders,12
+../_shared/dominion_alaska/alaska_input_data,1,47,1,13,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,47,1,14,,Precinct 1,Elizabeth Warren,Amy Klobuchar,12,Pete Buttigieg,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,47,1,15,,Precinct 1,Bernie Sanders,Tulsi Gabbard,Amy Klobuchar,Elizabeth Warren,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,47,1,16,,Precinct 1,Tulsi Gabbard,Elizabeth Warren,12,Pete Buttigieg,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,47,1,17,,Precinct 1,Elizabeth Warren,Tom Steyer,Pete Buttigieg,Amy Klobuchar,12
+../_shared/dominion_alaska/alaska_input_data,1,47,1,18,,Precinct 1,Elizabeth Warren,Tom Steyer,Joseph R. Biden,12,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,47,1,19,,Precinct 1,Pete Buttigieg,Michael R. Bloomberg,Tulsi Gabbard,12,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,47,1,20,,Precinct 1,Amy Klobuchar,12,Bernie Sanders,Joseph R. Biden,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,17,1,1,,Precinct 1,Bernie Sanders,Elizabeth Warren,12,Tom Steyer,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,17,1,2,,Precinct 1,12,Elizabeth Warren,Bernie Sanders,Michael R. Bloomberg,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,17,1,3,,Precinct 1,Tulsi Gabbard,Elizabeth Warren,Joseph R. Biden,12,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,17,1,4,,Precinct 1,Pete Buttigieg,Michael R. Bloomberg,Tulsi Gabbard,Elizabeth Warren,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,17,1,5,,Precinct 1,Elizabeth Warren,12,Pete Buttigieg,Michael R. Bloomberg,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,17,1,6,,Precinct 1,Amy Klobuchar,Tulsi Gabbard,Michael R. Bloomberg,12,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,17,1,7,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,17,1,8,,Precinct 1,Tulsi Gabbard,Elizabeth Warren,Tom Steyer,Joseph R. Biden,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,17,1,9,,Precinct 1,Tulsi Gabbard,Pete Buttigieg,Michael R. Bloomberg,12,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,17,1,10,,Precinct 1,Pete Buttigieg,Michael R. Bloomberg,Tom Steyer,12,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,17,1,11,,Precinct 1,Bernie Sanders,Elizabeth Warren,Pete Buttigieg,Joseph R. Biden,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,17,1,12,,Precinct 1,Tulsi Gabbard,Michael R. Bloomberg,Tom Steyer,12,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,17,1,13,,Precinct 1,Joseph R. Biden,Tom Steyer,Tulsi Gabbard,Elizabeth Warren,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,17,1,14,,Precinct 1,Tulsi Gabbard,12,Bernie Sanders,Pete Buttigieg,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,17,1,15,,Precinct 1,Pete Buttigieg,Joseph R. Biden,Amy Klobuchar,Elizabeth Warren,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,17,1,16,,Precinct 1,Tom Steyer,12,Tulsi Gabbard,Michael R. Bloomberg,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,17,1,17,,Precinct 1,Bernie Sanders,Joseph R. Biden,Michael R. Bloomberg,12,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,17,1,18,,Precinct 1,Michael R. Bloomberg,Tom Steyer,Pete Buttigieg,Tulsi Gabbard,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,17,1,19,,Precinct 1,12,Michael R. Bloomberg,Bernie Sanders,Tulsi Gabbard,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,17,1,20,,Precinct 1,Tom Steyer,Michael R. Bloomberg,Tulsi Gabbard,Pete Buttigieg,12
+../_shared/dominion_alaska/alaska_input_data,1,40,1,1,,Precinct 1,Tom Steyer,Amy Klobuchar,Pete Buttigieg,Elizabeth Warren,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,40,1,2,,Precinct 1,Tulsi Gabbard,Michael R. Bloomberg,Elizabeth Warren,Tom Steyer,12
+../_shared/dominion_alaska/alaska_input_data,1,40,1,3,,Precinct 1,12,Michael R. Bloomberg,Amy Klobuchar,Elizabeth Warren,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,40,1,4,,Precinct 1,Michael R. Bloomberg,Elizabeth Warren,12,Amy Klobuchar,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,40,1,5,,Precinct 1,Tulsi Gabbard,Michael R. Bloomberg,Bernie Sanders,12,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,40,1,6,,Precinct 1,Pete Buttigieg,12,Joseph R. Biden,Bernie Sanders,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,40,1,7,,Precinct 1,12,Joseph R. Biden,Bernie Sanders,Tom Steyer,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,40,1,8,,Precinct 1,Tulsi Gabbard,Tom Steyer,Bernie Sanders,12,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,40,1,9,,Precinct 1,12,Amy Klobuchar,Joseph R. Biden,Bernie Sanders,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,40,1,10,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,40,1,11,,Precinct 1,Pete Buttigieg,Joseph R. Biden,Amy Klobuchar,12,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,40,1,12,,Precinct 1,Tulsi Gabbard,Joseph R. Biden,Amy Klobuchar,Bernie Sanders,12
+../_shared/dominion_alaska/alaska_input_data,1,40,1,13,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,40,1,14,,Precinct 1,Elizabeth Warren,Tulsi Gabbard,Bernie Sanders,Pete Buttigieg,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,40,1,15,,Precinct 1,Amy Klobuchar,Bernie Sanders,12,Tom Steyer,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,40,1,16,,Precinct 1,Michael R. Bloomberg,Joseph R. Biden,12,Pete Buttigieg,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,40,1,17,,Precinct 1,Amy Klobuchar,Pete Buttigieg,12,Elizabeth Warren,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,40,1,18,,Precinct 1,Tom Steyer,Pete Buttigieg,Michael R. Bloomberg,Amy Klobuchar,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,40,1,19,,Precinct 1,Amy Klobuchar,Joseph R. Biden,Michael R. Bloomberg,12,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,40,1,20,,Precinct 1,Tom Steyer,Pete Buttigieg,12,Michael R. Bloomberg,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,16,1,1,,Precinct 1,Pete Buttigieg,Michael R. Bloomberg,Elizabeth Warren,Tom Steyer,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,16,1,2,,Precinct 1,Joseph R. Biden,12,Tulsi Gabbard,Amy Klobuchar,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,16,1,3,,Precinct 1,Pete Buttigieg,Tulsi Gabbard,Michael R. Bloomberg,Amy Klobuchar,"Joseph R. Biden
+Tom Steyer
+Bernie Sanders
+Amy Klobuchar
+Elizabeth Warren
+12"
+../_shared/dominion_alaska/alaska_input_data,1,16,1,4,,Precinct 1,Amy Klobuchar,Pete Buttigieg,Michael R. Bloomberg,12,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,16,1,5,,Precinct 1,12,Elizabeth Warren,Amy Klobuchar,Tom Steyer,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,16,1,6,,Precinct 1,Elizabeth Warren,12,Tom Steyer,Joseph R. Biden,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,16,1,7,,Precinct 1,Elizabeth Warren,Tulsi Gabbard,Amy Klobuchar,Pete Buttigieg,12
+../_shared/dominion_alaska/alaska_input_data,1,16,1,8,,Precinct 1,Michael R. Bloomberg,Tom Steyer,Joseph R. Biden,Amy Klobuchar,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,16,1,9,,Precinct 1,Joseph R. Biden,Elizabeth Warren,Bernie Sanders,Amy Klobuchar,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,16,1,10,,Precinct 1,Amy Klobuchar,Tom Steyer,Tulsi Gabbard,Elizabeth Warren,12
+../_shared/dominion_alaska/alaska_input_data,1,16,1,11,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,16,1,12,,Precinct 1,12,Tom Steyer,Michael R. Bloomberg,Elizabeth Warren,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,16,1,13,,Precinct 1,Amy Klobuchar,12,Tom Steyer,Pete Buttigieg,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,16,1,14,,Precinct 1,12,Tulsi Gabbard,Amy Klobuchar,Tom Steyer,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,16,1,15,,Precinct 1,Bernie Sanders,Elizabeth Warren,12,Michael R. Bloomberg,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,16,1,16,,Precinct 1,Amy Klobuchar,12,Tom Steyer,Bernie Sanders,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,16,1,17,,Precinct 1,Bernie Sanders,Amy Klobuchar,Elizabeth Warren,Tom Steyer,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,16,1,18,,Precinct 1,12,Joseph R. Biden,Tom Steyer,Elizabeth Warren,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,16,1,19,,Precinct 1,Michael R. Bloomberg,Tom Steyer,Joseph R. Biden,12,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,16,1,20,,Precinct 1,Amy Klobuchar,Tom Steyer,Elizabeth Warren,Pete Buttigieg,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,39,1,1,,Precinct 1,Michael R. Bloomberg,Amy Klobuchar,Tulsi Gabbard,Elizabeth Warren,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,39,1,2,,Precinct 1,Elizabeth Warren,Joseph R. Biden,Pete Buttigieg,12,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,39,1,3,,Precinct 1,12,Tom Steyer,Amy Klobuchar,Elizabeth Warren,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,39,1,4,,Precinct 1,Tom Steyer,Elizabeth Warren,Joseph R. Biden,Bernie Sanders,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,39,1,5,,Precinct 1,Michael R. Bloomberg,Tom Steyer,Joseph R. Biden,Bernie Sanders,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,39,1,6,,Precinct 1,Bernie Sanders,Tom Steyer,Elizabeth Warren,Tulsi Gabbard,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,39,1,7,,Precinct 1,Bernie Sanders,Elizabeth Warren,Joseph R. Biden,Tulsi Gabbard,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,39,1,8,,Precinct 1,Pete Buttigieg,Amy Klobuchar,12,Bernie Sanders,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,39,1,9,,Precinct 1,Elizabeth Warren,Amy Klobuchar,Tom Steyer,Tulsi Gabbard,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,39,1,10,,Precinct 1,Tulsi Gabbard,Tom Steyer,Amy Klobuchar,Bernie Sanders,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,39,1,11,,Precinct 1,Joseph R. Biden,Tom Steyer,Bernie Sanders,12,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,39,1,12,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,39,1,13,,Precinct 1,Tulsi Gabbard,Michael R. Bloomberg,Joseph R. Biden,12,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,39,1,14,,Precinct 1,Amy Klobuchar,Joseph R. Biden,Pete Buttigieg,Michael R. Bloomberg,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,39,1,15,,Precinct 1,12,Bernie Sanders,Amy Klobuchar,Michael R. Bloomberg,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,39,1,16,,Precinct 1,Amy Klobuchar,Pete Buttigieg,Tom Steyer,12,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,39,1,17,,Precinct 1,Joseph R. Biden,Elizabeth Warren,Tom Steyer,Amy Klobuchar,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,39,1,18,,Precinct 1,Michael R. Bloomberg,Bernie Sanders,Elizabeth Warren,Tom Steyer,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,39,1,19,,Precinct 1,Tulsi Gabbard,Joseph R. Biden,Tom Steyer,Pete Buttigieg,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,39,1,20,,Precinct 1,Pete Buttigieg,Bernie Sanders,Tulsi Gabbard,Michael R. Bloomberg,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,38,1,1,,Precinct 1,Amy Klobuchar,Tulsi Gabbard,Elizabeth Warren,Joseph R. Biden,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,38,1,2,,Precinct 1,Tom Steyer,Pete Buttigieg,Amy Klobuchar,Bernie Sanders,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,38,1,3,,Precinct 1,Pete Buttigieg,Bernie Sanders,12,Joseph R. Biden,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,38,1,4,,Precinct 1,Pete Buttigieg,Tulsi Gabbard,12,Bernie Sanders,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,38,1,5,,Precinct 1,Amy Klobuchar,Joseph R. Biden,12,Michael R. Bloomberg,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,38,1,6,,Precinct 1,Joseph R. Biden,Bernie Sanders,Amy Klobuchar,Elizabeth Warren,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,38,1,7,,Precinct 1,Joseph R. Biden,Bernie Sanders,12,Michael R. Bloomberg,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,38,1,8,,Precinct 1,Elizabeth Warren,Tom Steyer,Bernie Sanders,12,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,38,1,9,,Precinct 1,Tulsi Gabbard,Elizabeth Warren,Michael R. Bloomberg,Joseph R. Biden,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,38,1,10,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,38,1,11,,Precinct 1,12,Michael R. Bloomberg,Amy Klobuchar,Tulsi Gabbard,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,38,1,12,,Precinct 1,Tom Steyer,Michael R. Bloomberg,Tulsi Gabbard,Bernie Sanders,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,38,1,13,,Precinct 1,Michael R. Bloomberg,Amy Klobuchar,12,Tom Steyer,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,38,1,14,,Precinct 1,Amy Klobuchar,Tom Steyer,12,Elizabeth Warren,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,38,1,15,,Precinct 1,Bernie Sanders,Elizabeth Warren,Joseph R. Biden,Tom Steyer,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,38,1,16,,Precinct 1,Pete Buttigieg,Tulsi Gabbard,Joseph R. Biden,Michael R. Bloomberg,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,38,1,17,,Precinct 1,Elizabeth Warren,Tulsi Gabbard,Amy Klobuchar,Joseph R. Biden,12
+../_shared/dominion_alaska/alaska_input_data,1,38,1,18,,Precinct 1,Elizabeth Warren,Michael R. Bloomberg,Joseph R. Biden,Amy Klobuchar,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,38,1,19,,Precinct 1,Michael R. Bloomberg,12,Elizabeth Warren,Pete Buttigieg,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,38,1,20,,Precinct 1,Bernie Sanders,12,Elizabeth Warren,Michael R. Bloomberg,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,20,1,1,,Precinct 1,Amy Klobuchar,Tom Steyer,Tulsi Gabbard,Michael R. Bloomberg,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,20,1,2,,Precinct 1,Tom Steyer,Bernie Sanders,Michael R. Bloomberg,Amy Klobuchar,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,20,1,3,,Precinct 1,Elizabeth Warren,Pete Buttigieg,12,Amy Klobuchar,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,20,1,4,,Precinct 1,Bernie Sanders,Joseph R. Biden,Amy Klobuchar,Elizabeth Warren,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,20,1,5,,Precinct 1,Amy Klobuchar,Joseph R. Biden,Elizabeth Warren,Pete Buttigieg,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,20,1,6,,Precinct 1,Elizabeth Warren,Pete Buttigieg,Tom Steyer,Tulsi Gabbard,12
+../_shared/dominion_alaska/alaska_input_data,1,20,1,7,,Precinct 1,Amy Klobuchar,Bernie Sanders,Elizabeth Warren,12,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,20,1,8,,Precinct 1,Tom Steyer,Elizabeth Warren,Michael R. Bloomberg,Amy Klobuchar,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,20,1,9,,Precinct 1,Amy Klobuchar,Bernie Sanders,Pete Buttigieg,12,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,20,1,10,,Precinct 1,Pete Buttigieg,12,Tom Steyer,Joseph R. Biden,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,20,1,11,,Precinct 1,Pete Buttigieg,Joseph R. Biden,Amy Klobuchar,Tom Steyer,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,20,1,12,,Precinct 1,Tulsi Gabbard,Bernie Sanders,Amy Klobuchar,Tom Steyer,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,20,1,13,,Precinct 1,Michael R. Bloomberg,Amy Klobuchar,Tom Steyer,Tulsi Gabbard,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,20,1,14,,Precinct 1,Tulsi Gabbard,Pete Buttigieg,Elizabeth Warren,Bernie Sanders,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,20,1,15,,Precinct 1,Joseph R. Biden,Bernie Sanders,Michael R. Bloomberg,Elizabeth Warren,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,20,1,16,,Precinct 1,Elizabeth Warren,Joseph R. Biden,Amy Klobuchar,12,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,20,1,17,,Precinct 1,Bernie Sanders,Elizabeth Warren,Joseph R. Biden,Tom Steyer,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,20,1,18,,Precinct 1,Michael R. Bloomberg,Elizabeth Warren,Pete Buttigieg,Joseph R. Biden,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,20,1,19,,Precinct 1,Amy Klobuchar,Michael R. Bloomberg,Tulsi Gabbard,Bernie Sanders,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,20,1,20,,Precinct 1,Joseph R. Biden,Tom Steyer,Tulsi Gabbard,Elizabeth Warren,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,37,1,1,,Precinct 1,12,Elizabeth Warren,Bernie Sanders,Tom Steyer,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,37,1,2,,Precinct 1,Bernie Sanders,Tom Steyer,Tulsi Gabbard,12,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,37,1,3,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,37,1,4,,Precinct 1,12,Tulsi Gabbard,Bernie Sanders,Joseph R. Biden,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,37,1,5,,Precinct 1,Tom Steyer,Tulsi Gabbard,Joseph R. Biden,Pete Buttigieg,12
+../_shared/dominion_alaska/alaska_input_data,1,37,1,6,,Precinct 1,12,Bernie Sanders,Tulsi Gabbard,Michael R. Bloomberg,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,37,1,7,,Precinct 1,Elizabeth Warren,Michael R. Bloomberg,Pete Buttigieg,Amy Klobuchar,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,37,1,8,,Precinct 1,Pete Buttigieg,Tulsi Gabbard,Bernie Sanders,Amy Klobuchar,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,37,1,9,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,37,1,10,,Precinct 1,Elizabeth Warren,Michael R. Bloomberg,Joseph R. Biden,Pete Buttigieg,12
+../_shared/dominion_alaska/alaska_input_data,1,37,1,11,,Precinct 1,Elizabeth Warren,Michael R. Bloomberg,12,Pete Buttigieg,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,37,1,12,,Precinct 1,Tom Steyer,Amy Klobuchar,Pete Buttigieg,Tulsi Gabbard,12
+../_shared/dominion_alaska/alaska_input_data,1,37,1,13,,Precinct 1,Elizabeth Warren,Amy Klobuchar,12,Michael R. Bloomberg,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,37,1,14,,Precinct 1,Elizabeth Warren,Amy Klobuchar,Michael R. Bloomberg,Tom Steyer,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,37,1,15,,Precinct 1,Pete Buttigieg,12,Bernie Sanders,Tom Steyer,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,37,1,16,,Precinct 1,Michael R. Bloomberg,Tulsi Gabbard,Pete Buttigieg,Elizabeth Warren,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,37,1,17,,Precinct 1,Tulsi Gabbard,Pete Buttigieg,Elizabeth Warren,12,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,37,1,18,,Precinct 1,Tom Steyer,Michael R. Bloomberg,Elizabeth Warren,Pete Buttigieg,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,37,1,19,,Precinct 1,Tulsi Gabbard,Tom Steyer,Amy Klobuchar,Elizabeth Warren,12
+../_shared/dominion_alaska/alaska_input_data,1,37,1,20,,Precinct 1,Amy Klobuchar,Joseph R. Biden,Michael R. Bloomberg,Elizabeth Warren,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,15,1,1,,Precinct 1,Michael R. Bloomberg,Pete Buttigieg,Elizabeth Warren,Joseph R. Biden,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,15,1,2,,Precinct 1,Amy Klobuchar,Bernie Sanders,Pete Buttigieg,Joseph R. Biden,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,15,1,3,,Precinct 1,Tulsi Gabbard,Joseph R. Biden,Bernie Sanders,Michael R. Bloomberg,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,15,1,4,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,15,1,5,,Precinct 1,Amy Klobuchar,Joseph R. Biden,Bernie Sanders,Tulsi Gabbard,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,15,1,6,,Precinct 1,Elizabeth Warren,Amy Klobuchar,Tom Steyer,Michael R. Bloomberg,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,15,1,7,,Precinct 1,Tom Steyer,12,Pete Buttigieg,Michael R. Bloomberg,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,15,1,8,,Precinct 1,Joseph R. Biden,Tulsi Gabbard,Pete Buttigieg,12,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,15,1,9,,Precinct 1,Bernie Sanders,Tom Steyer,Michael R. Bloomberg,Joseph R. Biden,"Joseph R. Biden
+Amy Klobuchar
+Tulsi Gabbard
+Elizabeth Warren
+Michael R. Bloomberg
+Pete Buttigieg
+12"
+../_shared/dominion_alaska/alaska_input_data,1,15,1,10,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,15,1,11,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,15,1,12,,Precinct 1,Joseph R. Biden,Elizabeth Warren,Amy Klobuchar,Pete Buttigieg,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,15,1,13,,Precinct 1,Pete Buttigieg,Bernie Sanders,Tulsi Gabbard,Joseph R. Biden,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,15,1,14,,Precinct 1,Michael R. Bloomberg,Pete Buttigieg,Tulsi Gabbard,Tom Steyer,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,15,1,15,,Precinct 1,12,Joseph R. Biden,Michael R. Bloomberg,Tom Steyer,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,15,1,16,,Precinct 1,Joseph R. Biden,Amy Klobuchar,Michael R. Bloomberg,Tom Steyer,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,15,1,17,,Precinct 1,Amy Klobuchar,12,Elizabeth Warren,Michael R. Bloomberg,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,15,1,18,,Precinct 1,Tulsi Gabbard,Tom Steyer,Amy Klobuchar,Pete Buttigieg,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,15,1,19,,Precinct 1,12,Pete Buttigieg,Tulsi Gabbard,Amy Klobuchar,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,15,1,20,,Precinct 1,Pete Buttigieg,Tom Steyer,12,Tulsi Gabbard,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,30,1,1,,Precinct 1,Tulsi Gabbard,Bernie Sanders,12,Joseph R. Biden,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,30,1,2,,Precinct 1,Amy Klobuchar,Joseph R. Biden,Michael R. Bloomberg,Elizabeth Warren,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,30,1,3,,Precinct 1,Pete Buttigieg,Tulsi Gabbard,Elizabeth Warren,Joseph R. Biden,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,30,1,4,,Precinct 1,Bernie Sanders,Amy Klobuchar,Michael R. Bloomberg,Pete Buttigieg,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,30,1,5,,Precinct 1,Joseph R. Biden,Tom Steyer,Pete Buttigieg,Tulsi Gabbard,12
+../_shared/dominion_alaska/alaska_input_data,1,30,1,6,,Precinct 1,Tulsi Gabbard,Elizabeth Warren,Pete Buttigieg,Joseph R. Biden,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,30,1,7,,Precinct 1,Pete Buttigieg,12,Bernie Sanders,Joseph R. Biden,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,30,1,8,,Precinct 1,Tulsi Gabbard,Amy Klobuchar,Pete Buttigieg,Bernie Sanders,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,30,1,9,,Precinct 1,Tulsi Gabbard,Amy Klobuchar,Elizabeth Warren,Michael R. Bloomberg,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,30,1,10,,Precinct 1,Elizabeth Warren,Tulsi Gabbard,Tom Steyer,Joseph R. Biden,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,30,1,11,,Precinct 1,Tulsi Gabbard,Elizabeth Warren,Tom Steyer,12,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,30,1,12,,Precinct 1,Amy Klobuchar,Tom Steyer,12,Tulsi Gabbard,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,30,1,13,,Precinct 1,Michael R. Bloomberg,12,Amy Klobuchar,Tom Steyer,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,30,1,14,,Precinct 1,Elizabeth Warren,Pete Buttigieg,Tulsi Gabbard,Joseph R. Biden,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,30,1,15,,Precinct 1,Tom Steyer,Elizabeth Warren,Pete Buttigieg,Joseph R. Biden,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,30,1,16,,Precinct 1,12,Michael R. Bloomberg,Tom Steyer,Joseph R. Biden,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,30,1,17,,Precinct 1,Tulsi Gabbard,Pete Buttigieg,Tom Steyer,Michael R. Bloomberg,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,30,1,18,,Precinct 1,Bernie Sanders,Joseph R. Biden,Pete Buttigieg,Tulsi Gabbard,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,30,1,19,,Precinct 1,Tulsi Gabbard,Elizabeth Warren,Pete Buttigieg,Joseph R. Biden,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,30,1,20,,Precinct 1,Elizabeth Warren,Amy Klobuchar,Joseph R. Biden,Pete Buttigieg,12
+../_shared/dominion_alaska/alaska_input_data,1,36,1,1,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,36,1,2,,Precinct 1,Joseph R. Biden,Tom Steyer,12,Bernie Sanders,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,36,1,3,,Precinct 1,Bernie Sanders,12,Tom Steyer,Elizabeth Warren,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,36,1,4,,Precinct 1,Tom Steyer,Tulsi Gabbard,Elizabeth Warren,Pete Buttigieg,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,36,1,5,,Precinct 1,Bernie Sanders,Elizabeth Warren,Pete Buttigieg,Amy Klobuchar,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,36,1,6,,Precinct 1,Amy Klobuchar,12,Bernie Sanders,Pete Buttigieg,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,36,1,7,,Precinct 1,Elizabeth Warren,Joseph R. Biden,Tom Steyer,12,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,36,1,8,,Precinct 1,Michael R. Bloomberg,Elizabeth Warren,Pete Buttigieg,12,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,36,1,9,,Precinct 1,12,Bernie Sanders,Amy Klobuchar,Michael R. Bloomberg,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,36,1,10,,Precinct 1,Bernie Sanders,Pete Buttigieg,12,Elizabeth Warren,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,36,1,11,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,36,1,12,,Precinct 1,Pete Buttigieg,12,Joseph R. Biden,Bernie Sanders,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,36,1,13,,Precinct 1,12,Bernie Sanders,Tom Steyer,Michael R. Bloomberg,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,36,1,14,,Precinct 1,Michael R. Bloomberg,Pete Buttigieg,Joseph R. Biden,12,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,36,1,15,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,36,1,16,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,36,1,17,,Precinct 1,Joseph R. Biden,Bernie Sanders,"Michael R. Bloomberg
+12",Pete Buttigieg,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,36,1,18,,Precinct 1,Tulsi Gabbard,Elizabeth Warren,12,Tom Steyer,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,36,1,19,,Precinct 1,Amy Klobuchar,Tom Steyer,12,Bernie Sanders,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,36,1,20,,Precinct 1,Tom Steyer,12,Michael R. Bloomberg,Amy Klobuchar,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,46,1,1,,Precinct 1,Tulsi Gabbard,Joseph R. Biden,Pete Buttigieg,Elizabeth Warren,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,46,1,2,,Precinct 1,Pete Buttigieg,Elizabeth Warren,Michael R. Bloomberg,Bernie Sanders,12
+../_shared/dominion_alaska/alaska_input_data,1,46,1,3,,Precinct 1,12,Michael R. Bloomberg,Amy Klobuchar,Tom Steyer,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,46,1,4,,Precinct 1,Elizabeth Warren,Joseph R. Biden,Bernie Sanders,12,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,46,1,5,,Precinct 1,Pete Buttigieg,Joseph R. Biden,Elizabeth Warren,Bernie Sanders,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,46,1,6,,Precinct 1,Michael R. Bloomberg,Tulsi Gabbard,Bernie Sanders,Pete Buttigieg,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,46,1,7,,Precinct 1,Tom Steyer,Bernie Sanders,Elizabeth Warren,Tulsi Gabbard,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,46,1,8,,Precinct 1,Bernie Sanders,Tulsi Gabbard,Michael R. Bloomberg,Pete Buttigieg,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,46,1,9,,Precinct 1,Pete Buttigieg,Joseph R. Biden,Tom Steyer,Michael R. Bloomberg,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,46,1,10,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,46,1,11,,Precinct 1,Michael R. Bloomberg,Elizabeth Warren,Pete Buttigieg,Amy Klobuchar,12
+../_shared/dominion_alaska/alaska_input_data,1,46,1,12,,Precinct 1,Amy Klobuchar,12,Tulsi Gabbard,Pete Buttigieg,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,46,1,13,,Precinct 1,12,Elizabeth Warren,Amy Klobuchar,Joseph R. Biden,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,46,1,14,,Precinct 1,Tom Steyer,Tulsi Gabbard,Bernie Sanders,Pete Buttigieg,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,46,1,15,,Precinct 1,Joseph R. Biden,Amy Klobuchar,Pete Buttigieg,Tom Steyer,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,46,1,16,,Precinct 1,Pete Buttigieg,Michael R. Bloomberg,Tulsi Gabbard,Joseph R. Biden,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,46,1,17,,Precinct 1,Tulsi Gabbard,12,Pete Buttigieg,Bernie Sanders,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,46,1,18,,Precinct 1,Michael R. Bloomberg,Joseph R. Biden,Bernie Sanders,Elizabeth Warren,12
+../_shared/dominion_alaska/alaska_input_data,1,46,1,19,,Precinct 1,Joseph R. Biden,Pete Buttigieg,Elizabeth Warren,Michael R. Bloomberg,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,46,1,20,,Precinct 1,Bernie Sanders,Elizabeth Warren,12,Tom Steyer,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,14,1,1,,Precinct 1,Tom Steyer,Joseph R. Biden,Elizabeth Warren,Bernie Sanders,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,14,1,2,,Precinct 1,Tulsi Gabbard,Michael R. Bloomberg,Pete Buttigieg,Elizabeth Warren,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,14,1,3,,Precinct 1,Tulsi Gabbard,Amy Klobuchar,12,Bernie Sanders,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,14,1,4,,Precinct 1,Elizabeth Warren,12,Amy Klobuchar,Pete Buttigieg,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,14,1,5,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,14,1,6,,Precinct 1,Amy Klobuchar,Joseph R. Biden,Tulsi Gabbard,Tom Steyer,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,14,1,7,,Precinct 1,Tom Steyer,Bernie Sanders,Joseph R. Biden,12,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,14,1,8,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,14,1,9,,Precinct 1,Amy Klobuchar,Bernie Sanders,Pete Buttigieg,Tulsi Gabbard,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,14,1,10,,Precinct 1,Pete Buttigieg,Bernie Sanders,Michael R. Bloomberg,Tom Steyer,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,14,1,11,,Precinct 1,Bernie Sanders,Tulsi Gabbard,Joseph R. Biden,12,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,14,1,12,,Precinct 1,Tom Steyer,Michael R. Bloomberg,Elizabeth Warren,12,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,14,1,13,,Precinct 1,Tom Steyer,Amy Klobuchar,Joseph R. Biden,12,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,14,1,14,,Precinct 1,Amy Klobuchar,Tulsi Gabbard,Michael R. Bloomberg,Joseph R. Biden,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,14,1,15,,Precinct 1,Joseph R. Biden,Bernie Sanders,Pete Buttigieg,12,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,14,1,16,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,14,1,17,,Precinct 1,Elizabeth Warren,Tom Steyer,Bernie Sanders,Amy Klobuchar,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,14,1,18,,Precinct 1,Bernie Sanders,Michael R. Bloomberg,Elizabeth Warren,Tom Steyer,12
+../_shared/dominion_alaska/alaska_input_data,1,14,1,19,,Precinct 1,Amy Klobuchar,Elizabeth Warren,Tom Steyer,Pete Buttigieg,12
+../_shared/dominion_alaska/alaska_input_data,1,14,1,20,,Precinct 1,Tulsi Gabbard,Elizabeth Warren,Bernie Sanders,12,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,13,1,1,,Precinct 1,Joseph R. Biden,12,Tulsi Gabbard,Pete Buttigieg,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,13,1,2,,Precinct 1,Michael R. Bloomberg,Joseph R. Biden,Tom Steyer,Tulsi Gabbard,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,13,1,3,,Precinct 1,Tulsi Gabbard,Amy Klobuchar,Bernie Sanders,Tom Steyer,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,13,1,4,,Precinct 1,Tulsi Gabbard,Amy Klobuchar,12,Joseph R. Biden,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,13,1,5,,Precinct 1,Michael R. Bloomberg,Elizabeth Warren,Tom Steyer,Joseph R. Biden,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,13,1,6,,Precinct 1,Joseph R. Biden,12,Tom Steyer,Tulsi Gabbard,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,13,1,7,,Precinct 1,Amy Klobuchar,Michael R. Bloomberg,12,Joseph R. Biden,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,13,1,8,,Precinct 1,Pete Buttigieg,12,Bernie Sanders,Tulsi Gabbard,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,13,1,9,,Precinct 1,Michael R. Bloomberg,Amy Klobuchar,12,Tom Steyer,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,13,1,10,,Precinct 1,Tom Steyer,Michael R. Bloomberg,Tulsi Gabbard,Pete Buttigieg,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,13,1,11,,Precinct 1,Joseph R. Biden,Elizabeth Warren,Bernie Sanders,Michael R. Bloomberg,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,13,1,12,,Precinct 1,Bernie Sanders,Tom Steyer,Michael R. Bloomberg,Pete Buttigieg,12
+../_shared/dominion_alaska/alaska_input_data,1,13,1,13,,Precinct 1,Joseph R. Biden,Tulsi Gabbard,12,Michael R. Bloomberg,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,13,1,14,,Precinct 1,Elizabeth Warren,Pete Buttigieg,Michael R. Bloomberg,Tulsi Gabbard,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,13,1,15,,Precinct 1,Amy Klobuchar,Pete Buttigieg,Joseph R. Biden,Michael R. Bloomberg,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,13,1,16,,Precinct 1,Tulsi Gabbard,Elizabeth Warren,Pete Buttigieg,Tom Steyer,12
+../_shared/dominion_alaska/alaska_input_data,1,13,1,17,,Precinct 1,Tom Steyer,Elizabeth Warren,Tulsi Gabbard,Joseph R. Biden,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,13,1,18,,Precinct 1,Amy Klobuchar,Elizabeth Warren,12,Bernie Sanders,"Joseph R. Biden
+Tom Steyer
+Bernie Sanders
+Tulsi Gabbard
+Elizabeth Warren
+Michael R. Bloomberg
+Pete Buttigieg"
+../_shared/dominion_alaska/alaska_input_data,1,13,1,19,,Precinct 1,12,Joseph R. Biden,Elizabeth Warren,Michael R. Bloomberg,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,13,1,20,,Precinct 1,12,Tom Steyer,Pete Buttigieg,Bernie Sanders,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,29,1,1,,Precinct 1,Tulsi Gabbard,Pete Buttigieg,Amy Klobuchar,12,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,29,1,2,,Precinct 1,Pete Buttigieg,Tom Steyer,Bernie Sanders,Tulsi Gabbard,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,29,1,3,,Precinct 1,Michael R. Bloomberg,Bernie Sanders,Tulsi Gabbard,Pete Buttigieg,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,29,1,4,,Precinct 1,Joseph R. Biden,Tulsi Gabbard,Michael R. Bloomberg,12,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,29,1,5,,Precinct 1,12,Joseph R. Biden,Bernie Sanders,Amy Klobuchar,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,29,1,6,,Precinct 1,Bernie Sanders,Joseph R. Biden,Elizabeth Warren,12,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,29,1,7,,Precinct 1,Tulsi Gabbard,Tom Steyer,Joseph R. Biden,Michael R. Bloomberg,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,29,1,8,,Precinct 1,12,Elizabeth Warren,Joseph R. Biden,Tom Steyer,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,29,1,9,,Precinct 1,Michael R. Bloomberg,Pete Buttigieg,Bernie Sanders,undervote,12
+../_shared/dominion_alaska/alaska_input_data,1,29,1,10,,Precinct 1,Tulsi Gabbard,Joseph R. Biden,Pete Buttigieg,Michael R. Bloomberg,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,29,1,11,,Precinct 1,Bernie Sanders,Pete Buttigieg,Amy Klobuchar,Elizabeth Warren,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,29,1,12,,Precinct 1,12,Amy Klobuchar,Pete Buttigieg,Tulsi Gabbard,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,29,1,13,,Precinct 1,12,Elizabeth Warren,Amy Klobuchar,Joseph R. Biden,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,29,1,14,,Precinct 1,12,Joseph R. Biden,Pete Buttigieg,Tom Steyer,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,29,1,15,,Precinct 1,Pete Buttigieg,Amy Klobuchar,Michael R. Bloomberg,Bernie Sanders,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,29,1,16,,Precinct 1,Bernie Sanders,Michael R. Bloomberg,Joseph R. Biden,Tom Steyer,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,29,1,17,,Precinct 1,Tulsi Gabbard,Joseph R. Biden,Tom Steyer,Bernie Sanders,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,29,1,18,,Precinct 1,Amy Klobuchar,Tulsi Gabbard,Elizabeth Warren,12,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,29,1,19,,Precinct 1,Joseph R. Biden,12,Michael R. Bloomberg,Bernie Sanders,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,29,1,20,,Precinct 1,Pete Buttigieg,Tom Steyer,Amy Klobuchar,12,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,12,1,1,,Precinct 1,Elizabeth Warren,Tom Steyer,Amy Klobuchar,12,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,12,1,2,,Precinct 1,Pete Buttigieg,Bernie Sanders,Tom Steyer,Joseph R. Biden,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,12,1,3,,Precinct 1,Tulsi Gabbard,Pete Buttigieg,Joseph R. Biden,Tom Steyer,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,12,1,4,,Precinct 1,12,Bernie Sanders,Tom Steyer,Elizabeth Warren,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,12,1,5,,Precinct 1,12,Bernie Sanders,Pete Buttigieg,Amy Klobuchar,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,12,1,6,,Precinct 1,Tulsi Gabbard,Bernie Sanders,Amy Klobuchar,Michael R. Bloomberg,12
+../_shared/dominion_alaska/alaska_input_data,1,12,1,7,,Precinct 1,Pete Buttigieg,Tom Steyer,Michael R. Bloomberg,Amy Klobuchar,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,12,1,8,,Precinct 1,Tom Steyer,Joseph R. Biden,Amy Klobuchar,12,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,12,1,9,,Precinct 1,Amy Klobuchar,Tulsi Gabbard,12,Bernie Sanders,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,12,1,10,,Precinct 1,Pete Buttigieg,Tulsi Gabbard,Elizabeth Warren,Joseph R. Biden,12
+../_shared/dominion_alaska/alaska_input_data,1,12,1,11,,Precinct 1,Elizabeth Warren,Joseph R. Biden,Tom Steyer,Michael R. Bloomberg,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,12,1,12,,Precinct 1,Amy Klobuchar,Michael R. Bloomberg,Pete Buttigieg,Bernie Sanders,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,12,1,13,,Precinct 1,Bernie Sanders,Joseph R. Biden,Michael R. Bloomberg,Pete Buttigieg,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,12,1,14,,Precinct 1,Joseph R. Biden,Joseph R. Biden,Pete Buttigieg,Tom Steyer,12
+../_shared/dominion_alaska/alaska_input_data,1,12,1,15,,Precinct 1,Bernie Sanders,Amy Klobuchar,Joseph R. Biden,Michael R. Bloomberg,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,12,1,16,,Precinct 1,Bernie Sanders,Tulsi Gabbard,"Amy Klobuchar
+Pete Buttigieg
+12",Michael R. Bloomberg,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,12,1,17,,Precinct 1,Tom Steyer,Michael R. Bloomberg,12,Tulsi Gabbard,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,12,1,18,,Precinct 1,Pete Buttigieg,Elizabeth Warren,Tom Steyer,Joseph R. Biden,12
+../_shared/dominion_alaska/alaska_input_data,1,12,1,19,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,12,1,20,,Precinct 1,12,Bernie Sanders,Amy Klobuchar,Pete Buttigieg,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,35,1,1,,Precinct 1,Bernie Sanders,Pete Buttigieg,Tom Steyer,Michael R. Bloomberg,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,35,1,2,,Precinct 1,12,Tom Steyer,Joseph R. Biden,Pete Buttigieg,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,35,1,3,,Precinct 1,Michael R. Bloomberg,Joseph R. Biden,Tom Steyer,Tulsi Gabbard,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,35,1,4,,Precinct 1,Amy Klobuchar,Bernie Sanders,Tulsi Gabbard,Pete Buttigieg,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,35,1,5,,Precinct 1,Tulsi Gabbard,Pete Buttigieg,Tom Steyer,12,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,35,1,6,,Precinct 1,Pete Buttigieg,Michael R. Bloomberg,Amy Klobuchar,12,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,35,1,7,,Precinct 1,Elizabeth Warren,12,Tulsi Gabbard,Michael R. Bloomberg,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,35,1,8,,Precinct 1,12,Amy Klobuchar,Joseph R. Biden,Elizabeth Warren,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,35,1,9,,Precinct 1,Michael R. Bloomberg,Tulsi Gabbard,Joseph R. Biden,Amy Klobuchar,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,35,1,10,,Precinct 1,Tulsi Gabbard,Tom Steyer,Elizabeth Warren,Amy Klobuchar,12
+../_shared/dominion_alaska/alaska_input_data,1,35,1,11,,Precinct 1,Tom Steyer,Pete Buttigieg,Bernie Sanders,Michael R. Bloomberg,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,35,1,12,,Precinct 1,Michael R. Bloomberg,12,Tulsi Gabbard,Elizabeth Warren,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,35,1,13,,Precinct 1,Elizabeth Warren,12,Joseph R. Biden,Tulsi Gabbard,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,35,1,14,,Precinct 1,Joseph R. Biden,Elizabeth Warren,Pete Buttigieg,Michael R. Bloomberg,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,35,1,15,,Precinct 1,Michael R. Bloomberg,Elizabeth Warren,Bernie Sanders,Tom Steyer,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,35,1,16,,Precinct 1,Pete Buttigieg,Elizabeth Warren,Amy Klobuchar,Michael R. Bloomberg,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,35,1,17,,Precinct 1,Pete Buttigieg,Elizabeth Warren,Bernie Sanders,Tom Steyer,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,35,1,18,,Precinct 1,Amy Klobuchar,Bernie Sanders,12,Joseph R. Biden,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,35,1,19,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,35,1,20,,Precinct 1,Tulsi Gabbard,12,Tom Steyer,Michael R. Bloomberg,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,19,1,1,,Precinct 1,12,Amy Klobuchar,Tom Steyer,Elizabeth Warren,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,19,1,2,,Precinct 1,Bernie Sanders,Elizabeth Warren,Pete Buttigieg,Michael R. Bloomberg,12
+../_shared/dominion_alaska/alaska_input_data,1,19,1,3,,Precinct 1,Elizabeth Warren,Tom Steyer,Pete Buttigieg,Tulsi Gabbard,12
+../_shared/dominion_alaska/alaska_input_data,1,19,1,4,,Precinct 1,Michael R. Bloomberg,12,Amy Klobuchar,Pete Buttigieg,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,19,1,5,,Precinct 1,Michael R. Bloomberg,Tulsi Gabbard,Bernie Sanders,Joseph R. Biden,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,19,1,6,,Precinct 1,Joseph R. Biden,Bernie Sanders,Elizabeth Warren,Pete Buttigieg,12
+../_shared/dominion_alaska/alaska_input_data,1,19,1,7,,Precinct 1,Michael R. Bloomberg,Pete Buttigieg,Amy Klobuchar,Tom Steyer,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,19,1,8,,Precinct 1,Tulsi Gabbard,Michael R. Bloomberg,Amy Klobuchar,12,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,19,1,9,,Precinct 1,12,Bernie Sanders,Pete Buttigieg,Joseph R. Biden,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,19,1,10,,Precinct 1,Tulsi Gabbard,Pete Buttigieg,Bernie Sanders,Tom Steyer,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,19,1,11,,Precinct 1,Amy Klobuchar,Tulsi Gabbard,Tom Steyer,12,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,19,1,12,,Precinct 1,Elizabeth Warren,Pete Buttigieg,Amy Klobuchar,12,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,19,1,13,,Precinct 1,12,Tom Steyer,Pete Buttigieg,Amy Klobuchar,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,19,1,14,,Precinct 1,Pete Buttigieg,12,Tulsi Gabbard,Amy Klobuchar,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,19,1,15,,Precinct 1,Joseph R. Biden,Elizabeth Warren,Michael R. Bloomberg,Amy Klobuchar,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,19,1,16,,Precinct 1,Michael R. Bloomberg,Tom Steyer,Pete Buttigieg,Elizabeth Warren,12
+../_shared/dominion_alaska/alaska_input_data,1,19,1,17,,Precinct 1,Tom Steyer,Bernie Sanders,Pete Buttigieg,Michael R. Bloomberg,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,19,1,18,,Precinct 1,Michael R. Bloomberg,12,Amy Klobuchar,Bernie Sanders,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,19,1,19,,Precinct 1,Joseph R. Biden,Tom Steyer,Michael R. Bloomberg,Tulsi Gabbard,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,19,1,20,,Precinct 1,Tom Steyer,Pete Buttigieg,12,Tulsi Gabbard,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,11,1,1,,Precinct 1,Tom Steyer,Tulsi Gabbard,Bernie Sanders,12,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,11,1,2,,Precinct 1,12,Elizabeth Warren,Bernie Sanders,Michael R. Bloomberg,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,11,1,3,,Precinct 1,Tulsi Gabbard,Tom Steyer,Pete Buttigieg,Joseph R. Biden,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,11,1,4,,Precinct 1,Amy Klobuchar,Tom Steyer,Tulsi Gabbard,Joseph R. Biden,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,11,1,5,,Precinct 1,Bernie Sanders,Pete Buttigieg,Michael R. Bloomberg,Tulsi Gabbard,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,11,1,6,,Precinct 1,12,Tulsi Gabbard,Michael R. Bloomberg,Elizabeth Warren,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,11,1,7,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,11,1,8,,Precinct 1,Pete Buttigieg,Tom Steyer,Joseph R. Biden,Tulsi Gabbard,12
+../_shared/dominion_alaska/alaska_input_data,1,11,1,9,,Precinct 1,Amy Klobuchar,12,Joseph R. Biden,Tulsi Gabbard,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,11,1,10,,Precinct 1,Joseph R. Biden,Pete Buttigieg,Elizabeth Warren,12,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,11,1,11,,Precinct 1,Michael R. Bloomberg,Elizabeth Warren,12,Bernie Sanders,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,11,1,12,,Precinct 1,Elizabeth Warren,Tom Steyer,Bernie Sanders,Amy Klobuchar,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,11,1,13,,Precinct 1,12,Elizabeth Warren,Pete Buttigieg,"Joseph R. Biden
+Tom Steyer
+Bernie Sanders
+Amy Klobuchar
+Tulsi Gabbard
+Michael R. Bloomberg",Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,11,1,14,,Precinct 1,Tom Steyer,Tulsi Gabbard,Bernie Sanders,Pete Buttigieg,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,11,1,15,,Precinct 1,Elizabeth Warren,Tom Steyer,Pete Buttigieg,12,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,11,1,16,,Precinct 1,Tulsi Gabbard,12,Pete Buttigieg,Amy Klobuchar,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,11,1,17,,Precinct 1,Tulsi Gabbard,Joseph R. Biden,12,Michael R. Bloomberg,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,11,1,18,,Precinct 1,12,Tom Steyer,Elizabeth Warren,Amy Klobuchar,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,11,1,19,,Precinct 1,Elizabeth Warren,Pete Buttigieg,Tom Steyer,Michael R. Bloomberg,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,11,1,20,,Precinct 1,Tulsi Gabbard,Amy Klobuchar,12,Tom Steyer,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,45,1,1,,Precinct 1,Joseph R. Biden,Amy Klobuchar,Elizabeth Warren,Michael R. Bloomberg,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,45,1,2,,Precinct 1,12,Joseph R. Biden,Pete Buttigieg,Tom Steyer,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,45,1,3,,Precinct 1,12,Tom Steyer,Bernie Sanders,Joseph R. Biden,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,45,1,4,,Precinct 1,Joseph R. Biden,Pete Buttigieg,Tulsi Gabbard,Amy Klobuchar,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,45,1,5,,Precinct 1,Tom Steyer,Michael R. Bloomberg,Amy Klobuchar,Elizabeth Warren,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,45,1,6,,Precinct 1,Tom Steyer,Pete Buttigieg,Michael R. Bloomberg,12,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,45,1,7,,Precinct 1,Elizabeth Warren,Michael R. Bloomberg,Amy Klobuchar,Pete Buttigieg,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,45,1,8,,Precinct 1,Elizabeth Warren,Tulsi Gabbard,Bernie Sanders,Tom Steyer,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,45,1,9,,Precinct 1,Tulsi Gabbard,12,Tom Steyer,Pete Buttigieg,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,45,1,10,,Precinct 1,Tom Steyer,Bernie Sanders,12,Pete Buttigieg,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,45,1,11,,Precinct 1,Elizabeth Warren,Joseph R. Biden,Tulsi Gabbard,12,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,45,1,12,,Precinct 1,Elizabeth Warren,Tom Steyer,Pete Buttigieg,Amy Klobuchar,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,45,1,13,,Precinct 1,Joseph R. Biden,Tulsi Gabbard,Michael R. Bloomberg,Bernie Sanders,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,45,1,14,,Precinct 1,Tulsi Gabbard,Bernie Sanders,Tom Steyer,Michael R. Bloomberg,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,45,1,15,,Precinct 1,Bernie Sanders,12,Elizabeth Warren,Tulsi Gabbard,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,45,1,16,,Precinct 1,Michael R. Bloomberg,Tom Steyer,Pete Buttigieg,Elizabeth Warren,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,45,1,17,,Precinct 1,Tulsi Gabbard,Tom Steyer,Amy Klobuchar,Elizabeth Warren,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,45,1,18,,Precinct 1,Bernie Sanders,12,Tom Steyer,Elizabeth Warren,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,45,1,19,,Precinct 1,12,Tulsi Gabbard,Bernie Sanders,Pete Buttigieg,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,45,1,20,,Precinct 1,Tom Steyer,Bernie Sanders,12,Amy Klobuchar,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,27,1,1,,Precinct 1,12,Pete Buttigieg,Bernie Sanders,Elizabeth Warren,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,27,1,2,,Precinct 1,Bernie Sanders,Pete Buttigieg,Tulsi Gabbard,Michael R. Bloomberg,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,27,1,3,,Precinct 1,Michael R. Bloomberg,Elizabeth Warren,Amy Klobuchar,Bernie Sanders,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,27,1,4,,Precinct 1,Bernie Sanders,Pete Buttigieg,Tom Steyer,Elizabeth Warren,12
+../_shared/dominion_alaska/alaska_input_data,1,27,1,5,,Precinct 1,Tulsi Gabbard,Elizabeth Warren,12,Pete Buttigieg,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,27,1,6,,Precinct 1,Elizabeth Warren,Amy Klobuchar,Michael R. Bloomberg,Tulsi Gabbard,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,27,1,7,,Precinct 1,Michael R. Bloomberg,Joseph R. Biden,12,Tulsi Gabbard,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,27,1,8,,Precinct 1,Joseph R. Biden,Pete Buttigieg,Tulsi Gabbard,Amy Klobuchar,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,27,1,9,,Precinct 1,Bernie Sanders,Tulsi Gabbard,Joseph R. Biden,Tom Steyer,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,27,1,10,,Precinct 1,Tulsi Gabbard,Bernie Sanders,Joseph R. Biden,Pete Buttigieg,12
+../_shared/dominion_alaska/alaska_input_data,1,27,1,11,,Precinct 1,Elizabeth Warren,Bernie Sanders,Tulsi Gabbard,Michael R. Bloomberg,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,27,1,12,,Precinct 1,Pete Buttigieg,Tom Steyer,Joseph R. Biden,Amy Klobuchar,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,27,1,13,,Precinct 1,Tulsi Gabbard,Joseph R. Biden,Elizabeth Warren,Amy Klobuchar,12
+../_shared/dominion_alaska/alaska_input_data,1,27,1,14,,Precinct 1,Joseph R. Biden,Elizabeth Warren,Michael R. Bloomberg,Tom Steyer,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,27,1,15,,Precinct 1,Michael R. Bloomberg,Bernie Sanders,Pete Buttigieg,Tulsi Gabbard,12
+../_shared/dominion_alaska/alaska_input_data,1,27,1,16,,Precinct 1,Elizabeth Warren,Tom Steyer,12,Tulsi Gabbard,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,27,1,17,,Precinct 1,Amy Klobuchar,Tulsi Gabbard,Elizabeth Warren,12,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,27,1,18,,Precinct 1,Tulsi Gabbard,Joseph R. Biden,Michael R. Bloomberg,12,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,27,1,19,,Precinct 1,Michael R. Bloomberg,Pete Buttigieg,12,Elizabeth Warren,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,27,1,20,,Precinct 1,Michael R. Bloomberg,12,Joseph R. Biden,Pete Buttigieg,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,10,1,1,,Precinct 1,Joseph R. Biden,Tulsi Gabbard,Bernie Sanders,Pete Buttigieg,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,10,1,2,,Precinct 1,Bernie Sanders,Joseph R. Biden,Michael R. Bloomberg,Tulsi Gabbard,12
+../_shared/dominion_alaska/alaska_input_data,1,10,1,3,,Precinct 1,Amy Klobuchar,Tom Steyer,Joseph R. Biden,Pete Buttigieg,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,10,1,4,,Precinct 1,Tom Steyer,Michael R. Bloomberg,Pete Buttigieg,Bernie Sanders,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,10,1,5,,Precinct 1,Tulsi Gabbard,Michael R. Bloomberg,Elizabeth Warren,12,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,10,1,6,,Precinct 1,"Joseph R. Biden
+Tom Steyer
+Bernie Sanders
+Amy Klobuchar
+Tulsi Gabbard
+Elizabeth Warren
+Michael R. Bloomberg
+Pete Buttigieg",12,Elizabeth Warren,Joseph R. Biden,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,10,1,7,,Precinct 1,Bernie Sanders,12,Elizabeth Warren,Tom Steyer,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,10,1,8,,Precinct 1,Joseph R. Biden,Tulsi Gabbard,Bernie Sanders,Amy Klobuchar,12
+../_shared/dominion_alaska/alaska_input_data,1,10,1,9,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,10,1,10,,Precinct 1,Joseph R. Biden,Bernie Sanders,Tulsi Gabbard,Pete Buttigieg,12
+../_shared/dominion_alaska/alaska_input_data,1,10,1,11,,Precinct 1,Tulsi Gabbard,Joseph R. Biden,Elizabeth Warren,12,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,10,1,12,,Precinct 1,Tom Steyer,12,Elizabeth Warren,Amy Klobuchar,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,10,1,13,,Precinct 1,Tom Steyer,Pete Buttigieg,Tulsi Gabbard,Bernie Sanders,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,10,1,14,,Precinct 1,Pete Buttigieg,Michael R. Bloomberg,12,Elizabeth Warren,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,10,1,15,,Precinct 1,Elizabeth Warren,Michael R. Bloomberg,Pete Buttigieg,Bernie Sanders,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,10,1,16,,Precinct 1,Tom Steyer,Tulsi Gabbard,Joseph R. Biden,Amy Klobuchar,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,10,1,17,,Precinct 1,Tom Steyer,Tulsi Gabbard,Elizabeth Warren,Michael R. Bloomberg,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,10,1,18,,Precinct 1,12,Tom Steyer,Bernie Sanders,Elizabeth Warren,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,10,1,19,,Precinct 1,Joseph R. Biden,12,Bernie Sanders,Tulsi Gabbard,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,10,1,20,,Precinct 1,12,Michael R. Bloomberg,Joseph R. Biden,Pete Buttigieg,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,44,1,1,,Precinct 1,Elizabeth Warren,Tulsi Gabbard,Bernie Sanders,Michael R. Bloomberg,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,44,1,2,,Precinct 1,12,Bernie Sanders,Joseph R. Biden,Michael R. Bloomberg,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,44,1,3,,Precinct 1,12,Elizabeth Warren,Pete Buttigieg,Joseph R. Biden,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,44,1,4,,Precinct 1,Tulsi Gabbard,Michael R. Bloomberg,Pete Buttigieg,12,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,44,1,5,,Precinct 1,Amy Klobuchar,Tom Steyer,Bernie Sanders,Pete Buttigieg,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,44,1,6,,Precinct 1,Elizabeth Warren,Joseph R. Biden,Bernie Sanders,Amy Klobuchar,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,44,1,7,,Precinct 1,12,Tom Steyer,Amy Klobuchar,Bernie Sanders,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,44,1,8,,Precinct 1,Pete Buttigieg,Michael R. Bloomberg,Tom Steyer,Tulsi Gabbard,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,44,1,9,,Precinct 1,Tom Steyer,12,Bernie Sanders,Joseph R. Biden,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,44,1,10,,Precinct 1,Pete Buttigieg,Joseph R. Biden,Tom Steyer,Amy Klobuchar,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,44,1,11,,Precinct 1,Tom Steyer,Elizabeth Warren,Amy Klobuchar,12,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,44,1,12,,Precinct 1,Michael R. Bloomberg,Elizabeth Warren,Pete Buttigieg,Joseph R. Biden,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,44,1,13,,Precinct 1,Bernie Sanders,Joseph R. Biden,Tulsi Gabbard,Amy Klobuchar,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,44,1,14,,Precinct 1,12,Tulsi Gabbard,Joseph R. Biden,Pete Buttigieg,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,44,1,15,,Precinct 1,Tom Steyer,Tulsi Gabbard,Elizabeth Warren,Amy Klobuchar,12
+../_shared/dominion_alaska/alaska_input_data,1,44,1,16,,Precinct 1,12,Bernie Sanders,Tom Steyer,Elizabeth Warren,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,44,1,17,,Precinct 1,Amy Klobuchar,12,Joseph R. Biden,Pete Buttigieg,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,44,1,18,,Precinct 1,Bernie Sanders,Tom Steyer,12,Pete Buttigieg,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,44,1,19,,Precinct 1,Elizabeth Warren,12,Amy Klobuchar,Michael R. Bloomberg,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,44,1,20,,Precinct 1,Bernie Sanders,Joseph R. Biden,Elizabeth Warren,Tulsi Gabbard,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,1,1,1,,Precinct 1,Tulsi Gabbard,Joseph R. Biden,Pete Buttigieg,Amy Klobuchar,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,1,1,2,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,1,1,3,,Precinct 1,Pete Buttigieg,Amy Klobuchar,Tom Steyer,12,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,1,1,4,,Precinct 1,Michael R. Bloomberg,Tom Steyer,Elizabeth Warren,Joseph R. Biden,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,1,1,5,,Precinct 1,Joseph R. Biden,Bernie Sanders,Elizabeth Warren,Tulsi Gabbard,12
+../_shared/dominion_alaska/alaska_input_data,1,1,1,6,,Precinct 1,Amy Klobuchar,12,Tulsi Gabbard,Joseph R. Biden,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,1,1,7,,Precinct 1,Tulsi Gabbard,12,Joseph R. Biden,Amy Klobuchar,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,1,1,8,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,1,1,9,,Precinct 1,Tulsi Gabbard,Michael R. Bloomberg,Bernie Sanders,Tom Steyer,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,1,1,10,,Precinct 1,Bernie Sanders,Joseph R. Biden,Tulsi Gabbard,Amy Klobuchar,12
+../_shared/dominion_alaska/alaska_input_data,1,1,1,11,,Precinct 1,Elizabeth Warren,Pete Buttigieg,Tom Steyer,Bernie Sanders,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,1,1,12,,Precinct 1,Pete Buttigieg,Amy Klobuchar,Tulsi Gabbard,Tom Steyer,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,1,1,13,,Precinct 1,Michael R. Bloomberg,Joseph R. Biden,Pete Buttigieg,Tulsi Gabbard,12
+../_shared/dominion_alaska/alaska_input_data,1,1,1,14,,Precinct 1,Joseph R. Biden,12,Elizabeth Warren,Pete Buttigieg,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,1,1,15,,Precinct 1,Tom Steyer,Elizabeth Warren,Pete Buttigieg,Joseph R. Biden,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,1,1,16,,Precinct 1,Pete Buttigieg,Amy Klobuchar,Tom Steyer,Bernie Sanders,12
+../_shared/dominion_alaska/alaska_input_data,1,1,1,17,,Precinct 1,12,Elizabeth Warren,Tulsi Gabbard,Michael R. Bloomberg,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,1,1,18,,Precinct 1,Amy Klobuchar,Elizabeth Warren,Michael R. Bloomberg,Bernie Sanders,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,1,1,19,,Precinct 1,Tulsi Gabbard,Bernie Sanders,Amy Klobuchar,Joseph R. Biden,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,1,1,20,,Precinct 1,Tulsi Gabbard,Tom Steyer,12,Amy Klobuchar,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,43,1,1,,Precinct 1,Tom Steyer,Pete Buttigieg,Bernie Sanders,Michael R. Bloomberg,12
+../_shared/dominion_alaska/alaska_input_data,1,43,1,2,,Precinct 1,Joseph R. Biden,Michael R. Bloomberg,Bernie Sanders,Amy Klobuchar,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,43,1,3,,Precinct 1,12,Joseph R. Biden,Elizabeth Warren,Tom Steyer,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,43,1,4,,Precinct 1,12,Tulsi Gabbard,Pete Buttigieg,Bernie Sanders,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,43,1,5,,Precinct 1,Elizabeth Warren,Michael R. Bloomberg,12,Joseph R. Biden,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,43,1,6,,Precinct 1,Joseph R. Biden,Tulsi Gabbard,Elizabeth Warren,Amy Klobuchar,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,43,1,7,,Precinct 1,Bernie Sanders,Michael R. Bloomberg,Amy Klobuchar,Elizabeth Warren,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,43,1,8,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,43,1,9,,Precinct 1,Tulsi Gabbard,Amy Klobuchar,Tom Steyer,Joseph R. Biden,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,43,1,10,,Precinct 1,Bernie Sanders,Tulsi Gabbard,Pete Buttigieg,Joseph R. Biden,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,43,1,11,,Precinct 1,Joseph R. Biden,Tom Steyer,Michael R. Bloomberg,Amy Klobuchar,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,43,1,12,,Precinct 1,12,Michael R. Bloomberg,Bernie Sanders,Joseph R. Biden,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,43,1,13,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,43,1,14,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,43,1,15,,Precinct 1,Tom Steyer,Amy Klobuchar,Joseph R. Biden,Bernie Sanders,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,43,1,16,,Precinct 1,12,Joseph R. Biden,Amy Klobuchar,Bernie Sanders,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,43,1,17,,Precinct 1,Tulsi Gabbard,Tom Steyer,Bernie Sanders,Amy Klobuchar,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,43,1,18,,Precinct 1,Bernie Sanders,Elizabeth Warren,Tulsi Gabbard,Joseph R. Biden,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,43,1,19,,Precinct 1,Bernie Sanders,Amy Klobuchar,Joseph R. Biden,Michael R. Bloomberg,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,43,1,20,,Precinct 1,Michael R. Bloomberg,Elizabeth Warren,Joseph R. Biden,Amy Klobuchar,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,9,1,1,,Precinct 1,Elizabeth Warren,Michael R. Bloomberg,12,Tulsi Gabbard,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,9,1,2,,Precinct 1,Bernie Sanders,Tulsi Gabbard,Michael R. Bloomberg,12,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,9,1,3,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,9,1,4,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,9,1,5,,Precinct 1,Elizabeth Warren,Tulsi Gabbard,12,Michael R. Bloomberg,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,9,1,6,,Precinct 1,Elizabeth Warren,Amy Klobuchar,Tulsi Gabbard,Tom Steyer,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,9,1,7,,Precinct 1,Pete Buttigieg,Amy Klobuchar,Michael R. Bloomberg,Bernie Sanders,12
+../_shared/dominion_alaska/alaska_input_data,1,9,1,8,,Precinct 1,Bernie Sanders,12,Elizabeth Warren,Michael R. Bloomberg,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,9,1,9,,Precinct 1,Bernie Sanders,Michael R. Bloomberg,Amy Klobuchar,Elizabeth Warren,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,9,1,10,,Precinct 1,Tulsi Gabbard,Joseph R. Biden,Elizabeth Warren,Michael R. Bloomberg,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,9,1,11,,Precinct 1,Elizabeth Warren,Pete Buttigieg,Michael R. Bloomberg,12,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,9,1,12,,Precinct 1,Tom Steyer,Michael R. Bloomberg,Bernie Sanders,Elizabeth Warren,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,9,1,13,,Precinct 1,12,Tulsi Gabbard,Bernie Sanders,Amy Klobuchar,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,9,1,14,,Precinct 1,12,Elizabeth Warren,Tulsi Gabbard,Tom Steyer,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,9,1,15,,Precinct 1,Amy Klobuchar,Bernie Sanders,12,Elizabeth Warren,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,9,1,16,,Precinct 1,Tom Steyer,Bernie Sanders,Tulsi Gabbard,12,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,9,1,17,,Precinct 1,Elizabeth Warren,Tulsi Gabbard,Michael R. Bloomberg,Bernie Sanders,12
+../_shared/dominion_alaska/alaska_input_data,1,9,1,18,,Precinct 1,Bernie Sanders,Elizabeth Warren,Joseph R. Biden,Amy Klobuchar,12
+../_shared/dominion_alaska/alaska_input_data,1,9,1,19,,Precinct 1,12,Amy Klobuchar,Joseph R. Biden,Bernie Sanders,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,9,1,20,,Precinct 1,Tom Steyer,Amy Klobuchar,Joseph R. Biden,Bernie Sanders,12
+../_shared/dominion_alaska/alaska_input_data,1,4,1,1,,Precinct 1,Michael R. Bloomberg,Elizabeth Warren,Tom Steyer,Pete Buttigieg,12
+../_shared/dominion_alaska/alaska_input_data,1,4,1,2,,Precinct 1,Pete Buttigieg,Joseph R. Biden,Amy Klobuchar,Tom Steyer,12
+../_shared/dominion_alaska/alaska_input_data,1,4,1,3,,Precinct 1,Amy Klobuchar,Bernie Sanders,Tom Steyer,Tulsi Gabbard,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,4,1,4,,Precinct 1,Amy Klobuchar,Bernie Sanders,Tulsi Gabbard,12,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,4,1,5,,Precinct 1,Tom Steyer,Amy Klobuchar,Tulsi Gabbard,Michael R. Bloomberg,12
+../_shared/dominion_alaska/alaska_input_data,1,4,1,6,,Precinct 1,Joseph R. Biden,Tom Steyer,Tulsi Gabbard,Pete Buttigieg,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,4,1,7,,Precinct 1,Pete Buttigieg,Michael R. Bloomberg,Bernie Sanders,Joseph R. Biden,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,4,1,8,,Precinct 1,Tulsi Gabbard,12,Tom Steyer,Amy Klobuchar,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,4,1,9,,Precinct 1,Joseph R. Biden,Amy Klobuchar,Michael R. Bloomberg,Tulsi Gabbard,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,4,1,10,,Precinct 1,Pete Buttigieg,Joseph R. Biden,12,Tulsi Gabbard,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,4,1,11,,Precinct 1,Amy Klobuchar,Tom Steyer,Pete Buttigieg,Michael R. Bloomberg,12
+../_shared/dominion_alaska/alaska_input_data,1,4,1,12,,Precinct 1,Tom Steyer,Amy Klobuchar,Joseph R. Biden,Bernie Sanders,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,4,1,13,,Precinct 1,Michael R. Bloomberg,Tom Steyer,Joseph R. Biden,Elizabeth Warren,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,4,1,14,,Precinct 1,Pete Buttigieg,Amy Klobuchar,Michael R. Bloomberg,Tulsi Gabbard,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,4,1,15,,Precinct 1,Elizabeth Warren,Tulsi Gabbard,Pete Buttigieg,Bernie Sanders,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,4,1,16,,Precinct 1,12,Elizabeth Warren,Tom Steyer,Amy Klobuchar,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,4,1,17,,Precinct 1,12,Joseph R. Biden,Amy Klobuchar,Elizabeth Warren,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,4,1,18,,Precinct 1,Amy Klobuchar,Tom Steyer,Elizabeth Warren,Tulsi Gabbard,12
+../_shared/dominion_alaska/alaska_input_data,1,4,1,19,,Precinct 1,Amy Klobuchar,Joseph R. Biden,Tulsi Gabbard,Michael R. Bloomberg,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,4,1,20,,Precinct 1,Michael R. Bloomberg,Joseph R. Biden,Tulsi Gabbard,Amy Klobuchar,12
+../_shared/dominion_alaska/alaska_input_data,1,8,1,1,,Precinct 1,Tom Steyer,12,Michael R. Bloomberg,Pete Buttigieg,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,8,1,2,,Precinct 1,Amy Klobuchar,Michael R. Bloomberg,Pete Buttigieg,Tulsi Gabbard,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,8,1,3,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,8,1,4,,Precinct 1,Joseph R. Biden,Tulsi Gabbard,Amy Klobuchar,12,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,8,1,5,,Precinct 1,Tulsi Gabbard,Bernie Sanders,Michael R. Bloomberg,Joseph R. Biden,12
+../_shared/dominion_alaska/alaska_input_data,1,8,1,6,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,8,1,7,,Precinct 1,Amy Klobuchar,Pete Buttigieg,Michael R. Bloomberg,Elizabeth Warren,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,8,1,8,,Precinct 1,Bernie Sanders,Elizabeth Warren,12,Tom Steyer,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,8,1,9,,Precinct 1,Tulsi Gabbard,Michael R. Bloomberg,Amy Klobuchar,12,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,8,1,10,,Precinct 1,Elizabeth Warren,12,Pete Buttigieg,Tom Steyer,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,8,1,11,,Precinct 1,Bernie Sanders,Tulsi Gabbard,Amy Klobuchar,12,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,8,1,12,,Precinct 1,Bernie Sanders,Elizabeth Warren,Tom Steyer,Tulsi Gabbard,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,8,1,13,,Precinct 1,Joseph R. Biden,Tom Steyer,Bernie Sanders,Pete Buttigieg,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,8,1,14,,Precinct 1,Tulsi Gabbard,Joseph R. Biden,Elizabeth Warren,"Bernie Sanders
+Amy Klobuchar",Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,8,1,15,,Precinct 1,Bernie Sanders,Tulsi Gabbard,Tom Steyer,Amy Klobuchar,12
+../_shared/dominion_alaska/alaska_input_data,1,8,1,16,,Precinct 1,Bernie Sanders,Tulsi Gabbard,Amy Klobuchar,Elizabeth Warren,12
+../_shared/dominion_alaska/alaska_input_data,1,8,1,17,,Precinct 1,Pete Buttigieg,Michael R. Bloomberg,Tulsi Gabbard,Elizabeth Warren,12
+../_shared/dominion_alaska/alaska_input_data,1,8,1,18,,Precinct 1,Bernie Sanders,Elizabeth Warren,Michael R. Bloomberg,Pete Buttigieg,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,8,1,19,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,8,1,20,,Precinct 1,Tulsi Gabbard,Elizabeth Warren,12,Amy Klobuchar,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,7,1,1,,Precinct 1,Joseph R. Biden,12,Michael R. Bloomberg,Tulsi Gabbard,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,7,1,2,,Precinct 1,Michael R. Bloomberg,Joseph R. Biden,Tom Steyer,Amy Klobuchar,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,7,1,3,,Precinct 1,Amy Klobuchar,Joseph R. Biden,12,Tulsi Gabbard,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,7,1,4,,Precinct 1,12,Pete Buttigieg,Tulsi Gabbard,Bernie Sanders,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,7,1,5,,Precinct 1,Amy Klobuchar,Michael R. Bloomberg,Joseph R. Biden,Pete Buttigieg,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,7,1,6,,Precinct 1,Michael R. Bloomberg,Tom Steyer,Bernie Sanders,Joseph R. Biden,12
+../_shared/dominion_alaska/alaska_input_data,1,7,1,7,,Precinct 1,Michael R. Bloomberg,Amy Klobuchar,Tulsi Gabbard,12,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,7,1,8,,Precinct 1,Michael R. Bloomberg,Amy Klobuchar,Pete Buttigieg,Joseph R. Biden,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,7,1,9,,Precinct 1,Tom Steyer,Tulsi Gabbard,Elizabeth Warren,12,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,7,1,10,,Precinct 1,Michael R. Bloomberg,Bernie Sanders,Tulsi Gabbard,Pete Buttigieg,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,7,1,11,,Precinct 1,Michael R. Bloomberg,Pete Buttigieg,Bernie Sanders,Tom Steyer,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,7,1,12,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,7,1,13,,Precinct 1,Joseph R. Biden,Pete Buttigieg,Elizabeth Warren,Michael R. Bloomberg,12
+../_shared/dominion_alaska/alaska_input_data,1,7,1,14,,Precinct 1,Bernie Sanders,Tom Steyer,Michael R. Bloomberg,Amy Klobuchar,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,7,1,15,,Precinct 1,Tom Steyer,Amy Klobuchar,Michael R. Bloomberg,Bernie Sanders,12
+../_shared/dominion_alaska/alaska_input_data,1,7,1,16,,Precinct 1,Pete Buttigieg,Amy Klobuchar,Michael R. Bloomberg,Bernie Sanders,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,7,1,17,,Precinct 1,Bernie Sanders,Amy Klobuchar,Tom Steyer,Joseph R. Biden,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,7,1,18,,Precinct 1,Joseph R. Biden,12,Amy Klobuchar,Pete Buttigieg,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,7,1,19,,Precinct 1,Tom Steyer,Tulsi Gabbard,Amy Klobuchar,Pete Buttigieg,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,7,1,20,,Precinct 1,Amy Klobuchar,Tulsi Gabbard,Tom Steyer,Elizabeth Warren,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,28,1,1,,Precinct 1,Amy Klobuchar,Michael R. Bloomberg,Tulsi Gabbard,Pete Buttigieg,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,28,1,2,,Precinct 1,Tom Steyer,undervote,Elizabeth Warren,Pete Buttigieg,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,28,1,3,,Precinct 1,Joseph R. Biden,Elizabeth Warren,Michael R. Bloomberg,12,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,28,1,4,,Precinct 1,Joseph R. Biden,Bernie Sanders,Tom Steyer,Michael R. Bloomberg,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,28,1,5,,Precinct 1,Amy Klobuchar,Michael R. Bloomberg,Joseph R. Biden,12,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,28,1,6,,Precinct 1,12,Michael R. Bloomberg,Tom Steyer,Amy Klobuchar,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,28,1,7,,Precinct 1,Bernie Sanders,Elizabeth Warren,Tom Steyer,Joseph R. Biden,12
+../_shared/dominion_alaska/alaska_input_data,1,28,1,8,,Precinct 1,Tulsi Gabbard,Amy Klobuchar,12,Pete Buttigieg,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,28,1,9,,Precinct 1,Bernie Sanders,12,Tom Steyer,Tulsi Gabbard,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,28,1,10,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,28,1,11,,Precinct 1,12,Tulsi Gabbard,Elizabeth Warren,Bernie Sanders,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,28,1,12,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,28,1,13,,Precinct 1,Tom Steyer,Bernie Sanders,Joseph R. Biden,Michael R. Bloomberg,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,28,1,14,,Precinct 1,Amy Klobuchar,12,Elizabeth Warren,Pete Buttigieg,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,28,1,15,,Precinct 1,Bernie Sanders,Michael R. Bloomberg,Pete Buttigieg,Tulsi Gabbard,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,28,1,16,,Precinct 1,Pete Buttigieg,Joseph R. Biden,Elizabeth Warren,12,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,28,1,17,,Precinct 1,Joseph R. Biden,Michael R. Bloomberg,Amy Klobuchar,Elizabeth Warren,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,28,1,18,,Precinct 1,Michael R. Bloomberg,Tom Steyer,Amy Klobuchar,12,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,28,1,19,,Precinct 1,Michael R. Bloomberg,Amy Klobuchar,12,Bernie Sanders,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,28,1,20,,Precinct 1,Michael R. Bloomberg,Bernie Sanders,Amy Klobuchar,Pete Buttigieg,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,6,1,1,,Precinct 1,Elizabeth Warren,Tom Steyer,Tulsi Gabbard,Pete Buttigieg,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,6,1,2,,Precinct 1,Michael R. Bloomberg,Amy Klobuchar,Tom Steyer,12,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,6,1,3,,Precinct 1,Amy Klobuchar,Tulsi Gabbard,Pete Buttigieg,Bernie Sanders,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,6,1,4,,Precinct 1,Tulsi Gabbard,Michael R. Bloomberg,12,Pete Buttigieg,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,6,1,5,,Precinct 1,"Joseph R. Biden
+Amy Klobuchar
+Tulsi Gabbard
+Michael R. Bloomberg
+Pete Buttigieg
+12",Tom Steyer,Elizabeth Warren,Bernie Sanders,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,6,1,6,,Precinct 1,12,Tulsi Gabbard,Pete Buttigieg,Michael R. Bloomberg,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,6,1,7,,Precinct 1,Michael R. Bloomberg,Tulsi Gabbard,Bernie Sanders,Joseph R. Biden,12
+../_shared/dominion_alaska/alaska_input_data,1,6,1,8,,Precinct 1,Joseph R. Biden,12,Pete Buttigieg,Tulsi Gabbard,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,6,1,9,,Precinct 1,Elizabeth Warren,Michael R. Bloomberg,Amy Klobuchar,Tom Steyer,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,6,1,10,,Precinct 1,12,Michael R. Bloomberg,Amy Klobuchar,Pete Buttigieg,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,6,1,11,,Precinct 1,Michael R. Bloomberg,12,Elizabeth Warren,Amy Klobuchar,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,6,1,12,,Precinct 1,Tom Steyer,Joseph R. Biden,12,Pete Buttigieg,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,6,1,13,,Precinct 1,Pete Buttigieg,Elizabeth Warren,Joseph R. Biden,12,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,6,1,14,,Precinct 1,Tulsi Gabbard,Amy Klobuchar,Bernie Sanders,Elizabeth Warren,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,6,1,15,,Precinct 1,Pete Buttigieg,Michael R. Bloomberg,Amy Klobuchar,Elizabeth Warren,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,6,1,16,,Precinct 1,Joseph R. Biden,12,Pete Buttigieg,Elizabeth Warren,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,6,1,17,,Precinct 1,Tulsi Gabbard,Pete Buttigieg,12,Tom Steyer,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,6,1,18,,Precinct 1,Tulsi Gabbard,12,Amy Klobuchar,Elizabeth Warren,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,6,1,19,,Precinct 1,Tom Steyer,Tulsi Gabbard,Amy Klobuchar,12,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,6,1,20,,Precinct 1,Pete Buttigieg,Tom Steyer,Joseph R. Biden,Michael R. Bloomberg,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,5,1,1,,Precinct 1,Tom Steyer,Tulsi Gabbard,Amy Klobuchar,Pete Buttigieg,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,5,1,2,,Precinct 1,Pete Buttigieg,Elizabeth Warren,Bernie Sanders,Tulsi Gabbard,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,5,1,3,,Precinct 1,Amy Klobuchar,Pete Buttigieg,Tulsi Gabbard,Tom Steyer,12
+../_shared/dominion_alaska/alaska_input_data,1,5,1,4,,Precinct 1,12,Tulsi Gabbard,Tom Steyer,Amy Klobuchar,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,5,1,5,,Precinct 1,12,Michael R. Bloomberg,Tulsi Gabbard,Tom Steyer,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,5,1,6,,Precinct 1,Elizabeth Warren,Michael R. Bloomberg,12,Amy Klobuchar,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,5,1,7,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,5,1,8,,Precinct 1,Tom Steyer,Michael R. Bloomberg,12,Elizabeth Warren,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,5,1,9,,Precinct 1,Amy Klobuchar,12,Bernie Sanders,Pete Buttigieg,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,5,1,10,,Precinct 1,Bernie Sanders,Pete Buttigieg,12,Elizabeth Warren,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,5,1,11,,Precinct 1,Bernie Sanders,Michael R. Bloomberg,Tom Steyer,Pete Buttigieg,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,5,1,12,,Precinct 1,Pete Buttigieg,Elizabeth Warren,Tom Steyer,Amy Klobuchar,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,5,1,13,,Precinct 1,Pete Buttigieg,Amy Klobuchar,Tulsi Gabbard,Tom Steyer,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,5,1,14,,Precinct 1,Tulsi Gabbard,Elizabeth Warren,Michael R. Bloomberg,Pete Buttigieg,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,5,1,15,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,5,1,16,,Precinct 1,Joseph R. Biden,Amy Klobuchar,Tulsi Gabbard,Pete Buttigieg,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,5,1,17,,Precinct 1,Bernie Sanders,Tom Steyer,Pete Buttigieg,Elizabeth Warren,12
+../_shared/dominion_alaska/alaska_input_data,1,5,1,18,,Precinct 1,Pete Buttigieg,Elizabeth Warren,12,Tom Steyer,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,5,1,19,,Precinct 1,Bernie Sanders,Tulsi Gabbard,Michael R. Bloomberg,Pete Buttigieg,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,5,1,20,,Precinct 1,Joseph R. Biden,Pete Buttigieg,Amy Klobuchar,Elizabeth Warren,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,3,1,1,,Precinct 1,Amy Klobuchar,Elizabeth Warren,Tom Steyer,Bernie Sanders,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,3,1,2,,Precinct 1,Tulsi Gabbard,Pete Buttigieg,12,Amy Klobuchar,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,3,1,3,,Precinct 1,Bernie Sanders,Amy Klobuchar,12,Michael R. Bloomberg,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,3,1,4,,Precinct 1,Joseph R. Biden,Tulsi Gabbard,Bernie Sanders,Amy Klobuchar,12
+../_shared/dominion_alaska/alaska_input_data,1,3,1,5,,Precinct 1,Pete Buttigieg,Joseph R. Biden,Tom Steyer,Amy Klobuchar,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,3,1,6,,Precinct 1,Pete Buttigieg,Joseph R. Biden,12,Elizabeth Warren,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,3,1,7,,Precinct 1,Elizabeth Warren,Tulsi Gabbard,Joseph R. Biden,Amy Klobuchar,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,3,1,8,,Precinct 1,Bernie Sanders,Pete Buttigieg,Tulsi Gabbard,Joseph R. Biden,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,3,1,9,,Precinct 1,Joseph R. Biden,Tulsi Gabbard,Tom Steyer,Amy Klobuchar,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,3,1,10,,Precinct 1,Elizabeth Warren,Joseph R. Biden,Amy Klobuchar,Tulsi Gabbard,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,3,1,11,,Precinct 1,Pete Buttigieg,Tulsi Gabbard,Amy Klobuchar,12,Tom Steyer
+../_shared/dominion_alaska/alaska_input_data,1,3,1,12,,Precinct 1,Bernie Sanders,Michael R. Bloomberg,Joseph R. Biden,Tom Steyer,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,3,1,13,,Precinct 1,undervote,undervote,undervote,undervote,undervote
+../_shared/dominion_alaska/alaska_input_data,1,3,1,14,,Precinct 1,Elizabeth Warren,Bernie Sanders,Pete Buttigieg,Amy Klobuchar,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,3,1,15,,Precinct 1,Pete Buttigieg,12,Elizabeth Warren,Joseph R. Biden,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,3,1,16,,Precinct 1,Tom Steyer,Amy Klobuchar,Elizabeth Warren,Pete Buttigieg,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,3,1,17,,Precinct 1,Michael R. Bloomberg,Amy Klobuchar,Elizabeth Warren,Tulsi Gabbard,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,3,1,18,,Precinct 1,Michael R. Bloomberg,Pete Buttigieg,Joseph R. Biden,Elizabeth Warren,12
+../_shared/dominion_alaska/alaska_input_data,1,3,1,19,,Precinct 1,Michael R. Bloomberg,Elizabeth Warren,12,Pete Buttigieg,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,3,1,20,,Precinct 1,Joseph R. Biden,Bernie Sanders,Tom Steyer,Tulsi Gabbard,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,2,1,1,,Precinct 1,12,Michael R. Bloomberg,Pete Buttigieg,Bernie Sanders,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,2,1,2,,Precinct 1,Elizabeth Warren,Tom Steyer,Joseph R. Biden,Bernie Sanders,Tulsi Gabbard
+../_shared/dominion_alaska/alaska_input_data,1,2,1,3,,Precinct 1,Bernie Sanders,Michael R. Bloomberg,Elizabeth Warren,Tulsi Gabbard,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,2,1,4,,Precinct 1,Tulsi Gabbard,Bernie Sanders,Elizabeth Warren,Pete Buttigieg,12
+../_shared/dominion_alaska/alaska_input_data,1,2,1,5,,Precinct 1,Joseph R. Biden,Michael R. Bloomberg,12,Amy Klobuchar,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,2,1,6,,Precinct 1,Bernie Sanders,Amy Klobuchar,Tulsi Gabbard,12,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,2,1,7,,Precinct 1,12,Joseph R. Biden,Tom Steyer,Michael R. Bloomberg,Amy Klobuchar
+../_shared/dominion_alaska/alaska_input_data,1,2,1,8,,Precinct 1,Elizabeth Warren,12,Tom Steyer,Tulsi Gabbard,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,2,1,9,,Precinct 1,Elizabeth Warren,Amy Klobuchar,Tom Steyer,Tulsi Gabbard,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,2,1,10,,Precinct 1,Amy Klobuchar,Joseph R. Biden,Elizabeth Warren,Pete Buttigieg,Bernie Sanders
+../_shared/dominion_alaska/alaska_input_data,1,2,1,11,,Precinct 1,Amy Klobuchar,Joseph R. Biden,Tulsi Gabbard,Pete Buttigieg,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,2,1,12,,Precinct 1,Amy Klobuchar,Bernie Sanders,Tom Steyer,Michael R. Bloomberg,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,2,1,13,,Precinct 1,Tom Steyer,12,Elizabeth Warren,Pete Buttigieg,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,2,1,14,,Precinct 1,Tulsi Gabbard,Michael R. Bloomberg,Pete Buttigieg,Joseph R. Biden,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,2,1,15,,Precinct 1,Bernie Sanders,Amy Klobuchar,Joseph R. Biden,Tulsi Gabbard,Michael R. Bloomberg
+../_shared/dominion_alaska/alaska_input_data,1,2,1,16,,Precinct 1,Tom Steyer,Pete Buttigieg,12,Bernie Sanders,Elizabeth Warren
+../_shared/dominion_alaska/alaska_input_data,1,2,1,17,,Precinct 1,12,Bernie Sanders,Amy Klobuchar,Tulsi Gabbard,Joseph R. Biden
+../_shared/dominion_alaska/alaska_input_data,1,2,1,18,,Precinct 1,Michael R. Bloomberg,Elizabeth Warren,Joseph R. Biden,Tom Steyer,12
+../_shared/dominion_alaska/alaska_input_data,1,2,1,19,,Precinct 1,Tom Steyer,Michael R. Bloomberg,Joseph R. Biden,Elizabeth Warren,Pete Buttigieg
+../_shared/dominion_alaska/alaska_input_data,1,2,1,20,,Precinct 1,Michael R. Bloomberg,12,Tom Steyer,Amy Klobuchar,Bernie Sanders

--- a/src/test/resources/network/brightspots/rcv/test_data/convert_to_cdf_from_ess/convert_to_cdf_from_ess_expected.csv
+++ b/src/test/resources/network/brightspots/rcv/test_data/convert_to_cdf_from_ess/convert_to_cdf_from_ess_expected.csv
@@ -1,11 +1,11 @@
-Contest Id,Tabulator Id,Batch Id,Record Id,Precinct,Precinct Portion,Rank 1,Rank 2,Rank 3
-,,,simple_ess_cvr.xlsx-1,,,Mookie Blaylock,undervote,undervote
-,,,simple_ess_cvr.xlsx-2,,,Mookie Blaylock,undervote,undervote
-,,,simple_ess_cvr.xlsx-3,,,Mookie Blaylock,undervote,undervote
-,,,simple_ess_cvr.xlsx-4,,,Mookie Blaylock,undervote,undervote
-,,,simple_ess_cvr.xlsx-5,,,Yinka Dare,undervote,undervote
-,,,simple_ess_cvr.xlsx-6,,,Yinka Dare,undervote,undervote
-,,,simple_ess_cvr.xlsx-7,,,Yinka Dare,undervote,undervote
-,,,simple_ess_cvr.xlsx-8,,,George Gervin,undervote,undervote
-,,,simple_ess_cvr.xlsx-9,,,George Gervin,Yinka Dare,undervote
-,,,simple_ess_cvr.xlsx-10,,,Sedale Threatt,George Gervin,undervote
+Source Filepath,Contest Id,Tabulator Id,Batch Id,Record Id,Precinct,Precinct Portion,Rank 1,Rank 2,Rank 3
+../_shared/simple_ess_cvr.xlsx,,,,simple_ess_cvr.xlsx-1,,,Mookie Blaylock,undervote,undervote
+../_shared/simple_ess_cvr.xlsx,,,,simple_ess_cvr.xlsx-2,,,Mookie Blaylock,undervote,undervote
+../_shared/simple_ess_cvr.xlsx,,,,simple_ess_cvr.xlsx-3,,,Mookie Blaylock,undervote,undervote
+../_shared/simple_ess_cvr.xlsx,,,,simple_ess_cvr.xlsx-4,,,Mookie Blaylock,undervote,undervote
+../_shared/simple_ess_cvr.xlsx,,,,simple_ess_cvr.xlsx-5,,,Yinka Dare,undervote,undervote
+../_shared/simple_ess_cvr.xlsx,,,,simple_ess_cvr.xlsx-6,,,Yinka Dare,undervote,undervote
+../_shared/simple_ess_cvr.xlsx,,,,simple_ess_cvr.xlsx-7,,,Yinka Dare,undervote,undervote
+../_shared/simple_ess_cvr.xlsx,,,,simple_ess_cvr.xlsx-8,,,George Gervin,undervote,undervote
+../_shared/simple_ess_cvr.xlsx,,,,simple_ess_cvr.xlsx-9,,,George Gervin,Yinka Dare,undervote
+../_shared/simple_ess_cvr.xlsx,,,,simple_ess_cvr.xlsx-10,,,Sedale Threatt,George Gervin,undervote


### PR DESCRIPTION
Closes #753 

1. Adds the source name to the "RCTab CVR CSV"
2. Removes the term "overvotes" and instead includes newline-separated values in case of an overvote
3. Resolve #777