### PR TITLE
Automatically determine the number of decimal places to use in the bottoms-up threshold

### DIFF
--- a/src/test/java/network/brightspots/rcv/ContestConfigTests.java
+++ b/src/test/java/network/brightspots/rcv/ContestConfigTests.java
@@ -16,7 +16,9 @@
 
 package network.brightspots.rcv;
 
+import static network.brightspots.rcv.ContestConfig.numSigFigsInString;
 import static network.brightspots.rcv.ContestConfigMigration.isVersionNewer;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -58,5 +60,41 @@ class ContestConfigTests {
     assertFalse(isVersionNewer("1.4.0-alpha", "1.4.0-beta"));
     assertTrue(isVersionNewer("1.4.0", "1.4.0-alpha"));
     assertFalse(isVersionNewer("1.4.0-alpha", "1.4.0"));
+  }
+
+  void assertSigFigTestsFails(String input) {
+    try {
+      numSigFigsInString(input);
+      throw new AssertionError("Expected IllegalArgumentException for '" + input + "'");
+    } catch (IllegalArgumentException e) {
+      // Expected exception
+    }
+  }
+
+  @Test
+  @DisplayName("test numSigFigsInString")
+  void testNumSigFigsInString() {
+    // This test ensures that the automatic precision that occurs when setting
+    // the bottoms-up threshold is accurate
+    assertEquals(1, numSigFigsInString("0.1"));
+    assertEquals(2, numSigFigsInString("0.15"));
+    assertEquals(2, numSigFigsInString("0.10"));
+    assertEquals(3, numSigFigsInString("0.100"));
+    assertEquals(4, numSigFigsInString("0.0100"));
+    assertEquals(1, numSigFigsInString("1"));
+    assertEquals(2, numSigFigsInString("10"));
+    assertEquals(3, numSigFigsInString("100"));
+    assertEquals(2, numSigFigsInString("1.0"));
+    assertEquals(3, numSigFigsInString("1.01"));
+    assertEquals(4, numSigFigsInString("50.50"));
+    assertEquals(3, numSigFigsInString("100"));
+    assertEquals(3, numSigFigsInString("100."));
+    assertEquals(4, numSigFigsInString("100.0"));
+    assertSigFigTestsFails("");
+    assertSigFigTestsFails("100..");
+    assertSigFigTestsFails("0.00100.0");
+    assertSigFigTestsFails(null);
+    assertSigFigTestsFails("g.g");
+
   }
 }

--- a/src/test/java/network/brightspots/rcv/ContestConfigTests.java
+++ b/src/test/java/network/brightspots/rcv/ContestConfigTests.java
@@ -16,12 +16,14 @@
 
 package network.brightspots.rcv;
 
-import static network.brightspots.rcv.ContestConfig.numSigFigsInString;
+import static network.brightspots.rcv.ContestConfig.getPercentageFromStringWithAccurateSigFigs;
+import static network.brightspots.rcv.ContestConfig.numDecimalsInString;
 import static network.brightspots.rcv.ContestConfigMigration.isVersionNewer;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.math.BigDecimal;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -62,9 +64,9 @@ class ContestConfigTests {
     assertFalse(isVersionNewer("1.4.0-alpha", "1.4.0"));
   }
 
-  void assertSigFigTestsFails(String input) {
+  void assertNumDecimalsTestsFails(String input) {
     try {
-      numSigFigsInString(input);
+      numDecimalsInString(input);
       throw new AssertionError("Expected IllegalArgumentException for '" + input + "'");
     } catch (IllegalArgumentException e) {
       // Expected exception
@@ -72,29 +74,41 @@ class ContestConfigTests {
   }
 
   @Test
-  @DisplayName("test numSigFigsInString")
-  void testNumSigFigsInString() {
+  @DisplayName("test numDecimalsInString")
+  void testNumDecimalsInString() {
     // This test ensures that the automatic precision that occurs when setting
     // the bottoms-up threshold is accurate
-    assertEquals(1, numSigFigsInString("0.1"));
-    assertEquals(2, numSigFigsInString("0.15"));
-    assertEquals(2, numSigFigsInString("0.10"));
-    assertEquals(3, numSigFigsInString("0.100"));
-    assertEquals(4, numSigFigsInString("0.0100"));
-    assertEquals(1, numSigFigsInString("1"));
-    assertEquals(2, numSigFigsInString("10"));
-    assertEquals(3, numSigFigsInString("100"));
-    assertEquals(2, numSigFigsInString("1.0"));
-    assertEquals(3, numSigFigsInString("1.01"));
-    assertEquals(4, numSigFigsInString("50.50"));
-    assertEquals(3, numSigFigsInString("100"));
-    assertEquals(3, numSigFigsInString("100."));
-    assertEquals(4, numSigFigsInString("100.0"));
-    assertSigFigTestsFails("");
-    assertSigFigTestsFails("100..");
-    assertSigFigTestsFails("0.00100.0");
-    assertSigFigTestsFails(null);
-    assertSigFigTestsFails("g.g");
+    assertEquals(1, numDecimalsInString("0.1"));
+    assertEquals(2, numDecimalsInString("0.15"));
+    assertEquals(2, numDecimalsInString("0.10"));
+    assertEquals(3, numDecimalsInString("0.100"));
+    assertEquals(4, numDecimalsInString("0.0100"));
+    assertEquals(0, numDecimalsInString("1"));
+    assertEquals(0, numDecimalsInString("10"));
+    assertEquals(0, numDecimalsInString("100"));
+    assertEquals(1, numDecimalsInString("1.0"));
+    assertEquals(2, numDecimalsInString("1.01"));
+    assertEquals(2, numDecimalsInString("50.50"));
+    assertEquals(0, numDecimalsInString("100"));
+    assertEquals(0, numDecimalsInString("100."));
+    assertEquals(1, numDecimalsInString("100.0"));
+    assertNumDecimalsTestsFails("");
+    assertNumDecimalsTestsFails("100..");
+    assertNumDecimalsTestsFails("0.00100.0");
+    assertNumDecimalsTestsFails(null);
+    assertNumDecimalsTestsFails("g.g");
+    assertEquals(new BigDecimal("0.010"),
+          getPercentageFromStringWithAccurateSigFigs("1.0"));
+    assertEquals(new BigDecimal("0.10"),
+            getPercentageFromStringWithAccurateSigFigs("10"));
+    assertEquals(new BigDecimal("0.15"),
+            getPercentageFromStringWithAccurateSigFigs("15"));
+    assertEquals(new BigDecimal("1.00"),
+            getPercentageFromStringWithAccurateSigFigs("100"));
+    assertEquals(new BigDecimal("0.9999"),
+            getPercentageFromStringWithAccurateSigFigs("99.99"));
+    assertEquals(new BigDecimal("0.009999"),
+            getPercentageFromStringWithAccurateSigFigs(".9999"));
 
   }
 }

--- a/src/test/resources/network/brightspots/rcv/test_data/multi_seat_bottoms_up_with_threshold/multi_seat_bottoms_up_with_threshold_expected_detailed_report.csv
+++ b/src/test/resources/network/brightspots/rcv/test_data/multi_seat_bottoms_up_with_threshold/multi_seat_bottoms_up_with_threshold_expected_detailed_report.csv
@@ -7,7 +7,7 @@ Jurisdiction,
 Office,
 Date,
 Winner(s),"A, B, C, G"
-Final Threshold,3.1500
+Final Threshold,3.15
 
 Contest Summary
 Number to be Elected,0
@@ -27,7 +27,7 @@ H,1,4.76%,0,1,4.76%,0,1,4.76%,-1,0,0.0%,0,0,0.0%,0
 E,0,0.0%,0,0,0.0%,0,0,0.0%,0,0,0.0%,0,0,0.0%,0
 F,0,0.0%,0,0,0.0%,0,0,0.0%,0,0,0.0%,0,0,0.0%,0
 Active Ballots,21,,,21,,,21,,,21,,,21,,
-Current Round Threshold,3.1500,,,3.1500,,,3.1500,,,3.1500,,,3.1500,,
+Current Round Threshold,3.15,,,3.15,,,3.15,,,3.15,,,3.15,,
 Inactive Ballots by Overvotes,0,,0,0,,0,0,,0,0,,0,0,,0
 Inactive Ballots by Skipped Rankings,0,,0,0,,0,0,,0,0,,0,0,,0
 Inactive Ballots by Exhausted Choices,0,,0,0,,0,0,,0,0,,0,0,,0

--- a/src/test/resources/network/brightspots/rcv/test_data/multi_seat_bottoms_up_with_threshold/multi_seat_bottoms_up_with_threshold_expected_detailed_report.json
+++ b/src/test/resources/network/brightspots/rcv/test_data/multi_seat_bottoms_up_with_threshold/multi_seat_bottoms_up_with_threshold_expected_detailed_report.json
@@ -29,7 +29,7 @@
       "eliminated" : "F",
       "transfers" : { }
     } ],
-    "threshold" : "3.1500"
+    "threshold" : "3.15"
   }, {
     "inactiveBallots" : {
       "exhaustedChoices" : "0",
@@ -51,7 +51,7 @@
       "eliminated" : "E",
       "transfers" : { }
     } ],
-    "threshold" : "3.1500"
+    "threshold" : "3.15"
   }, {
     "inactiveBallots" : {
       "exhaustedChoices" : "0",
@@ -74,7 +74,7 @@
         "G" : "1"
       }
     } ],
-    "threshold" : "3.1500"
+    "threshold" : "3.15"
   }, {
     "inactiveBallots" : {
       "exhaustedChoices" : "0",
@@ -96,7 +96,7 @@
         "G" : "3"
       }
     } ],
-    "threshold" : "3.1500"
+    "threshold" : "3.15"
   }, {
     "inactiveBallots" : {
       "exhaustedChoices" : "0",
@@ -124,10 +124,10 @@
       "elected" : "G",
       "transfers" : { }
     } ],
-    "threshold" : "3.1500"
+    "threshold" : "3.15"
   } ],
   "summary" : {
-    "finalThreshold" : "3.1500",
+    "finalThreshold" : "3.15",
     "numCandidates" : 8,
     "numWinners" : 0,
     "totalNumBallots" : "21",


### PR DESCRIPTION
Currently, if decimal precision is set to 1, a threshold of 15% gets turned into 10%. That's weird. See #944 

This PR automatically determines the number of decimal places used in the threshold based on the threshold value entered. That means 15% is 0.15, and 15.0% is 0.150.

Added tests to demonstrate the functionality.