### PR TITLE
Fix HartCvrReader.java line 120

### DIFF
--- a/src/main/java/network/brightspots/rcv/HartCvrReader.java
+++ b/src/main/java/network/brightspots/rcv/HartCvrReader.java
@@ -117,7 +117,9 @@ class HartCvrReader extends BaseCvrReader {
             // each digit corresponds to a rank and is set to 1 if that rank was voted:
             // 0100 indicates rank 2 was voted
             // 0000 indicates no rank was voted (undervote)
-            // 0101 indicates ranks 2 and 4 are voted (overvote)
+            // 0101 indicates ranks 2 and 4 are voted for one candidate (repeat ranking)
+            // 0100 in two different `Value` elements (within different `Option` elements)
+            // in the same CVR indicates two candidates recieved the same rank (overvote)
             for (int rank = 1; rank < option.Value.length() + 1; rank++) {
               String rankValue = option.Value.substring(rank - 1, rank);
               if (rankValue.equals("1")) {


### PR DESCRIPTION
Current HartCvrReader  line 120:
```java
// 0101 indicates ranks 2 and 4 are voted (overvote)
```

Currently the comment says that `0101` is an overvote, when it is actually a repeat ranking;

I also added an actual overvote example (2 different `Option` elements with ones in the same digit of the `Value` string in the Hart CVR; they would have different a different Name and Id)

pseudo code example of overvote:
```xml
<Option>
  <Name>Malachi Gruenhagen</Name>
  <Id>6b5ea7f0-eedd-437b-bb11-0e890f3a2662</Id>
  <Value>001000</Value>
</Option>
<Option>
  <Name>Mathew Ruberg</Name>
  <Id>1799b71a-19b3-41d4-a91c-6c52bc3f7dc1</Id>
  <Value>001000</Value>
</Option>
```

pseudo code example of repeat ranking:
```xml
<Option>
  <Name>Malachi Gruenhagen</Name>
  <Id>6b5ea7f0-eedd-437b-bb11-0e890f3a2662</Id>
  <Value>001010</Value>
</Option>
```