### PR TITLE
run test on PR, not on push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: "Build, Lint, and Test"
 
-on: [push]
+on: [pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
This enables running tests on forked pull requests. The rules for that are configured in the github settings:

1.  Require approval for first-time contributors who are new to GitHub
2. Require approval for first-time contributors
3. Require approval for all outside collaborators