### PR TITLE
Speed up: Don't copy all the output folders when running tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -235,6 +235,10 @@ def sampleInputToCopy = copySpec {
     }
 }
 
+tasks.processTestResources {
+    exclude '**/output/**'
+}
+
 tasks.jlink.doLast {
     copy {
         with docsToCopy


### PR DESCRIPTION
If you run tests with a debugger and kill the debugger frequently before the tests finish running, the cleanup step doesn't happen and it leads to annoying errors where you have to manually clean things up. Plus, it's copying a bunch of files each time it just doesn't need. This PR speeds up test runs locally and avoids those errors.