### PR TITLE
Fix for clearballot parsing: ignore quoted text in non-header rows

### DIFF
--- a/src/main/java/network/brightspots/rcv/ClearBallotCvrReader.java
+++ b/src/main/java/network/brightspots/rcv/ClearBallotCvrReader.java
@@ -103,7 +103,7 @@ class ClearBallotCvrReader {
           break;
         }
         // parse rankings
-        String[] cvrData = row.split(",");
+        String[] cvrData = row.split(",(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)");
         ArrayList<Pair<Integer, String>> rankings = new ArrayList<>();
         for (var entry : columnIndexToRanking.entrySet()) {
           if (Integer.parseInt(cvrData[entry.getKey()]) == 1) {

--- a/src/main/java/network/brightspots/rcv/ClearBallotCvrReader.java
+++ b/src/main/java/network/brightspots/rcv/ClearBallotCvrReader.java
@@ -32,6 +32,8 @@ import network.brightspots.rcv.TabulatorSession.UnrecognizedCandidatesException;
 
 class ClearBallotCvrReader {
 
+  private static final String unQuotedCommaRegex = ",(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)";
+
   private final String cvrPath;
   private final ContestConfig contestConfig;
   private final String undeclaredWriteInLabel;
@@ -58,7 +60,7 @@ class ClearBallotCvrReader {
         Logger.severe("No header row found in cast vote record file: %s", this.cvrPath);
         throw new CvrParseException();
       }
-      String[] headerData = firstRow.split(",(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)");
+      String[] headerData = firstRow.split(unQuotedCommaRegex);
       if (headerData.length < CvrColumnField.ChoicesBegin.ordinal()) {
         Logger.severe("No choice columns found in cast vote record file: %s", this.cvrPath);
         throw new CvrParseException();
@@ -103,7 +105,7 @@ class ClearBallotCvrReader {
           break;
         }
         // parse rankings
-        String[] cvrData = row.split(",(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)");
+        String[] cvrData = row.split(unQuotedCommaRegex);
         ArrayList<Pair<Integer, String>> rankings = new ArrayList<>();
         for (var entry : columnIndexToRanking.entrySet()) {
           if (Integer.parseInt(cvrData[entry.getKey()]) == 1) {

--- a/src/main/java/network/brightspots/rcv/Main.java
+++ b/src/main/java/network/brightspots/rcv/Main.java
@@ -27,7 +27,7 @@ import java.util.List;
 public class Main extends GuiApplication {
 
   public static final String APP_NAME = "RCTab";
-  public static final String APP_VERSION = "1.3.1 RC2";
+  public static final String APP_VERSION = "1.3.1 RC3";
 
   /**
    * Main entry point to RCTab.


### PR DESCRIPTION
Fix for clearballot parsing: ignore quoted text in non-header