### PR TITLE
Add suggestion to use jEnv in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ On Linux, you may install the .deb file, then run `/opt/rcv/bin/RCTab` to launch
     
     If the expected version isn't returned, you'll need to follow the instructions [here](https://www.java.com/en/download/help/path.xml) on how to set your Java path.
 
-    If you need to regularly switch between Java versions, consider installing [jEnv](https://www.jenv.be/). For a list of the Java versions installed on your machine, run `/usr/libexec/java_home -V` on MacOS or `update-alternatives --config java` on Linux.
+    If you are using Linux or MacOS and need to regularly switch between Java versions, consider installing [jEnv](https://www.jenv.be/). For a list of the Java versions installed on your machine, run `/usr/libexec/java_home -V` on MacOS or `update-alternatives --config java` on Linux.
 
 2. Download the [zip of the source code from GitHub](https://github.com/BrightSpots/rcv/archive/master.zip) and unzip it, or install git and use the following command at the terminal / command prompt to clone a local copy on your machine:
     

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ On Linux, you may install the .deb file, then run `/opt/rcv/bin/RCTab` to launch
     
     If the expected version isn't returned, you'll need to follow the instructions [here](https://www.java.com/en/download/help/path.xml) on how to set your Java path.
 
+    If you need to regularly switch between Java versions, consider installing [jEnv](https://www.jenv.be/). For a list of the Java versions installed on your machine, run `/usr/libexec/java_home -V` on MacOS or `update-alternatives --config java` on Linux.
+
 2. Download the [zip of the source code from GitHub](https://github.com/BrightSpots/rcv/archive/master.zip) and unzip it, or install git and use the following command at the terminal / command prompt to clone a local copy on your machine:
     
     `$ git clone https://github.com/BrightSpots/rcv.git`


### PR DESCRIPTION
As requested by @nurse-the-code in [PR 877](https://github.com/BrightSpots/rcv/pull/877#issuecomment-2293640983):
>As a bonus (doesn't have to be in this PR and is not critical for the RCTab 2.0 work), in the documentation we could direct users to using something like [JEnv](https://www.jenv.be/) to manage different Java versions.

