### PR TITLE
issue 800: Auto-Load candidates with zero votes

### DIFF
--- a/src/main/java/network/brightspots/rcv/BaseCvrReader.java
+++ b/src/main/java/network/brightspots/rcv/BaseCvrReader.java
@@ -51,7 +51,7 @@ abstract class BaseCvrReader {
 
   // Some CVRs have a list of candidates in the file. Read that list and return it.
   // This will be used in tandem with gatherUnknownCandidates, which only looks for candidates
-  // that has at least one vote.
+  // that have at least one vote.
   public List<String> readCandidateListFromCvr(List<CastVoteRecord> castVoteRecords)
       throws IOException {
     return new ArrayList<>();
@@ -78,9 +78,10 @@ abstract class BaseCvrReader {
     }
 
     if (includeCandidatesWithZeroVotes) {
-      // Second pass: read all candidates
-      // Not all CVR Readers have this implemented, so it's just a catch to
-      // find any candidate with zero votes.
+      // Second pass: read the entire candidate list from the CVR,
+      // regardless of whether they have any votes.
+      // TODO -- once all readers have this implemented, we can skip the first pass entirely
+      // during auto-load candidates and just use readCandidateListFromCvr.
       List<String> allCandidates = new ArrayList<>();
       try {
         allCandidates = readCandidateListFromCvr(castVoteRecords);
@@ -94,9 +95,10 @@ abstract class BaseCvrReader {
       allCandidates.remove(source.getUndeclaredWriteInLabel());
 
       // Combine the lists
-      for (String candidate : allCandidates) {
-        if (!unrecognizedCandidateCounts.containsKey(candidate)) {
-          unrecognizedCandidateCounts.put(candidate, 0);
+      for (String candidateName : allCandidates) {
+        if (!unrecognizedCandidateCounts.containsKey(candidateName)
+            && config.getNameForCandidate(candidateName) == null) {
+          unrecognizedCandidateCounts.put(candidateName, 0);
         }
       }
     }

--- a/src/main/java/network/brightspots/rcv/CsvCvrReader.java
+++ b/src/main/java/network/brightspots/rcv/CsvCvrReader.java
@@ -45,6 +45,25 @@ class CsvCvrReader extends BaseCvrReader {
     return "generic CSV";
   }
 
+  @Override
+  public List<String> readCandidateListFromCvr(List<CastVoteRecord> castVoteRecords)
+      throws IOException {
+    try (FileInputStream inputStream = new FileInputStream(Path.of(cvrPath).toFile())) {
+      CSVParser parser =
+              CSVParser.parse(
+                      inputStream,
+                      Charset.defaultCharset(),
+                      CSVFormat.Builder.create().setHeader().build());
+      List<String> rawCandidateNames = parser.getHeaderNames();
+      // Split rawCandidateNames from firstVoteColumnIndex to the end
+      return new ArrayList<>(rawCandidateNames.subList(
+            firstVoteColumnIndex, rawCandidateNames.size()));
+    } catch (IOException exception) {
+      Logger.severe("Error parsing cast vote record:\n%s", exception);
+      throw exception;
+    }
+  }
+
   // parse CVR CSV file into CastVoteRecord objects and add them to the input List<CastVoteRecord>
   @Override
   void readCastVoteRecords(List<CastVoteRecord> castVoteRecords)

--- a/src/main/java/network/brightspots/rcv/GuiConfigController.java
+++ b/src/main/java/network/brightspots/rcv/GuiConfigController.java
@@ -1571,7 +1571,9 @@ public class GuiConfigController implements Initializable {
                     List<CastVoteRecord> castVoteRecords = new ArrayList<>();
                     BaseCvrReader reader = provider.constructReader(config, source);
                     reader.readCastVoteRecords(castVoteRecords);
-                    unloadedNames.addAll(reader.gatherUnknownCandidates(castVoteRecords).keySet());
+                    Set<String> unknownCandidates = reader.gatherUnknownCandidates(
+                        castVoteRecords, true).keySet();
+                    unloadedNames.addAll(unknownCandidates);
                   } catch (ContestConfig.UnrecognizedProviderException e) {
                     Logger.severe(
                         "Unrecognized provider \"%s\" in source file \"%s\": %s",

--- a/src/main/java/network/brightspots/rcv/TabulatorSession.java
+++ b/src/main/java/network/brightspots/rcv/TabulatorSession.java
@@ -290,7 +290,7 @@ class TabulatorSession {
 
         // Check for unrecognized candidates
         Map<String, Integer> unrecognizedCandidateCounts =
-            reader.gatherUnknownCandidates(castVoteRecords);
+            reader.gatherUnknownCandidates(castVoteRecords, false);
 
         if (unrecognizedCandidateCounts.size() > 0) {
           throw new UnrecognizedCandidatesException(unrecognizedCandidateCounts);

--- a/src/main/resources/network/brightspots/rcv/GuiConfigLayout.fxml
+++ b/src/main/resources/network/brightspots/rcv/GuiConfigLayout.fxml
@@ -305,7 +305,7 @@
             <VBox spacing="20.0">
               <HBox styleClass="disableWhileEditingTable" alignment="CENTER" spacing="75.0">
                 <VBox styleClass="bordered-box" maxWidth="300.0">
-                  <VBox alignment="TOP_CENTER">
+                  <VBox alignment="TOP_CENTER" spacing="10">
                     <padding>
                       <Insets left="8.0" right="8.0" bottom="8.0" top="8.0"/>
                     </padding>
@@ -314,19 +314,22 @@
                         text="Search through all CVRs and load each unique candidate name found."
                         wrappingWidth="250"
                     />
+                    <Text
+                        text="NOTE: When using auto-load some vendors have explicit candidate lists that can be fully loaded, while others only list a candidate if they have a vote attributed to them. Using this auto-load is a convenience feature only and should be accompanied by manual confirmation."
+                        style="-fx-font-weight: bold; -fx-font-style: italic; -fx-font-size: 11"
+                        wrappingWidth="250"
+                    />
                     <Separator>
-                      <padding>
-                        <Insets bottom="8.0" top="8.0"/>
-                      </padding>
                     </Separator>
                     <Region prefHeight="25.0" VBox.vgrow="ALWAYS"/>
                     <HBox alignment="CENTER" spacing="4.0">
                       <Button mnemonicParsing="false" onAction="#buttonAutoLoadCandidatesClicked" text="Auto-Load"/>
                     </HBox>
+                    <Region prefHeight="25.0" VBox.vgrow="ALWAYS"/>
                   </VBox>
                 </VBox>
                 <VBox styleClass="bordered-box" maxWidth="400.0">
-                  <VBox alignment="TOP_CENTER">
+                  <VBox alignment="TOP_CENTER" spacing="10">
                     <padding>
                       <Insets left="8.0" right="8.0" bottom="8.0" top="8.0"/>
                     </padding>

--- a/src/main/resources/network/brightspots/rcv/GuiConfigLayout.fxml
+++ b/src/main/resources/network/brightspots/rcv/GuiConfigLayout.fxml
@@ -315,7 +315,7 @@
                         wrappingWidth="250"
                     />
                     <Text
-                        text="NOTE: When using auto-load some vendors have explicit candidate lists that can be fully loaded, while others only list a candidate if they have a vote attributed to them. Using this auto-load is a convenience feature only and should be accompanied by manual confirmation."
+                        text="NOTE: The auto-load feature relies on candidates appearing in vote data to populate the list of candidates. Users should confirm the list of candidates populated against the list of candidates in their election to confirm that all candidates were properly loaded."
                         style="-fx-font-weight: bold; -fx-font-style: italic; -fx-font-size: 11"
                         wrappingWidth="250"
                     />


### PR DESCRIPTION
closes #800 for CSV CVRs, and adds an easy-to-override method that we can implement in other CVR reader classes to address this issue for other CVRs.

To RCVRC, three questions:
1. Shall we invest time now in implementing this functionality across all readers, or do it on an as-needed basis?
2. Do we still want to add additional language to the auto-load to let people know about its limitations?
3. Do we want zero-vote candidates to throw halting errors in the final tabulation? (Currently, I've opted not to -- this could have unforeseen consequences.)