### PR TITLE
Release Build Updates and Fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,6 +188,6 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: build/${{ steps.basefn.outputs.FILEPATH }}*
-          tag: ${{ github.ref_name }}
+          tag: build-${{ github.ref_name }}
           overwrite: true
           file_glob: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,6 +187,14 @@ jobs:
             ${{ github.workspace }}/${{ steps.checksumsfn.outputs.FILEPATH }}.sha512
           retention-days: 90
 
+      - uses: dev-drprasad/delete-tag-and-release@v1.1
+        # Note: to update the date of the release, it must be deleted and then recreated
+        if: github.event_name == 'release' || github.event_name == 'schedule'
+        with:
+          tag_name: build-${{ github.ref_name }}
+          delete_release: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: "Upload binaries to release"
         uses: svenstaro/upload-release-action@v2
         if: github.event_name == 'release' || github.event_name == 'schedule'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,10 +171,12 @@ jobs:
           echo "Attach staple"
           xcrun stapler staple ${{ steps.exefn.outputs.FILEPATH }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Package
           if-no-files-found: error
+          overwrite: true
+          retention-days: 90
           path: |
             ${{ github.workspace }}/${{    steps.zipfn.outputs.FILEPATH    }}
             ${{ github.workspace }}/${{    steps.zipfn.outputs.FILEPATH    }}.sha512
@@ -185,7 +187,6 @@ jobs:
             ${{ github.workspace }}/${{   steps.cachefn.outputs.FILEPATH   }}.sha512
             ${{ github.workspace }}/${{ steps.checksumsfn.outputs.FILEPATH }}
             ${{ github.workspace }}/${{ steps.checksumsfn.outputs.FILEPATH }}.sha512
-          retention-days: 90
 
       - uses: dev-drprasad/delete-tag-and-release@v1.1
         # Note: to update the date of the release, it must be deleted and then recreated

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,7 +176,6 @@ jobs:
           name: Package
           if-no-files-found: error
           overwrite: true
-          retention-days: 90
           path: |
             ${{ github.workspace }}/${{    steps.zipfn.outputs.FILEPATH    }}
             ${{ github.workspace }}/${{    steps.zipfn.outputs.FILEPATH    }}.sha512
@@ -205,3 +204,15 @@ jobs:
           tag: build-${{ github.ref_name }}
           overwrite: true
           file_glob: true
+          make_latest: false
+
+      - name: "Upload cache to release"
+        uses: svenstaro/upload-release-action@v2
+        if: github.event_name == 'release' || github.event_name == 'schedule'
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: cache/*
+          tag: build-${{ github.ref_name }}
+          overwrite: true
+          file_glob: true
+          make_latest: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,11 @@ jobs:
           input: "~/.gradle/caches"
           zipFilename: ${{steps.cachefn.outputs.FILEPATH}}
 
+      - name: "Generate SHA512 for executable"
+        shell: bash
+        run: |
+          ./.github/workflows/sha.sh ${{ steps.exefn.outputs.FILEPATH }} ${{ runner.os }} 512 > ${{steps.exefn.outputs.FILEPATH}}.sha512
+
       - name: "Generate SHA512 for plugins cache"
         shell: bash
         run: |


### PR DESCRIPTION
git doesn't like having both a branch and a tag named develop. This changes the name of the biweekly builds to have tag `build-develop` instead of just `develop` (open to other names too)

Also closes #862 : 
1. Create the sha512 for the executables
2. Delete and recreate the release so the date gets updated