### PR TITLE
fix clearballot cvr parsing: ignore any commas in quoted text

### DIFF
--- a/src/main/java/network/brightspots/rcv/ClearBallotCvrReader.java
+++ b/src/main/java/network/brightspots/rcv/ClearBallotCvrReader.java
@@ -58,7 +58,7 @@ class ClearBallotCvrReader {
         Logger.severe("No header row found in cast vote record file: %s", this.cvrPath);
         throw new CvrParseException();
       }
-      String[] headerData = firstRow.split(",");
+      String[] headerData = firstRow.split(",(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)");
       if (headerData.length < CvrColumnField.ChoicesBegin.ordinal()) {
         Logger.severe("No choice columns found in cast vote record file: %s", this.cvrPath);
         throw new CvrParseException();

--- a/src/main/java/network/brightspots/rcv/Main.java
+++ b/src/main/java/network/brightspots/rcv/Main.java
@@ -27,7 +27,7 @@ import java.util.List;
 public class Main extends GuiApplication {
 
   public static final String APP_NAME = "RCTab";
-  public static final String APP_VERSION = "1.3.1";
+  public static final String APP_VERSION = "1.3.1 RC2";
 
   /**
    * Main entry point to RCTab.


### PR DESCRIPTION
cherry-picking commit c05543ccf6f8e7d3994890ec865a36cdf057df39 into the hotfix/1.3.1-clearballot branch