### PR TITLE
fix clearballot cvr parsing: ignore any commas in quoted text (#793)

### DIFF
--- a/src/main/java/network/brightspots/rcv/ClearBallotCvrReader.java
+++ b/src/main/java/network/brightspots/rcv/ClearBallotCvrReader.java
@@ -54,7 +54,7 @@ class ClearBallotCvrReader extends BaseCvrReader {
         Logger.severe("No header row found in cast vote record file: %s", this.cvrPath);
         throw new CvrParseException();
       }
-      String[] headerData = firstRow.split(",");
+      String[] headerData = firstRow.split(",(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)");
       if (headerData.length < CvrColumnField.ChoicesBegin.ordinal()) {
         Logger.severe("No choice columns found in cast vote record file: %s", this.cvrPath);
         throw new CvrParseException();


### PR DESCRIPTION
populate headerData array by splitting the firstRow value across commas that are not contained within quoted text.