### PR TITLE
issue 826: show per-source ballot counts

### DIFF
--- a/src/main/java/network/brightspots/rcv/GuiConfigController.java
+++ b/src/main/java/network/brightspots/rcv/GuiConfigController.java
@@ -1980,11 +1980,9 @@ public class GuiConfigController implements Initializable {
     }
   }
 
-  /**
-   * Adapted from https://stackoverflow.com/a/41282740/1057105
-   */
-  public static class NumberTableCellFactory<S, T>
-        implements Callback<TableColumn<S, T>, TableCell<S, T>> {
+  /** Adapted from https://stackoverflow.com/a/41282740/1057105 */
+  static class NumberTableCellFactory<S, T>
+      implements Callback<TableColumn<S, T>, TableCell<S, T>> {
     private final int startNumber;
 
     public NumberTableCellFactory(@NamedArg("startNumber") int startNumber) {

--- a/src/main/java/network/brightspots/rcv/GuiConfigController.java
+++ b/src/main/java/network/brightspots/rcv/GuiConfigController.java
@@ -1983,7 +1983,7 @@ public class GuiConfigController implements Initializable {
   /**
    * Adapted from https://stackoverflow.com/a/41282740/1057105
    */
-  private static class NumberTableCellFactory<S, T>
+  public static class NumberTableCellFactory<S, T>
         implements Callback<TableColumn<S, T>, TableCell<S, T>> {
     private final int startNumber;
 

--- a/src/main/java/network/brightspots/rcv/GuiConfigController.java
+++ b/src/main/java/network/brightspots/rcv/GuiConfigController.java
@@ -1991,7 +1991,7 @@ public class GuiConfigController implements Initializable {
       this.startNumber = startNumber;
     }
 
-    public static class NumberTableCell<S, T> extends TableCell<S, T> {
+    private static class NumberTableCell<S, T> extends TableCell<S, T> {
       private final int startNumber;
 
       public NumberTableCell(int startNumber) {
@@ -2011,6 +2011,13 @@ public class GuiConfigController implements Initializable {
       return new NumberTableCell<>(startNumber);
     }
 
+    /**
+     * Create a new column that numbers rows starting at the given number.
+     *
+     * @param text The column header text
+     * @param startNumber The number to start counting at
+     * @return The new column
+     */
     public static <T> TableColumn<T, Void> createNumberColumn(String text, int startNumber) {
       TableColumn<T, Void> column = new TableColumn<>(text);
       column.setSortable(false);

--- a/src/main/java/network/brightspots/rcv/GuiTabulateController.java
+++ b/src/main/java/network/brightspots/rcv/GuiTabulateController.java
@@ -218,26 +218,27 @@ public class GuiTabulateController {
   }
 
   private void watchParseCvrServiceProgress(Service<LoadedCvrData> service) {
-    EventHandler<WorkerStateEvent> onSucceededEvent = workerStateEvent -> {
-      enableButtonsUpTo(tabulateButton);
-      LoadedCvrData data = service.getValue();
-      tabulateButton.setText("Tabulate " + String.format("%,d", data.numCvrs()) + " ballots");
+    EventHandler<WorkerStateEvent> onSucceededEvent =
+        workerStateEvent -> {
+          enableButtonsUpTo(tabulateButton);
+          LoadedCvrData data = service.getValue();
+          tabulateButton.setText("Tabulate " + String.format("%,d", data.numCvrs()) + " ballots");
 
-      // Populate the per-source CVR count table, and calculate the width of the filename column
-      perSourceCvrCountTable.getItems().clear();
-      int maxFilenameLength = 0;
-      for (Pair<String, Integer> perSourceCount : data.getPerSourceCvrCounts()) {
-        String countString = String.format("%,d", perSourceCount.getValue());
-        String fileString = new File(perSourceCount.getKey()).getName();
-        perSourceCvrCountTable.getItems().add(new Pair<>(fileString, countString));
-        maxFilenameLength = Math.max(maxFilenameLength, fileString.length());
-      }
-      perSourceCvrColumnFilepath.setPrefWidth(getEstWidthForStringInPixels(maxFilenameLength));
-      perSourceCvrCountTable.setVisible(true);
+          // Populate the per-source CVR count table, and calculate the width of the filename column
+          perSourceCvrCountTable.getItems().clear();
+          int maxFilenameLength = 0;
+          for (Pair<String, Integer> perSourceCount : data.getPerSourceCvrCounts()) {
+            String countString = String.format("%,d", perSourceCount.getValue());
+            String fileString = new File(perSourceCount.getKey()).getName();
+            perSourceCvrCountTable.getItems().add(new Pair<>(fileString, countString));
+            maxFilenameLength = Math.max(maxFilenameLength, fileString.length());
+          }
+          perSourceCvrColumnFilepath.setPrefWidth(getEstWidthForStringInPixels(maxFilenameLength));
+          perSourceCvrCountTable.setVisible(true);
 
-      data.discard();
-      lastLoadedCvrData = data;
-    };
+          data.discard();
+          lastLoadedCvrData = data;
+        };
 
     watchGenericService(service, onSucceededEvent);
   }

--- a/src/main/java/network/brightspots/rcv/GuiTabulateController.java
+++ b/src/main/java/network/brightspots/rcv/GuiTabulateController.java
@@ -84,9 +84,9 @@ public class GuiTabulateController {
   @FXML private Button tempSaveButton;
   @FXML private Label numberOfCandidates;
   @FXML private Label numberOfCvrFiles;
-  @FXML private TableView<Pair<String, Integer>> perSourceCvrCountTable;
-  @FXML private TableColumn<Pair<String, Integer>, String> perSourceCvrColumnFilepath;
-  @FXML private TableColumn<Pair<String, Integer>, String> perSourceCvrColumnCount;
+  @FXML private TableView<Pair<String, String>> perSourceCvrCountTable;
+  @FXML private TableColumn<Pair<String, String>, String> perSourceCvrColumnFilepath;
+  @FXML private TableColumn<Pair<String, String>, String> perSourceCvrColumnCount;
   @FXML private TextField userNameField;
   @FXML private ProgressBar progressBar;
   @FXML private Button loadCvrButton;
@@ -106,9 +106,9 @@ public class GuiTabulateController {
     tempSaveButton.managedProperty().bind(tempSaveButton.visibleProperty());
 
     perSourceCvrColumnFilepath.setCellValueFactory(
-            c -> new SimpleStringProperty(new File(c.getValue().getKey()).getName()));
+            c -> new SimpleStringProperty(c.getValue().getKey()));
     perSourceCvrColumnCount.setCellValueFactory(
-            c -> new SimpleStringProperty(c.getValue().getValue().toString()));
+            c -> new SimpleStringProperty(c.getValue().getValue()));
     perSourceCvrCountTable.getColumns().add(0,
             GuiConfigController.NumberTableCellFactory.createNumberColumn("#", 1));
     perSourceCvrCountTable.setVisible(false);
@@ -223,10 +223,16 @@ public class GuiTabulateController {
       LoadedCvrData data = service.getValue();
       tabulateButton.setText("Tabulate " + String.format("%,d", data.numCvrs()) + " ballots");
 
+      // Populate the per-source CVR count table, and calculate the width of the filename column
       perSourceCvrCountTable.getItems().clear();
+      int maxFilenameLength = 0;
       for (Pair<String, Integer> perSourceCount : data.getPerSourceCvrCounts()) {
-        perSourceCvrCountTable.getItems().add(perSourceCount);
+        String countString = String.format("%,d", perSourceCount.getValue());
+        String fileString = new File(perSourceCount.getKey()).getName();
+        perSourceCvrCountTable.getItems().add(new Pair<>(fileString, countString));
+        maxFilenameLength = Math.max(maxFilenameLength, fileString.length());
       }
+      perSourceCvrColumnFilepath.setPrefWidth(getEstWidthForStringInPixels(maxFilenameLength));
       perSourceCvrCountTable.setVisible(true);
 
       data.discard();
@@ -234,6 +240,10 @@ public class GuiTabulateController {
     };
 
     watchGenericService(service, onSucceededEvent);
+  }
+
+  private float getEstWidthForStringInPixels(int stringLength) {
+    return stringLength * 7.5f;
   }
 
   private <T> void watchGenericService(

--- a/src/main/java/network/brightspots/rcv/GuiTabulateController.java
+++ b/src/main/java/network/brightspots/rcv/GuiTabulateController.java
@@ -227,9 +227,9 @@ public class GuiTabulateController {
           // Populate the per-source CVR count table, and calculate the width of the filename column
           perSourceCvrCountTable.getItems().clear();
           int maxFilenameLength = 0;
-          for (Pair<String, Integer> perSourceCount : data.getPerSourceCvrCounts()) {
-            String countString = String.format("%,d", perSourceCount.getValue());
-            String fileString = new File(perSourceCount.getKey()).getName();
+          for (ResultsWriter.CvrSourceData sourceData : data.getCvrSourcesData()) {
+            String countString = String.format("%,d", sourceData.getNumCvrs());
+            String fileString = new File(sourceData.source.getFilePath()).getName();
             perSourceCvrCountTable.getItems().add(new Pair<>(fileString, countString));
             maxFilenameLength = Math.max(maxFilenameLength, fileString.length());
           }

--- a/src/main/java/network/brightspots/rcv/TabulatorSession.java
+++ b/src/main/java/network/brightspots/rcv/TabulatorSession.java
@@ -34,7 +34,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiConsumer;
-
 import javafx.util.Pair;
 import network.brightspots.rcv.CastVoteRecord.CvrParseException;
 import network.brightspots.rcv.ContestConfig.Provider;
@@ -339,9 +338,9 @@ class TabulatorSession {
       try {
         BaseCvrReader reader = provider.constructReader(config, source);
         Logger.info("Reading %s cast vote records from: %s...", reader.readerName(), cvrPath);
-        int origNumCvrs = castVoteRecords.size();
+        final int origNumCvrs = castVoteRecords.size();
         reader.readCastVoteRecords(castVoteRecords);
-        int numCvrsRead = castVoteRecords.size() - origNumCvrs;
+        final int numCvrsRead = castVoteRecords.size() - origNumCvrs;
 
         // Update the per-source data for the results writer
         perSourceDataForCsv.add(new ResultsWriter.PerSourceDataForCsv(
@@ -459,7 +458,8 @@ class TabulatorSession {
     private boolean isDiscarded;
     private final boolean doesMatchAllMetadata;
 
-    public LoadedCvrData(List<CastVoteRecord> cvrs, List<Pair<String, Integer>> perSourceCvrCounts) {
+    public LoadedCvrData(List<CastVoteRecord> cvrs,
+                         List<Pair<String, Integer>> perSourceCvrCounts) {
       this.cvrs = cvrs;
       this.successfullyReadAll = cvrs != null;
       this.numCvrs = cvrs != null ? cvrs.size() : 0;

--- a/src/main/resources/network/brightspots/rcv/GuiTabulationPopup.fxml
+++ b/src/main/resources/network/brightspots/rcv/GuiTabulationPopup.fxml
@@ -13,7 +13,6 @@
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.text.*?>
-
 <Pane prefHeight="513.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/17.0.2-ea" xmlns:fx="http://javafx.com/fxml/1" fx:controller="network.brightspots.rcv.GuiTabulateController">
    <children>
       <VBox layoutX="14.0" layoutY="10.0" prefHeight="343.0" prefWidth="573.0" spacing="10.0">
@@ -64,7 +63,8 @@
                <VBox prefWidth="500.0" spacing="30.0">
                   <TableView fx:id="perSourceCvrCountTable" prefWidth="330.0">
                      <columns>
-                        <TableColumn fx:id="perSourceCvrColumnCount" minWidth="20.0" prefWidth="70.0" text="Num Ballots" />
+                        <TableColumn fx:id="perSourceCvrColumnCount" minWidth="20.0"
+                                     prefWidth="80.0" text="Num Ballots"/>
                         <TableColumn fx:id="perSourceCvrColumnFilepath" minWidth="20.0" prefWidth="230.0" text="Filepath" />
                      </columns>
                   </TableView>

--- a/src/main/resources/network/brightspots/rcv/GuiTabulationPopup.fxml
+++ b/src/main/resources/network/brightspots/rcv/GuiTabulationPopup.fxml
@@ -42,22 +42,34 @@
                   <Insets top="10.0" />
                </VBox.margin>
             </Text>
-            <Label fx:id="numberOfCandidates" prefHeight="24.0" prefWidth="349.0" text="Number of Candidates: X" wrapText="true">
-               <font>
-                  <Font size="16.0" />
-               </font>
-               <VBox.margin>
-                  <Insets left="15.0" />
-               </VBox.margin>
-            </Label>
-            <Label fx:id="numberOfCvrFiles" prefHeight="24.0" prefWidth="349.0" text="Number of CVR Files: Y" wrapText="true">
-               <font>
-                  <Font size="16.0" />
-               </font>
-               <VBox.margin>
-                  <Insets left="15.0" />
-               </VBox.margin>
-            </Label>
+            <HBox prefWidth="567.0" spacing="30.0">
+               <VBox prefWidth="350.0" spacing="5.0">
+                  <Label fx:id="numberOfCandidates" prefHeight="24.0" prefWidth="349.0" text="Number of Candidates: X" wrapText="true">
+                     <font>
+                        <Font size="16.0" />
+                     </font>
+                     <VBox.margin>
+                        <Insets left="15.0" />
+                     </VBox.margin>
+                  </Label>
+                  <Label fx:id="numberOfCvrFiles" prefHeight="24.0" prefWidth="349.0" text="Number of CVR Files: Y" wrapText="true">
+                     <font>
+                        <Font size="16.0" />
+                     </font>
+                     <VBox.margin>
+                        <Insets left="15.0" />
+                     </VBox.margin>
+                  </Label>
+               </VBox>
+               <VBox prefWidth="500.0" spacing="30.0">
+                  <TableView fx:id="perSourceCvrCountTable" prefWidth="330.0">
+                     <columns>
+                        <TableColumn fx:id="perSourceCvrColumnCount" minWidth="20.0" prefWidth="70.0" text="Num Ballots" />
+                        <TableColumn fx:id="perSourceCvrColumnFilepath" minWidth="20.0" prefWidth="230.0" text="Filepath" />
+                     </columns>
+                  </TableView>
+               </VBox>
+            </HBox>
             <Text strokeType="OUTSIDE" strokeWidth="0.0" text="Auditing Information" wrappingWidth="225.1533203125">
                <font>
                   <Font name="System Bold" size="19.0" />


### PR DESCRIPTION
closes #826

This UI feels quite cluttered now. The table only appears after the first button is hit, so on pop-up it's cleaner.
1. Is there any risk of the same file name in different folders? Should we show the full path? If we do, it looks even harder to read.

<img width="602" alt="image" src="https://github.com/BrightSpots/rcv/assets/537316/ba33a72d-3a34-45b3-b822-b42a46ab960f">

This auto-sizes the filename column to try to make sure the full string is visible