### PR TITLE
Have dominion autoload use both names and codes

### DIFF
--- a/src/main/java/network/brightspots/rcv/BaseCvrReader.java
+++ b/src/main/java/network/brightspots/rcv/BaseCvrReader.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javafx.util.Pair;
+import network.brightspots.rcv.RawContestConfig.Candidate;
 import network.brightspots.rcv.RawContestConfig.CvrSource;
 
 abstract class BaseCvrReader {
@@ -68,6 +69,11 @@ abstract class BaseCvrReader {
   public List<String> readCandidateListFromCvr(List<CastVoteRecord> castVoteRecords)
       throws IOException {
     return new ArrayList<>();
+  }
+
+  // Allow any reader-specific postprocessing of the candidate list.
+  public Candidate postprocessAutoloadedCandidate(Candidate candidate) {
+    return candidate;
   }
 
   // Gather candidate names from the CVR that are not in the config.

--- a/src/main/java/network/brightspots/rcv/DominionCvrReader.java
+++ b/src/main/java/network/brightspots/rcv/DominionCvrReader.java
@@ -226,18 +226,19 @@ class DominionCvrReader extends BaseCvrReader {
     }
   }
 
-  // The autoloaded candidates loads only codes, and sets them as the name.
-  // Fix these candidates with the correct name, and their code as an alias instead.
+  // The Candidate Autoload looks only at the CVR file(s) and not the manifest files, so
+  // it doesn't know about the mapping between a code and the candidate's name. This function
+  // addresses that discrepancy.
   public RawContestConfig.Candidate postprocessAutoloadedCandidate(
-          RawContestConfig.Candidate candidateToFix) {
-    String candidateCode = candidateToFix.getName();
-    Candidate loadedCandidate = candidates.get(candidateCode);
+          RawContestConfig.Candidate autoloadedCandidate) {
+    String autoloadedCandidateName = autoloadedCandidate.getName();
+    Candidate candidateFromManifest = candidates.get(autoloadedCandidateName);
     RawContestConfig.Candidate fixedCandidate;
-    if (loadedCandidate != null && loadedCandidate.code.equals(candidateToFix.getName())) {
-      // The auto-loaded candidate loaded their code as a name. Fix it, and make the code an alias.
-      fixedCandidate = new RawContestConfig.Candidate(loadedCandidate.name, candidateCode, false);
+    if (candidateFromManifest == null) {
+      fixedCandidate = autoloadedCandidate;
     } else {
-      fixedCandidate = candidateToFix;
+      fixedCandidate = new RawContestConfig.Candidate(
+              candidateFromManifest.name, candidateFromManifest.code, false);
     }
 
     return fixedCandidate;


### PR DESCRIPTION
Closes #866 

This is a pretty annoying bug that makes the candidate autoload all-but-useless for Dominion, so despite being a P1, it could make  a nice impact on the next RCTab version. Let me know if the change is small enough to warrant inclusion in v2.0.0.