### PR TITLE
fix test-and-release workflow flakiness: update dependencies

### DIFF
--- a/.github/actions/zip/action.yml
+++ b/.github/actions/zip/action.yml
@@ -27,4 +27,14 @@ runs:
     - name: "Generate zip for Windows"
       if: runner.os == 'Windows'
       shell: powershell
-      run: Compress-Archive -Path ${{inputs.input}} -Destination ${{inputs.zipFilename}}
+      run: |
+        $inputPath = "${{inputs.input}}"
+        # Git Bash on Windows emits Unix-style paths like /c/Users/... instead of C:\Users\...
+        if ($inputPath -match '^/([a-zA-Z])/(.+)$') {
+            # Convert /c/some/path -> C:\some\path
+            $inputPath = $Matches[1].ToUpper() + ':' + ($Matches[2] -replace '/', '\')
+        } else {
+            # Expand ~ since PowerShell cmdlets don't resolve it in string arguments
+            $inputPath = $inputPath -replace '^~', $HOME
+        }
+        Compress-Archive -Path $inputPath -Destination ${{inputs.zipFilename}}

--- a/.github/workflows/generate-dependency-hashes.sh
+++ b/.github/workflows/generate-dependency-hashes.sh
@@ -9,7 +9,7 @@ os=$1
 parentPath=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 
 echo "Filename, SHA-1 Checksum, SHA-256 Checksum, Maven Dependency URL, Direct URL to SHA-1, Direct URL to SHA-256"
-cd ~/.gradle/caches/modules-2/files-2.1
+cd "${GRADLE_USER_HOME:-$HOME/.gradle}/caches/modules-2/files-2.1"
 for filename in $(find * -type f); do
     # filename is of format, with dot-separated org:
     # <org>/<dependency-name>/<version>/<sha-1>/<dependency-name>-<version>.<ext>

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,13 +108,13 @@ jobs:
         run: echo "FILEPATH=build/${{ steps.basefn.outputs.FILEPATH }}${{ steps.ext.outputs.EXT }}" >> $GITHUB_OUTPUT
 
       - name: "Set up JDK 21.0.7"
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           java-version: '21.0.7'
           distribution: 'temurin'
 
-      - name: "Validate Gradle wrapper"
-        uses: gradle/actions/wrapper-validation@v3
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
 
       - name: "Create zip with jlinkZip"
         uses: ./.github/actions/gradle-and-sha
@@ -140,12 +140,17 @@ jobs:
         shell: bash
         run: ./.github/workflows/generate-dependency-hashes.sh ${{ runner.os }} >> ${{steps.checksumsfn.outputs.FILEPATH}}
 
+      - name: "Get Gradle user home"
+        id: gradle-home
+        shell: bash
+        run: echo "PATH=${GRADLE_USER_HOME:-$HOME/.gradle}" >> $GITHUB_OUTPUT
+
       - name: "Create dependency zip"
         uses: ./.github/actions/zip
         with:
           # Build, then remove all non-essential files
           command: ./gradlew assemble && ./gradlew --stop
-          input: "~/.gradle/caches"
+          input: "${{ steps.gradle-home.outputs.PATH }}/caches"
           zipFilename: ${{steps.cachefn.outputs.FILEPATH}}
 
       - name: "Generate SHA512 for plugins cache"


### PR DESCRIPTION
The nightly build is failing. That should be fixed in later versions of the gradle wrapper validation: https://github.com/gradle/wrapper-validation-action/issues/40

Using setup-gradle uses wrapper-validation and we don't need both: https://github.com/gradle/actions/tree/main/wrapper-validation

This PR essentially updates gradle/actions/wrapper-validation@v3 to gradle/actions/setup-gradle@v6 and actions/setup-java@v3 to actions/setup-java@v5 and the other changes are necessary to support that.