### PR TITLE
WIP: reproducible hash values on build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,10 @@ on:
   release:
     types: [ published ]
 ## To test this workflow without creating a release, uncomment the following and add a branch name (making sure "push"
-##  is at the same indent level as "release":
-#  push:
-#    branches:
-#      - 'branch-name'
+#  is at the same indent level as "release":
+  push:
+    branches:
+      - 'feature/issue-759_golden-hash'
 
 jobs:
   release:
@@ -50,7 +50,7 @@ jobs:
           if [ ${{ runner.os }} == 'Windows' ]; then
             echo "FILEPATH=build/jpackage/RCTab-1.3.999.exe" >> $GITHUB_OUTPUT
           elif [ ${{ runner.os }} == 'Linux' ]; then
-            echo "FILEPATH=build/jpackage/rctab_1.3.999-1_amd64.deb" >> $GITHUB_OUTPUT
+            echo "FILEPATH=build/jpackage/rctab_1.3.999_amd64.deb" >> $GITHUB_OUTPUT
           else
             echo "FILEPATH=build/jpackage/RCTab-1.3.999.dmg" >> $GITHUB_OUTPUT
           fi

--- a/build.gradle
+++ b/build.gradle
@@ -235,3 +235,10 @@ tasks.jlink.doLast {
         into JLINK_DIR + "/sample_input"
     }
 }
+
+tasks.withType(AbstractArchiveTask) {
+    preserveFileTimestamps = false
+    reproducibleFileOrder = true
+    dirMode = 0755
+    fileMode = 0644
+}


### PR DESCRIPTION
Resolves #759 

Note: this creates a reproducible hash when run multiple times from one machine, but not when run on github actions multiple times, meaning it's not truly reproducible.

This package suggests that there are some tasks that do not support repackaging, so next step is to investigate if that applies to us: https://github.com/Johni0702/gradle-reproducible-builds-plugin