### PR TITLE
don't treat non-text files as text in git line ending conversion

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* text eol=lf
+* text=auto


### PR DESCRIPTION
closes #863 

I tested by cloning a fresh repo with just this branch and no files came back dirty. May be worth testing on windows too, but I don't currently have access to a Windows machine. You can test it by:
`git clone -b feature/issue-863_cloned-line-endings https://github.com/BrightSpots/rcv`