### PR TITLE
coalesce(computedId, suppliedId) in audit.log + fixes

### DIFF
--- a/src/main/java/network/brightspots/rcv/CastVoteRecord.java
+++ b/src/main/java/network/brightspots/rcv/CastVoteRecord.java
@@ -66,14 +66,7 @@ class CastVoteRecord {
       String precinct,
       String precinctPortion,
       List<Pair<Integer, String>> rankings) {
-    this.contestId = contestId;
-    this.tabulatorId = tabulatorId;
-    this.batchId = batchId;
-    this.computedId = null;
-    this.suppliedId = suppliedId;
-    this.precinct = precinct;
-    this.precinctPortion = precinctPortion;
-    this.candidateRankings = new CandidateRankingsList(rankings);
+    this(contestId, tabulatorId, batchId, suppliedId, null, precinct, precinctPortion, rankings);
   }
 
   CastVoteRecord(
@@ -88,8 +81,8 @@ class CastVoteRecord {
     this.contestId = contestId;
     this.tabulatorId = tabulatorId;
     this.batchId = batchId;
-    this.computedId = computedId;
     this.suppliedId = suppliedId;
+    this.computedId = computedId;
     this.precinct = precinct;
     this.precinctPortion = precinctPortion;
     this.candidateRankings = new CandidateRankingsList(rankings);
@@ -97,11 +90,7 @@ class CastVoteRecord {
 
   CastVoteRecord(
       String computedId, String suppliedId, String precinct, List<Pair<Integer, String>> rankings) {
-    this.computedId = computedId;
-    this.suppliedId = suppliedId;
-    this.precinct = precinct;
-    this.precinctPortion = null;
-    this.candidateRankings = new CandidateRankingsList(rankings);
+    this(null, null, null, suppliedId, computedId, precinct, null, rankings);
   }
 
   String getContestId() {

--- a/src/main/java/network/brightspots/rcv/CastVoteRecord.java
+++ b/src/main/java/network/brightspots/rcv/CastVoteRecord.java
@@ -77,6 +77,25 @@ class CastVoteRecord {
   }
 
   CastVoteRecord(
+          String contestId,
+          String tabulatorId,
+          String batchId,
+          String suppliedId,
+          String computedId,
+          String precinct,
+          String precinctPortion,
+          List<Pair<Integer, String>> rankings) {
+    this.contestId = contestId;
+    this.tabulatorId = tabulatorId;
+    this.batchId = batchId;
+    this.computedId = computedId;
+    this.suppliedId = suppliedId;
+    this.precinct = precinct;
+    this.precinctPortion = precinctPortion;
+    this.candidateRankings = new CandidateRankingsList(rankings);
+  }
+
+  CastVoteRecord(
       String computedId, String suppliedId, String precinct, List<Pair<Integer, String>> rankings) {
     this.computedId = computedId;
     this.suppliedId = suppliedId;
@@ -115,10 +134,10 @@ class CastVoteRecord {
 
     StringBuilder logStringBuilder = new StringBuilder();
     logStringBuilder.append("[Round] ").append(round).append(" [CVR] ");
-    if (!isNullOrBlank(suppliedId)) {
-      logStringBuilder.append(suppliedId);
-    } else {
+    if (!isNullOrBlank(computedId)) {
       logStringBuilder.append(computedId);
+    } else {
+      logStringBuilder.append(suppliedId);
     }
     if (outcomeType == VoteOutcomeType.IGNORED) {
       logStringBuilder.append(" [was ignored] ");

--- a/src/main/java/network/brightspots/rcv/CsvCvrReader.java
+++ b/src/main/java/network/brightspots/rcv/CsvCvrReader.java
@@ -60,7 +60,9 @@ class CsvCvrReader extends BaseCvrReader {
 
       parser.stream().skip(firstVoteRowIndex);
 
+      int index = 0;
       for (CSVRecord csvRecord : parser) {
+        index++;
         ArrayList<Pair<Integer, String>> rankings = new ArrayList<>();
         for (int col = firstVoteColumnIndex; col < csvRecord.size(); col++) {
           String rankAsString = csvRecord.get(col);
@@ -86,7 +88,7 @@ class CsvCvrReader extends BaseCvrReader {
 
         // create the new CastVoteRecord
         CastVoteRecord newCvr =
-            new CastVoteRecord(source.getContestId(), "no supplied ID", "no precinct", rankings);
+            new CastVoteRecord(Integer.toString(index), "no supplied ID", "no precinct", rankings);
         castVoteRecords.add(newCvr);
       }
     } catch (IOException exception) {

--- a/src/main/java/network/brightspots/rcv/DominionCvrReader.java
+++ b/src/main/java/network/brightspots/rcv/DominionCvrReader.java
@@ -354,8 +354,8 @@ class DominionCvrReader extends BaseCvrReader {
           }
           // create the new cvr
           CastVoteRecord newCvr =
-              new CastVoteRecord(
-                  contestId, tabulatorId, batchId, suppliedId, computedId, precinct, precinctPortion, rankings);
+              new CastVoteRecord(contestId, tabulatorId, batchId, suppliedId,
+                      computedId, precinct, precinctPortion, rankings);
           castVoteRecords.add(newCvr);
         }
       }

--- a/src/main/java/network/brightspots/rcv/DominionCvrReader.java
+++ b/src/main/java/network/brightspots/rcv/DominionCvrReader.java
@@ -30,6 +30,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javafx.util.Pair;
 import network.brightspots.rcv.CastVoteRecord.CvrParseException;
 
@@ -270,6 +272,10 @@ class DominionCvrReader extends BaseCvrReader {
       String batchId = session.get("BatchId").toString();
       Integer recordId = (Integer) session.get("RecordId");
       String suppliedId = recordId.toString();
+      String computedId = Stream.of(tabulatorId, batchId, Integer.toString(recordId))
+              .filter(s -> s != null && !s.isEmpty())
+              .collect(Collectors.joining("|"));
+
       // filter out records which are not current and replace them with adjudicated ones
       HashMap adjudicatedData = (HashMap) session.get("Original");
       boolean isCurrent = (boolean) adjudicatedData.get("IsCurrent");
@@ -349,7 +355,7 @@ class DominionCvrReader extends BaseCvrReader {
           // create the new cvr
           CastVoteRecord newCvr =
               new CastVoteRecord(
-                  contestId, tabulatorId, batchId, suppliedId, precinct, precinctPortion, rankings);
+                  contestId, tabulatorId, batchId, suppliedId, computedId, precinct, precinctPortion, rankings);
           castVoteRecords.add(newCvr);
         }
       }


### PR DESCRIPTION
resolves #804 by coalescing computedId then suppliedId when writing to audit log. Also fixes Dominion and Csv cvr readers to properly populate ComputedId