### PR TITLE
fix release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
           if [ ${{ runner.os }} == 'Windows' ]; then
             echo "FILEPATH=build/jpackage/RCTab-1.3.999.exe" >> $GITHUB_OUTPUT
           elif [ ${{ runner.os }} == 'Linux' ]; then
-            echo "FILEPATH=build/jpackage/rctab_1.3.999-1_amd64.deb" >> $GITHUB_OUTPUT
+            echo "FILEPATH=build/jpackage/rctab_1.3.999_amd64.deb" >> $GITHUB_OUTPUT
           else
             echo "FILEPATH=build/jpackage/RCTab-1.3.999.dmg" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
I feel like I've had to swap this `-1` back and forth a few times now, and I'm starting to wonder if it's nondeterministic...anyway, this is now needed to build releases successfully.