### PR TITLE
reduce audit log spam

### DIFF
--- a/src/main/java/network/brightspots/rcv/CastVoteRecord.java
+++ b/src/main/java/network/brightspots/rcv/CastVoteRecord.java
@@ -149,7 +149,7 @@ class CastVoteRecord {
       logStringBuilder.append(" [value] ").append(fractionalTransferValue);
     }
 
-    Logger.fine(logStringBuilder.toString());
+    Logger.info(logStringBuilder.toString());
   }
 
   Map<Integer, List<Pair<String, BigDecimal>>> getCdfSnapshotData() {

--- a/src/main/java/network/brightspots/rcv/CastVoteRecord.java
+++ b/src/main/java/network/brightspots/rcv/CastVoteRecord.java
@@ -48,11 +48,11 @@ class CastVoteRecord {
   // a set is used to handle overvotes
   CandidateRankingsList candidateRankings;
   // contest associated with this CVR
-  private String contestId;
+  private final String contestId;
   // tabulatorId parsed from Dominion CVR data
-  private String tabulatorId;
+  private final String tabulatorId;
   // batchId parsed from Dominion CVR data
-  private String batchId;
+  private final String batchId;
   // the ballot status for the current round, which will change as tabulation progresses.
   private StatusForRound currentRoundStatus = StatusForRound.ACTIVE;
   // tells us which candidate is currently receiving this CVR's vote (or fractional vote)
@@ -149,7 +149,7 @@ class CastVoteRecord {
       logStringBuilder.append(" [value] ").append(fractionalTransferValue);
     }
 
-    Logger.info(logStringBuilder.toString());
+    Logger.auditable(logStringBuilder.toString());
   }
 
   Map<Integer, List<Pair<String, BigDecimal>>> getCdfSnapshotData() {

--- a/src/main/java/network/brightspots/rcv/Logger.java
+++ b/src/main/java/network/brightspots/rcv/Logger.java
@@ -14,8 +14,8 @@
  * log message
  *  |
  *  v
- * Tabulation handler (FINE) -> tabulation "audit" file
- *  When a tabulation is in progress this captures all FINE level logging including audit info.
+ * Tabulation handler (AUDIT) -> tabulation "audit" file
+ *  When a tabulation is in progress this captures all AUDIT level logging including audit info.
  *
  * Execution handler (INFO) -> execution file
  *  Captures all INFO level logging for the execution of a session.
@@ -54,7 +54,6 @@ import javafx.scene.control.Label;
 import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.scene.control.MenuItem;
-import javafx.scene.control.MultipleSelectionModel;
 import javafx.scene.control.SelectionMode;
 import javafx.scene.effect.BlendMode;
 import javafx.scene.input.Clipboard;
@@ -65,6 +64,7 @@ import javafx.scene.paint.Color;
 import javafx.scene.paint.Paint;
 
 class Logger {
+  // Custom "audit" logging level, designed to fit between FINE and INFO levels
   private static final Level AUDIT_LEVEL = new Level("AUDIT", Level.FINE.intValue() + 1) {};
 
   // execution log file name (%g tracks count of log file if additional versions are created)

--- a/src/main/java/network/brightspots/rcv/Logger.java
+++ b/src/main/java/network/brightspots/rcv/Logger.java
@@ -83,7 +83,7 @@ class Logger {
 
   static void setup() {
     logger = java.util.logging.Logger.getLogger("");
-    logger.setLevel(Level.FINE);
+    logger.setLevel(Level.INFO);
 
     // logPath is where execution file logging is written
     // "user.dir" property is the current working directory, i.e. folder from whence the rcv jar

--- a/src/main/java/network/brightspots/rcv/Logger.java
+++ b/src/main/java/network/brightspots/rcv/Logger.java
@@ -65,6 +65,7 @@ import javafx.scene.paint.Color;
 import javafx.scene.paint.Paint;
 
 class Logger {
+  private static final Level AUDIT_LEVEL = new Level("AUDIT", Level.FINE.intValue() + 1) {};
 
   // execution log file name (%g tracks count of log file if additional versions are created)
   private static final String EXECUTION_LOG_FILE_NAME = "rcv_%g.log";
@@ -83,7 +84,7 @@ class Logger {
 
   static void setup() {
     logger = java.util.logging.Logger.getLogger("");
-    logger.setLevel(Level.INFO);
+    logger.setLevel(AUDIT_LEVEL);
 
     // logPath is where execution file logging is written
     // "user.dir" property is the current working directory, i.e. folder from whence the rcv jar
@@ -153,8 +154,8 @@ class Logger {
     }
   }
 
-  static void fine(String message, Object... obj) {
-    log(Level.FINE, message, obj);
+  static void auditable(String message, Object... obj) {
+    log(AUDIT_LEVEL, message, obj);
   }
 
   static void info(String message, Object... obj) {

--- a/src/main/java/network/brightspots/rcv/Logger.java
+++ b/src/main/java/network/brightspots/rcv/Logger.java
@@ -129,7 +129,7 @@ class Logger {
             tabulationLogPattern,
             LOG_FILE_MAX_SIZE_BYTES, TABULATION_LOG_FILE_COUNT, true);
     tabulationHandler.setFormatter(formatter);
-    tabulationHandler.setLevel(Level.FINE);
+    tabulationHandler.setLevel(AUDIT_LEVEL);
     logger.addHandler(tabulationHandler);
     info("Tabulation logging to: %s", tabulationLogPattern.replace("%g", "0"));
   }

--- a/src/main/java/network/brightspots/rcv/StreamingCvrReader.java
+++ b/src/main/java/network/brightspots/rcv/StreamingCvrReader.java
@@ -213,7 +213,7 @@ class StreamingCvrReader extends BaseCvrReader {
     }
 
     // Log the raw data for auditing
-    Logger.fine("[Raw Data]: " + currentCvrData.toString());
+    Logger.auditable("[Raw Data]: " + currentCvrData.toString());
 
     // create new cast vote record
     CastVoteRecord newRecord = new CastVoteRecord(

--- a/src/main/java/network/brightspots/rcv/TabulatorSession.java
+++ b/src/main/java/network/brightspots/rcv/TabulatorSession.java
@@ -165,15 +165,15 @@ class TabulatorSession {
       Logger.info("Config file: %s", configPath);
 
       try {
-        Logger.fine("Begin config file contents:");
+        Logger.auditable("Begin config file contents:");
         BufferedReader reader =
             new BufferedReader(new FileReader(configPath, StandardCharsets.UTF_8));
         String line = reader.readLine();
         while (line != null) {
-          Logger.fine(line);
+          Logger.auditable(line);
           line = reader.readLine();
         }
-        Logger.fine("End config file contents.");
+        Logger.auditable("End config file contents.");
         reader.close();
       } catch (IOException exception) {
         exceptionsEncountered.add(exception.getClass().toString());


### PR DESCRIPTION
Closes #844 

I'm not sure why the audit log includes `FINE` level logging at all -- it seems more useful to limit it to `INFO`. Thoughts on just removing all `FINE`s, rather than hunting down why certain UI elements log to `FINE`?