### PR TITLE
schedule a dev build regularly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,8 @@ name: "Generate Releases"
 on:
   release:
     types: [ published ]
+  schedule:
+    - cron: '0 12 1,15 * *'  # On the 1st and 15th of the month at noon
 ## To test this workflow without creating a release, uncomment the following and add a branch name (making sure "push"
 ##  is at the same indent level as "release":
 #  push:
@@ -136,7 +138,7 @@ jobs:
 
       - name: "Upload binaries to release"
         uses: svenstaro/upload-release-action@v2
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' || github.event_name == 'schedule'
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: build/${{ steps.basefn.outputs.FILEPATH }}*


### PR DESCRIPTION
closes #827 

We're getting occasional emails from non-developers who want to use the latest RCTab without installing Java. I've been linking them to files in my google drive and trying to keep up-to-date with the latest develop, but having a recurring build would be helpful. If needed we can adjust this to once a month or whatever, but it's currently set to twice a month.