### PR TITLE
check if ranking is allowed rather than using unacceptable default

### DIFF
--- a/src/main/java/network/brightspots/rcv/BaseCvrReader.java
+++ b/src/main/java/network/brightspots/rcv/BaseCvrReader.java
@@ -46,7 +46,15 @@ abstract class BaseCvrReader {
 
   // Any reader-specific validations can override this function.
   public void runAdditionalValidations(List<CastVoteRecord> castVoteRecords)
-      throws CastVoteRecord.CvrParseException {}
+      throws CastVoteRecord.CvrParseException {
+    for (CastVoteRecord cvr : castVoteRecords) {
+      for (Pair<Integer, CandidatesAtRanking> ranking : cvr.candidateRankings) {
+        if (!this.config.isRankingAllowed(ranking.getKey())) {
+          throw new CastVoteRecord.CvrParseException();
+        }
+      }
+    }
+  }
 
   // Gather candidate names from the CVR that are not in the config.
   Map<String, Integer> gatherUnknownCandidates(List<CastVoteRecord> castVoteRecords) {

--- a/src/main/java/network/brightspots/rcv/BaseCvrReader.java
+++ b/src/main/java/network/brightspots/rcv/BaseCvrReader.java
@@ -40,8 +40,8 @@ abstract class BaseCvrReader {
       throws CastVoteRecord.CvrParseException, IOException;
 
   // Individual contests may have a different value than what the config allows.
-  public Integer getMaxRankingsAllowed(String contestId) {
-    return config.getMaxRankingsAllowed();
+  public boolean isRankingAllowed(int rank, String contestId) {
+    return config.isRankingAllowed(rank);
   }
 
   // Any reader-specific validations can override this function.

--- a/src/main/java/network/brightspots/rcv/ClearBallotCvrReader.java
+++ b/src/main/java/network/brightspots/rcv/ClearBallotCvrReader.java
@@ -82,7 +82,9 @@ class ClearBallotCvrReader extends BaseCvrReader {
           choiceName = Tabulator.UNDECLARED_WRITE_IN_OUTPUT_LABEL;
         }
         Integer rank = Integer.parseInt(choiceFields[RcvChoiceHeaderField.RANK.ordinal()]);
-        columnIndexToRanking.put(columnIndex, new Pair<>(rank, choiceName));
+        if (this.config.isRankingAllowed(rank)) {
+          columnIndexToRanking.put(columnIndex, new Pair<>(rank, choiceName));
+        }
       }
       // read all remaining rows and create CastVoteRecords for each one
       while (true) {

--- a/src/main/java/network/brightspots/rcv/ClearBallotCvrReader.java
+++ b/src/main/java/network/brightspots/rcv/ClearBallotCvrReader.java
@@ -82,12 +82,6 @@ class ClearBallotCvrReader extends BaseCvrReader {
           choiceName = Tabulator.UNDECLARED_WRITE_IN_OUTPUT_LABEL;
         }
         Integer rank = Integer.parseInt(choiceFields[RcvChoiceHeaderField.RANK.ordinal()]);
-        if (!this.config.isRankingAllowed(rank)) {
-          Logger.severe(
-              "Rank: %d exceeds max rankings allowed in config: %s",
-              rank, this.config.getMaxRankingsAllowedAsString());
-          throw new CvrParseException();
-        }
         columnIndexToRanking.put(columnIndex, new Pair<>(rank, choiceName));
       }
       // read all remaining rows and create CastVoteRecords for each one

--- a/src/main/java/network/brightspots/rcv/ClearBallotCvrReader.java
+++ b/src/main/java/network/brightspots/rcv/ClearBallotCvrReader.java
@@ -82,10 +82,10 @@ class ClearBallotCvrReader extends BaseCvrReader {
           choiceName = Tabulator.UNDECLARED_WRITE_IN_OUTPUT_LABEL;
         }
         Integer rank = Integer.parseInt(choiceFields[RcvChoiceHeaderField.RANK.ordinal()]);
-        if (rank > this.config.getMaxRankingsAllowed()) {
+        if (!this.config.isRankingAllowed(rank)) {
           Logger.severe(
-              "Rank: %d exceeds max rankings allowed in config: %d",
-              rank, this.config.getMaxRankingsAllowed());
+              "Rank: %d exceeds max rankings allowed in config: %s",
+              rank, this.config.getMaxRankingsAllowedAsString());
           throw new CvrParseException();
         }
         columnIndexToRanking.put(columnIndex, new Pair<>(rank, choiceName));

--- a/src/main/java/network/brightspots/rcv/ContestConfig.java
+++ b/src/main/java/network/brightspots/rcv/ContestConfig.java
@@ -994,6 +994,10 @@ class ContestConfig {
   // Instead of returning the max rank, only allow checking via this function,
   // or returning the value as a string for audit logging.
   boolean isRankingAllowed(int rank) {
+    if (rank <= 0) {
+      return false;
+    }
+
     if (isMaxRankingsSetToMaximum()) {
       return true;
     }

--- a/src/main/java/network/brightspots/rcv/ContestConfig.java
+++ b/src/main/java/network/brightspots/rcv/ContestConfig.java
@@ -988,9 +988,13 @@ class ContestConfig {
     return rawConfig.rules.maxRankingsAllowed;
   }
 
-  // Because the max rank can be set to "max", there's no reasonable value we can
-  // return outward. Returning MAX_VALUE could cause integer overflows if
-  // the caller tries to do arithmetic with the result (e.g. convert to a max column)
+  // Because the max rank can be set to "max", there's no single value that makes sense
+  // to all callers of this function.
+  // Returning MAX_VALUE could cause integer overflows if
+  // the caller tries to do arithmetic with the result (e.g. convert to a max column),
+  // or if the caller is iterating for all values up until the max rank.
+  // Returning NumDeclaredCandidates is not valid in cases where this is used before
+  // candidates are declared.
   // Instead of returning the max rank, only allow checking via this function,
   // or returning the value as a string for audit logging.
   boolean isRankingAllowed(int rank) {
@@ -1005,10 +1009,11 @@ class ContestConfig {
     return rank <= Integer.parseInt(getMaxRankingsAllowedRaw());
   }
 
-  // There are times when it is necessary to grab the max ranking, though:
-  // notably, when writing outputs up until the max ranking, or when
-  // reading inputs where a "blank" indicates an undeclared write-in.
-  // Handle that, but ensure the caller has checked if it's set to "max"
+  // There are times when it is necessary to grab the max ranking, for example,
+  // when iterating up until the max ranking, or when reading inputs where a
+  // "blank" indicates an undeclared write-in.
+  // Force the caller of this function to check isMaxRankingsSetToMaximum first,
+  // so we know they've handled that special case.
   Integer getMaxRankingsAllowedWhenNotSetToMaximum() {
     if (isMaxRankingsSetToMaximum()) {
       throw new RuntimeException(

--- a/src/main/java/network/brightspots/rcv/ContestConfig.java
+++ b/src/main/java/network/brightspots/rcv/ContestConfig.java
@@ -678,9 +678,9 @@ class ContestConfig {
       Logger.severe("Invalid winnerElectionMode!");
     }
 
-    if (getMaxRankingsAllowed() == null
+    if (getMaxRankingsAllowedAsString() == null
         || (getNumDeclaredCandidates() >= 1
-            && getMaxRankingsAllowed() < MIN_MAX_RANKINGS_ALLOWED)) {
+            && !isRankingAllowed(MIN_MAX_RANKINGS_ALLOWED))) {
       validationErrors.add(ValidationError.RULES_MAX_RANKINGS_ALLOWED_INVALID);
       Logger.severe(
           "maxRankingsAllowed must either be \"%s\" or an integer from %d to %d!",
@@ -988,11 +988,38 @@ class ContestConfig {
     return rawConfig.rules.maxRankingsAllowed;
   }
 
-  Integer getMaxRankingsAllowed() {
-    return stringToIntWithOption(
-        getMaxRankingsAllowedRaw(),
-        MAX_RANKINGS_ALLOWED_NUM_CANDIDATES_OPTION,
-        getNumDeclaredCandidates());
+  // Because the max rank can be set to "max", there's no reasonable value we can
+  // return outward. Returning MAX_VALUE could cause integer overflows if
+  // the caller tries to do arithmetic with the result (e.g. convert to a max column)
+  // Instead of returning the max rank, only allow checking via this function,
+  // or returning the value as a string for audit logging.
+  boolean isRankingAllowed(int rank) {
+    if (isMaxRankingsSetToMaximum()) {
+      return true;
+    }
+
+    return rank <= Integer.parseInt(getMaxRankingsAllowedRaw());
+  }
+
+  // There are times when it is necessary to grab the max ranking, though:
+  // notably, when writing outputs up until the max ranking, or when
+  // reading inputs where a "blank" indicates an undeclared write-in.
+  // Handle that, but ensure the caller has checked if it's set to "max"
+  Integer getMaxRankingsAllowedWhenNotSetToMaximum() {
+    if (isMaxRankingsSetToMaximum()) {
+      throw new RuntimeException(
+              "Do not call this function without first checking isMaxRankingsSetToMaximum!");
+    }
+
+    return Integer.parseInt(getMaxRankingsAllowedRaw());
+  }
+
+  boolean isMaxRankingsSetToMaximum() {
+    return getMaxRankingsAllowedRaw().equals(MAX_RANKINGS_ALLOWED_NUM_CANDIDATES_OPTION);
+  }
+
+  String getMaxRankingsAllowedAsString() {
+    return getMaxRankingsAllowedRaw();
   }
 
   boolean isBatchEliminationEnabled() {

--- a/src/main/java/network/brightspots/rcv/DominionCvrReader.java
+++ b/src/main/java/network/brightspots/rcv/DominionCvrReader.java
@@ -176,7 +176,7 @@ class DominionCvrReader extends BaseCvrReader {
 
   @Override
   public boolean isRankingAllowed(int rank, String contestId) {
-    return rank <= contests.get(contestId).getMaxRanks();
+    return rank > 0 && rank <= contests.get(contestId).getMaxRanks();
   }
 
   private void validateNamesAreInContest(List<CastVoteRecord> castVoteRecords)

--- a/src/main/java/network/brightspots/rcv/DominionCvrReader.java
+++ b/src/main/java/network/brightspots/rcv/DominionCvrReader.java
@@ -175,8 +175,8 @@ class DominionCvrReader extends BaseCvrReader {
   }
 
   @Override
-  public Integer getMaxRankingsAllowed(String contestId) {
-    return contests.get(contestId).getMaxRanks();
+  public boolean isRankingAllowed(int rank, String contestId) {
+    return rank <= contests.get(contestId).getMaxRanks();
   }
 
   private void validateNamesAreInContest(List<CastVoteRecord> castVoteRecords)

--- a/src/main/java/network/brightspots/rcv/DominionCvrReader.java
+++ b/src/main/java/network/brightspots/rcv/DominionCvrReader.java
@@ -171,6 +171,7 @@ class DominionCvrReader extends BaseCvrReader {
   @Override
   public void runAdditionalValidations(List<CastVoteRecord> castVoteRecords)
       throws CastVoteRecord.CvrParseException {
+    super.runAdditionalValidations(castVoteRecords);
     validateNamesAreInContest(castVoteRecords);
   }
 

--- a/src/main/java/network/brightspots/rcv/ResultsWriter.java
+++ b/src/main/java/network/brightspots/rcv/ResultsWriter.java
@@ -542,7 +542,8 @@ class ResultsWriter {
   // returns the filepath written
   String writeGenericCvrCsv(
       List<CastVoteRecord> castVoteRecords,
-      Integer numRanks,
+      CvrSource source,
+      BaseCvrReader reader,
       String csvOutputFolder,
       String inputFilepath,
       String contestId,
@@ -581,7 +582,11 @@ class ResultsWriter {
       csvPrinter.print("Record Id");
       csvPrinter.print("Precinct");
       csvPrinter.print("Precinct Portion");
-      for (int rank = 1; rank <= numRanks; rank++) {
+      int maxRank = 0;
+      for (CastVoteRecord castVoteRecord : castVoteRecords) {
+        maxRank = Math.max(maxRank, castVoteRecord.candidateRankings.maxRankingNumber());
+      }
+      for (int rank = 1; rank <= maxRank; rank++) {
         String label = String.format("Rank %d", rank);
         csvPrinter.print(label);
       }
@@ -602,7 +607,7 @@ class ResultsWriter {
         } else {
           csvPrinter.print(castVoteRecord.getPrecinctPortion());
         }
-        printRankings(undeclaredWriteInLabel, numRanks, csvPrinter, castVoteRecord);
+        printRankings(undeclaredWriteInLabel, maxRank, reader, source, csvPrinter, castVoteRecord);
         csvPrinter.println();
       }
       // finalize the file
@@ -624,12 +629,17 @@ class ResultsWriter {
   private void printRankings(
       String undeclaredWriteInLabel,
       Integer maxRanks,
+      BaseCvrReader reader,
+      CvrSource source,
       CSVPrinter csvPrinter,
       CastVoteRecord castVoteRecord)
       throws IOException {
     // for each rank determine what candidate id, overvote, or undervote occurred and print it
     for (int rank = 1; rank <= maxRanks; rank++) {
       if (castVoteRecord.candidateRankings.hasRankingAt(rank)) {
+        if (reader.isRankingAllowed(rank, source.getContestId())) {
+          break;
+        }
         CandidatesAtRanking candidates = castVoteRecord.candidateRankings.get(rank);
         if (candidates.count() == 1) {
           String selection = candidates.get(0);

--- a/src/main/java/network/brightspots/rcv/ResultsWriter.java
+++ b/src/main/java/network/brightspots/rcv/ResultsWriter.java
@@ -638,6 +638,8 @@ class ResultsWriter {
       throws IOException {
     // for each rank determine what candidate id, overvote, or undervote occurred and print it
     for (int rank = 1; rank <= maxRanks; rank++) {
+      // If the configuration did not allow this ranking, we want to exclude it
+      // from the RCTab CVR -- even if it was present in the source CVRs.
       if (!reader.isRankingAllowed(rank, source.getContestId())) {
         break;
       }

--- a/src/main/java/network/brightspots/rcv/ResultsWriter.java
+++ b/src/main/java/network/brightspots/rcv/ResultsWriter.java
@@ -582,9 +582,11 @@ class ResultsWriter {
       csvPrinter.print("Record Id");
       csvPrinter.print("Precinct");
       csvPrinter.print("Precinct Portion");
-      int maxRank = 0;
-      for (CastVoteRecord castVoteRecord : castVoteRecords) {
-        maxRank = Math.max(maxRank, castVoteRecord.candidateRankings.maxRankingNumber());
+      int maxRank;
+      if (config.isMaxRankingsSetToMaximum()) {
+        maxRank = config.getNumDeclaredCandidates();
+      } else {
+        maxRank = config.getMaxRankingsAllowedWhenNotSetToMaximum();
       }
       for (int rank = 1; rank <= maxRank; rank++) {
         String label = String.format("Rank %d", rank);
@@ -636,10 +638,10 @@ class ResultsWriter {
       throws IOException {
     // for each rank determine what candidate id, overvote, or undervote occurred and print it
     for (int rank = 1; rank <= maxRanks; rank++) {
+      if (!reader.isRankingAllowed(rank, source.getContestId())) {
+        break;
+      }
       if (castVoteRecord.candidateRankings.hasRankingAt(rank)) {
-        if (reader.isRankingAllowed(rank, source.getContestId())) {
-          break;
-        }
         CandidatesAtRanking candidates = castVoteRecord.candidateRankings.get(rank);
         if (candidates.count() == 1) {
           String selection = candidates.get(0);

--- a/src/main/java/network/brightspots/rcv/StreamingCvrReader.java
+++ b/src/main/java/network/brightspots/rcv/StreamingCvrReader.java
@@ -166,7 +166,9 @@ class StreamingCvrReader extends BaseCvrReader {
   // complete construction of new CVR object
   private void endCvr() {
     // handle any empty cells which may appear at the end of this row
-    handleEmptyCells(config.getMaxRankingsAllowed() + 1);
+    if (!config.isMaxRankingsSetToMaximum()) {
+      handleEmptyCells(config.getMaxRankingsAllowedWhenNotSetToMaximum() + 1);
+    }
     String computedCastVoteRecordId =
         String.format("%s-%d", ResultsWriter.sanitizeStringForOutput(excelFileName), cvrIndex);
 
@@ -215,7 +217,7 @@ class StreamingCvrReader extends BaseCvrReader {
 
     // see if this column is in the ranking range
     if (col >= firstVoteColumnIndex
-        && col < firstVoteColumnIndex + config.getMaxRankingsAllowed()) {
+        && config.isRankingAllowed(col - firstVoteColumnIndex)) {
       int currentRank = col - firstVoteColumnIndex + 1;
       // handle any empty cells which may exist between this cell and any previous one
       handleEmptyCells(currentRank);

--- a/src/main/java/network/brightspots/rcv/StreamingCvrReader.java
+++ b/src/main/java/network/brightspots/rcv/StreamingCvrReader.java
@@ -216,9 +216,8 @@ class StreamingCvrReader extends BaseCvrReader {
     }
 
     // see if this column is in the ranking range
-    if (col >= firstVoteColumnIndex
-        && config.isRankingAllowed(col - firstVoteColumnIndex)) {
-      int currentRank = col - firstVoteColumnIndex + 1;
+    int currentRank = col - firstVoteColumnIndex + 1;
+    if (config.isRankingAllowed(currentRank)) {
       // handle any empty cells which may exist between this cell and any previous one
       handleEmptyCells(currentRank);
       String cellString = cellData.trim();

--- a/src/main/java/network/brightspots/rcv/Tabulator.java
+++ b/src/main/java/network/brightspots/rcv/Tabulator.java
@@ -1132,8 +1132,14 @@ class Tabulator {
         // if this is the last ranking we are out of rankings and must exhaust this cvr
         // determine if the reason is skipping too many ranks, or no continuing candidates
         if (rank == cvr.candidateRankings.maxRankingNumber()) {
-          if (!config.isMaxRankingsSetToMaximum()
-              && config.getMaxRankingsAllowedWhenNotSetToMaximum() - rank > config.getMaxSkippedRanksAllowed()) {
+          // When determining if this is an undervote or exhausted choice, look at either
+          // the max ranking allowed by the config, or if the config does not impose a limit,
+          // look at the number of declared candidates.
+          int maxAllowedRanking = config.isMaxRankingsSetToMaximum()
+                  ? config.getNumDeclaredCandidates()
+                  : config.getMaxRankingsAllowedWhenNotSetToMaximum();
+          if (config.getMaxSkippedRanksAllowed() != Integer.MAX_VALUE
+              && maxAllowedRanking - rank > config.getMaxSkippedRanksAllowed()) {
             recordSelectionForCastVoteRecord(
                 cvr, roundTally, null, StatusForRound.INACTIVE_BY_UNDERVOTE, "");
           } else {

--- a/src/main/java/network/brightspots/rcv/Tabulator.java
+++ b/src/main/java/network/brightspots/rcv/Tabulator.java
@@ -1132,8 +1132,8 @@ class Tabulator {
         // if this is the last ranking we are out of rankings and must exhaust this cvr
         // determine if the reason is skipping too many ranks, or no continuing candidates
         if (rank == cvr.candidateRankings.maxRankingNumber()) {
-          if (config.getMaxSkippedRanksAllowed() != Integer.MAX_VALUE
-              && config.getMaxRankingsAllowed() - rank > config.getMaxSkippedRanksAllowed()) {
+          if (!config.isMaxRankingsSetToMaximum()
+              && config.getMaxRankingsAllowedWhenNotSetToMaximum() - rank > config.getMaxSkippedRanksAllowed()) {
             recordSelectionForCastVoteRecord(
                 cvr, roundTally, null, StatusForRound.INACTIVE_BY_UNDERVOTE, "");
           } else {

--- a/src/main/java/network/brightspots/rcv/TabulatorSession.java
+++ b/src/main/java/network/brightspots/rcv/TabulatorSession.java
@@ -306,7 +306,8 @@ class TabulatorSession {
           this.convertedFilePath =
               writer.writeGenericCvrCsv(
                   castVoteRecords,
-                  reader.getMaxRankingsAllowed(source.getContestId()),
+                  source,
+                  reader,
                   config.getOutputDirectory(),
                   source.getFilePath(),
                   source.getContestId(),

--- a/src/test/resources/network/brightspots/rcv/test_data/convert_to_cdf_from_dominion/convert_to_cdf_from_dominion_expected.csv
+++ b/src/test/resources/network/brightspots/rcv/test_data/convert_to_cdf_from_dominion/convert_to_cdf_from_dominion_expected.csv
@@ -1,4 +1,4 @@
-Contest Id,Tabulator Id,Batch Id,Record Id,Precinct,Precinct Portion,Rank 1,Rank 2,Rank 3,Rank 4,Rank 5
+Contest Id,Tabulator Id,Batch Id,Record Id,Precinct,Precinct Portion,Rank 1,Rank 2,Rank 3,Rank 4,Rank 5,Rank 6,Rank 7,Rank 8
 1,42,1,1,,Precinct 1,Michael R. Bloomberg,Joseph R. Biden,12,Elizabeth Warren,Tulsi Gabbard
 1,42,1,2,,Precinct 1,Joseph R. Biden,12,Bernie Sanders,Pete Buttigieg,Tulsi Gabbard
 1,42,1,3,,Precinct 1,12,Amy Klobuchar,Tulsi Gabbard,Joseph R. Biden,Michael R. Bloomberg


### PR DESCRIPTION
Resolves #766 

Auto-loading candidates failed when Max Rankings was set to "Max," because rather than returning a value like INT_MAX, we'd return NumCandidates (which was likely 0).

I think it's best to not return this value at all, but to allow the config to check it directly. In this PR, I replace `getMaxRankingsAllowed()` with `isRankingAllowed(int rank)` throughout.

The only change in functionality is when creating the CVR CSV, and only in the case that the Dominion max ranking is different than the one entered in the config. One test has been updated to match this. (Note: this would have changed anyway when we created the combined CVR CSV in #785.)

For completeness, I also removed the check that ClearBallot was doing that no other reader did (as discussed in #776).