### PR TITLE
make the log output faster, and add colors too

### DIFF
--- a/src/main/java/network/brightspots/rcv/GuiConfigController.java
+++ b/src/main/java/network/brightspots/rcv/GuiConfigController.java
@@ -62,6 +62,7 @@ import javafx.scene.control.ChoiceBox;
 import javafx.scene.control.Control;
 import javafx.scene.control.DatePicker;
 import javafx.scene.control.Label;
+import javafx.scene.control.ListView;
 import javafx.scene.control.MenuBar;
 import javafx.scene.control.RadioButton;
 import javafx.scene.control.SelectionMode;
@@ -126,7 +127,7 @@ public class GuiConfigController implements Initializable {
   private boolean guiIsBusy;
 
   @FXML
-  private TextArea textAreaStatus;
+  private ListView<Label> textAreaStatus;
   @FXML
   private TextArea textAreaHelp;
   @FXML

--- a/src/main/java/network/brightspots/rcv/Logger.java
+++ b/src/main/java/network/brightspots/rcv/Logger.java
@@ -187,10 +187,13 @@ class Logger {
           setText(null);
           setStyle(null);
         } else {
-          setGraphic(item);
+          // Reset the widths to allow word wrap
+          item.setMinWidth(listView.getWidth() - 50);
+          item.setMaxWidth(listView.getWidth() - 50);
+          item.setPrefWidth(listView.getWidth() - 50);
 
-          // Remove the label padding
-          setPadding(new Insets(0, 0, 0, 0));
+          // Fix the label padding
+          setPadding(new Insets(0, 0, 0, 3));
 
           // First remove any existing style, which can either be overridden
           // (if it needs a custom background) or can remain as the default.
@@ -215,6 +218,8 @@ class Logger {
           } else {
             setBlendMode(BlendMode.SRC_OVER);
           }
+
+          setGraphic(item);
         }
       }
     });
@@ -226,8 +231,8 @@ class Logger {
             if (isLoggable(record)) {
               String msg = getFormatter().format(record);
               Label logLabel = new Label(msg);
-              logLabel.setPadding(new Insets(0, 0, 0, 0));
-              logLabel.setWrapText(false);
+              logLabel.setPadding(new Insets(0, 0, 0, 3));
+              logLabel.setWrapText(true);
 
               // Set background color based on log level
               if (record.getLevel() == Level.SEVERE) {

--- a/src/main/java/network/brightspots/rcv/Logger.java
+++ b/src/main/java/network/brightspots/rcv/Logger.java
@@ -39,7 +39,6 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.concurrent.BlockingDeque;
 import java.util.logging.FileHandler;
 import java.util.logging.Formatter;
 import java.util.logging.Handler;

--- a/src/main/java/network/brightspots/rcv/Logger.java
+++ b/src/main/java/network/brightspots/rcv/Logger.java
@@ -238,7 +238,7 @@ class Logger {
               if (record.getLevel() == Level.SEVERE) {
                 logLabel.setBackground(Background.fill(Color.DARKRED));
               } else if (record.getLevel() == Level.WARNING) {
-                logLabel.setBackground(Background.fill(Color.DARKORANGE));
+                logLabel.setBackground(Background.fill(Color.SIENNA));
               }
 
               // On Right Click, user can copy text

--- a/src/main/resources/network/brightspots/rcv/GuiConfigLayout.fxml
+++ b/src/main/resources/network/brightspots/rcv/GuiConfigLayout.fxml
@@ -696,13 +696,12 @@
         styleClass="help-text-area" wrapText="true" BorderPane.alignment="TOP_LEFT"/>
     </right>
     <bottom>
-      <TextArea id="textStatus" fx:id="textAreaStatus" editable="false" prefHeight="200.0"
-        prefWidth="200.0" styleClass="console-text-area" wrapText="true"
-        BorderPane.alignment="TOP_LEFT">
+      <ListView id="textStatus" fx:id="textAreaStatus" editable="false" prefHeight="200.0"
+        prefWidth="200.0" styleClass="console-text-area" BorderPane.alignment="TOP_LEFT">
         <BorderPane.margin>
           <Insets bottom="4.0" left="4.0" right="4.0" top="4.0"/>
         </BorderPane.margin>
-      </TextArea>
+      </ListView>
     </bottom>
   </BorderPane>
 </ScrollPane>


### PR DESCRIPTION
Closes #831 
Closes #830 

The issue was that appending to the textarea used string concatenation, which required reading the entire log string and recreating it each time a new log message was added. That made each subsequent GUI run slower, and also explains why we didn't see this in the unit tests: it's only a GUI issue. It also caused the GUI to hang for a short bit of time each time a log message was added.

I replaced the TextArea with a ListView. This makes it trivial to do something that I've wanted for a while: colors for log levels. I can change the foreground or background color. I would appreciate feedback on how this looks:

Screenshot:
<img width="1174" alt="image" src="https://github.com/BrightSpots/rcv/assets/537316/688b777e-9f49-4072-b630-1ece86b0f7b4">