### PR TITLE
Workaround for windows log issues

### DIFF
--- a/src/main/java/network/brightspots/rcv/Logger.java
+++ b/src/main/java/network/brightspots/rcv/Logger.java
@@ -274,7 +274,8 @@ class Logger {
           }
 
           private boolean shouldIgnore(LogRecord record) {
-            // On Windows, scrollToBottom can trigger a log message in VirtualFlow.java that causes:
+            // On Windows, scrollToBottom can trigger a log message in JavaFX.
+            // We'll get log spam from VirtualFlow.java that causes:
             // 1. A log message to be added to the queue
             // 2. The scroll-to-bottom to fail
             // This can cause a cycle of repeated log spam and sporadic scroll failures.

--- a/src/main/java/network/brightspots/rcv/Logger.java
+++ b/src/main/java/network/brightspots/rcv/Logger.java
@@ -239,7 +239,7 @@ class Logger {
         new Handler() {
           @Override
           public void publish(LogRecord record) {
-            if (isLoggable(record)) {
+            if (isLoggable(record) && !shouldIgnore(record)) {
               String msg = getFormatter().format(record);
               Label logLabel = new Label(msg.strip());
               logLabel.setPadding(new Insets(0, 0, 0, 3));
@@ -271,6 +271,17 @@ class Logger {
                 }
               }
             }
+          }
+
+          private boolean shouldIgnore(LogRecord record) {
+            // On Windows, scrollToBottom can trigger a log message in VirtualFlow.java that causes:
+            // 1. A log message to be added to the queue
+            // 2. The scroll-to-bottom to fail
+            // This can cause a cycle of repeated log spam and sporadic scroll failures.
+            // The problem seems entirely mitigated by ignoring this log message.
+            // The following bug is related, though it has very little information:
+            // https://bugs.openjdk.java.net/browse/JDK-8092801
+            return record.getMessage().startsWith("index exceeds maxCellCount");
           }
 
           private void addFromMainThread() {


### PR DESCRIPTION
Closes #840 

I was able to reproduce the bug, and each time it happened, I got some log spam that said:
```
INFO: index exceeds maxCellCount. Check size calculations for class network.brightspots.rcv.Logger$1
```

I spent a time investigating, but the code is so deep in the javafx windowing code that I couldn't find any clean workarounds.

The one thing that worked was simply filtering out the log spam message, which seems to make the problem go away entirely. I don't love this solution but couldn't immediately come up with another.